### PR TITLE
feat: helper text class name, dark mode error colors

### DIFF
--- a/lib/components/Input/Input.tsx
+++ b/lib/components/Input/Input.tsx
@@ -21,6 +21,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       theme,
       type = 'text',
       helperText,
+      helperTextClassName,
       ...delegated
     },
     ref,
@@ -96,7 +97,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           />
 
           {hasError ? (
-            <i className="absolute right-3 text-red-700 top-1/2 -translate-y-[50%]">
+            <i className="absolute right-3 text-red-700 dark:text-red-500 top-1/2 -translate-y-[50%]">
               <WarningIcon className="w-5 h-5" />
             </i>
           ) : null}
@@ -111,10 +112,19 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           ) : null}
         </div>
 
-        {error ? <span className="text-xs text-red-700">{error}</span> : null}
+        {error ? (
+          <span className="text-xs text-red-700 dark:text-red-500">
+            {error}
+          </span>
+        ) : null}
 
         {!error && helperText ? (
-          <span className="text-xs text-slate-600 civo-dark:text-slate-200 kubefirst-dark:text-slate-200">
+          <span
+            className={cn(
+              'text-xs text-slate-600 civo-dark:text-slate-200 kubefirst-dark:text-slate-200',
+              helperTextClassName,
+            )}
+          >
             {helperText}
           </span>
         ) : null}

--- a/lib/components/Input/Input.types.ts
+++ b/lib/components/Input/Input.types.ts
@@ -15,4 +15,5 @@ export interface InputProps
   isRequired?: boolean;
   isSearch?: boolean;
   helperText?: string;
+  helperTextClassName?: string;
 }

--- a/lib/components/Input/Input.variants.ts
+++ b/lib/components/Input/Input.variants.ts
@@ -41,7 +41,7 @@ export const inputVariants = cva(
       variant: {
         default: '',
         error:
-          'border-red-600 kubefirst-dark:border-red-500 civo-dark:border-red-500 pr-8 focus-visible:ring-transparent',
+          'border-red-600 kubefirst-dark:border-red-500 civo-dark:border-red-500 dark:border-red-500 pr-8 focus-visible:ring-transparent',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Description
- helper text class name + dark mode error colors for input

<img width="432" height="161" alt="Screenshot 2025-09-15 at 12 05 41 PM" src="https://github.com/user-attachments/assets/01dfaebb-e820-475b-baf8-e69854d2081c" />
<img width="470" height="129" alt="Screenshot 2025-09-15 at 12 04 36 PM" src="https://github.com/user-attachments/assets/85ca7777-3969-4673-81e1-7ff104758f3e" />


