### PR TITLE
🔒 security: disable postinstall scripts with trusted allowlist

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=false
+ignore-scripts=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,12 @@ Test files: `ComponentName.test.tsx`
 - **Always rebase with `main`** before every push, regardless of the commit (`git fetch origin main && git rebase origin/main`). This is mandatory — never push without rebasing first.
 - **Commit/PR message format**: `<emoji> <type>: <description>` — use gitmoji emojis (https://gitmoji.dev/). Examples: `✨ feat: add cluster detail page`, `🐛 fix: resolve onBlur validation`, `♻️ refactor: extract Tabs component`, `📝 docs: update CLAUDE.md rules`.
 
+## Security
+
+- **Postinstall scripts are disabled** via `ignore-scripts=true` in `.npmrc`. This prevents malicious code execution from compromised/unknown npm packages during install.
+- After `npm install`, run `npm run setup` once to rebuild the trusted packages the project needs (currently `esbuild` for Vite's build, and `husky` for git hooks).
+- Trusted-package allowlist lives in the `setup` script in `package.json`. To add a new entry, verify the package source, maintainers, and recent release history first, then extend the `setup` script — do not re-enable scripts globally.
+
 ## Coding Conventions
 
 - **Indentation**: tabs

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "format:prettier": "prettier lib --write './**/*.{js,jsx,ts,tsx}' --config ./.prettierrc",
     "lint": "eslint lib --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "prepare": "husky",
+    "setup": "npm rebuild esbuild && husky",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "test": "vitest run --coverage",


### PR DESCRIPTION
## Summary
- Add `ignore-scripts=true` to `.npmrc` so npm stops running postinstall scripts from dependencies automatically — mitigates the recent wave of compromised/malicious npm packages that abuse install-time hooks.
- Add a `setup` npm script as the explicit allowlist for packages this project does need to build: `npm rebuild esbuild` (Vite's native binary) and `husky` (git hooks via the root `prepare` script, which is also blocked by `ignore-scripts`).
- Document the new flow and allowlist policy in `CLAUDE.md` under a new **Security** section.

## Test plan
- [ ] `rm -rf node_modules && npm install` completes without executing dependency postinstall scripts.
- [ ] `npm run setup` rebuilds `esbuild` and installs husky git hooks successfully.
- [ ] `npm run build` succeeds after `npm run setup` (verifies esbuild binary is usable).
- [ ] `git commit` triggers husky hooks (verifies husky was installed).