### PR TITLE
✨ feat: auto-close Sidebar drawer on navigation and resolution change

### DIFF
--- a/lib/components/Sidebar/Sidebar.test.tsx
+++ b/lib/components/Sidebar/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReactNode } from 'react';
 
@@ -221,6 +221,55 @@ describe('Sidebar', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
       expect(screen.getByText('Clusters')).toBeInTheDocument();
       expect(screen.getByText('Main')).toBeInTheDocument();
+    });
+
+    it('closes the drawer when a navigation option is clicked', async () => {
+      renderWithGroups('drawer');
+
+      const user = userEvent.setup();
+      const trigger = screen.getByRole('button', {
+        name: /open navigation/i,
+      });
+
+      await user.click(trigger);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      const option = await screen.findByRole('option', { name: /clusters/i });
+      await user.click(option);
+
+      await waitFor(() =>
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+      );
+    });
+
+    it('keeps the drawer open when a navigation option opts out via closeDrawerOnClick={false}', async () => {
+      render(
+        <Sidebar mode="drawer">
+          <Logo>Logo</Logo>
+          <Navigation>
+            <NavigationGroup title="Main">
+              <NavigationOption closeDrawerOnClick={false}>
+                <Label>Stay open</Label>
+              </NavigationOption>
+            </NavigationGroup>
+          </Navigation>
+        </Sidebar>,
+      );
+
+      const user = userEvent.setup();
+      const trigger = screen.getByRole('button', {
+        name: /open navigation/i,
+      });
+
+      await user.click(trigger);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      const option = await screen.findByRole('option', { name: /stay open/i });
+      await user.click(option);
+
+      // Wait past the drawer close-animation window; dialog should remain.
+      await new Promise((resolve) => setTimeout(resolve, 350));
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
   });
 });

--- a/lib/components/Sidebar/components/Logo/Logo.tsx
+++ b/lib/components/Sidebar/components/Logo/Logo.tsx
@@ -2,12 +2,23 @@ import { FC } from 'react';
 
 import { cn } from '@/utils';
 
+import { useSidebarContext } from '../../contexts';
+
 import { Props } from './Logo.types';
 import { logoVariants } from './Logo.variants';
 
-const Logo: FC<Props> = ({ children, className }) => (
-  <header className={cn(logoVariants({ className }))}>{children}</header>
-);
+const Logo: FC<Props> = ({ children, className }) => {
+  const { closeDrawer } = useSidebarContext();
+
+  return (
+    <header
+      className={cn(logoVariants({ className }))}
+      onClick={() => closeDrawer()}
+    >
+      {children}
+    </header>
+  );
+};
 
 Logo.displayName = 'KonstructSidebarLogo';
 

--- a/lib/components/Sidebar/components/NavigationOption/NavigationOption.tsx
+++ b/lib/components/Sidebar/components/NavigationOption/NavigationOption.tsx
@@ -10,21 +10,35 @@ import { navigationOptionVariants } from './NavigationOption.variants';
 const NavigationOption: FC<Props> = ({
   children,
   className,
+  closeDrawerOnClick = true,
   isVisible = true,
   isActive,
   ...delegated
 }) => {
-  const { isCollapsed, expandOnHover } = useSidebarContext();
+  const { isCollapsed, expandOnHover, closeDrawer } = useSidebarContext();
   const isHoverExpandable = isCollapsed && expandOnHover;
 
   if (!isVisible) {
     return null;
   }
 
+  const userOnClick =
+    'onClick' in delegated
+      ? (delegated.onClick as VoidFunction | undefined)
+      : undefined;
+
+  const handleClick = () => {
+    if (closeDrawerOnClick) {
+      closeDrawer();
+    }
+    userOnClick?.();
+  };
+
   return (
     <li
       {...delegated}
       role="option"
+      onClick={handleClick}
       className={cn(
         navigationOptionVariants({
           className,

--- a/lib/components/Sidebar/components/NavigationOption/NavigationOption.types.ts
+++ b/lib/components/Sidebar/components/NavigationOption/NavigationOption.types.ts
@@ -7,6 +7,12 @@ type NavigationOption = VariantProps<typeof navigationOptionVariants> & {
   className?: string;
   isVisible?: boolean;
   isActive?: boolean;
+  /**
+   * Whether clicking this option should close the drawer when the Sidebar
+   * is in `drawer` mode. Defaults to `true`. Has no effect in `expanded` or
+   * `collapsed` modes.
+   */
+  closeDrawerOnClick?: boolean;
 };
 
 export type Props = NavigationOption &

--- a/lib/components/Sidebar/components/Wrapper/Wrapper.tsx
+++ b/lib/components/Sidebar/components/Wrapper/Wrapper.tsx
@@ -139,6 +139,12 @@ const Wrapper: FC<Props> = ({
   }, [resolvedMode]);
 
   useEffect(() => {
+    if (resolvedMode !== 'drawer') {
+      setIsDrawerOpen(false);
+    }
+  }, [resolvedMode]);
+
+  useEffect(() => {
     if (
       hasAppliedInitialWidthRef.current ||
       resolvedMode !== 'expanded' ||
@@ -195,6 +201,7 @@ const Wrapper: FC<Props> = ({
               expandOnHover: false,
               animateOnHover: false,
               separatorClassName,
+              closeDrawer: handleCloseDrawer,
             }}
           >
             <div
@@ -217,6 +224,7 @@ const Wrapper: FC<Props> = ({
     expandOnHover,
     animateOnHover,
     separatorClassName,
+    closeDrawer: handleCloseDrawer,
   };
 
   return (

--- a/lib/components/Sidebar/contexts/SidebarContext.tsx
+++ b/lib/components/Sidebar/contexts/SidebarContext.tsx
@@ -8,6 +8,12 @@ export interface SidebarContextValue {
   expandOnHover: boolean;
   animateOnHover: boolean;
   separatorClassName?: string;
+  /**
+   * Closes the drawer when the Sidebar is in `drawer` mode. No-op in
+   * `expanded` or `collapsed` modes. Useful for closing the drawer on
+   * navigation events (e.g. when the user clicks a link).
+   */
+  closeDrawer: () => void;
 }
 
 export const SidebarContext = createContext<SidebarContextValue>({
@@ -15,6 +21,7 @@ export const SidebarContext = createContext<SidebarContextValue>({
   isCollapsed: false,
   expandOnHover: false,
   animateOnHover: true,
+  closeDrawer: () => {},
 });
 
 export const useSidebarContext = (): SidebarContextValue => {


### PR DESCRIPTION
## Summary

The Sidebar's `drawer` mode now closes itself in the cases users expect, without requiring consumers to wire their own state. Specifically the drawer closes when:

- A `Sidebar.NavigationOption` is clicked. Per-option opt-out via the new `closeDrawerOnClick` prop (defaults to `true`).
- The `Sidebar.Logo` is clicked (typical "click logo to navigate home" UX in mobile).
- The Sidebar mode transitions away from `drawer` (e.g. viewport resizes back to `collapsed` / `expanded`). Previously `isDrawerOpen` persisted across mode changes, so resizing back to mobile would re-open a previously open drawer; this is fixed in the `Wrapper`.

## Implementation

- `SidebarContext` carries a new `closeDrawer: () => void` action (default no-op). `Wrapper` injects the real implementation in both branches of the provider so it's safe to call from any descendant slot regardless of current mode.
- `Wrapper` adds an effect that resets `isDrawerOpen` to `false` whenever `resolvedMode !== 'drawer'`.
- `NavigationOption` accepts a new `closeDrawerOnClick?: boolean` prop (default `true`) and wires an `onClick` on its `<li>` that invokes `closeDrawer()` and forwards to the user-provided `onClick` when present (`role="button"` variant). Clicks on descendant anchors bubble up so router-driven `<Link>` children get the same behavior for free.
- `Logo` invokes `closeDrawer()` on click of its `<header>`. No new prop — the call is a no-op in non-drawer modes.
- `useSidebarContext` stays internal; the public surface is the declarative `closeDrawerOnClick` prop.

## Backwards compatibility

No breaking changes. New prop defaults to `true`, which is the behavior most consumers will expect inside a drawer. Consumers that want to keep the drawer open after a click can pass `closeDrawerOnClick={false}` per option.

## Tests

Two new tests in `Sidebar.test.tsx`:

- Clicking a `NavigationOption` in `drawer` mode dismisses the dialog (waits past the close-animation window via `waitFor`).
- `closeDrawerOnClick={false}` keeps the dialog open after click (asserts after a 350ms delay covering `ANIMATION_DURATION_MS`).

Full suite: `429 / 429` passing locally (`bun run test`).

## Test plan

- [ ] CI lint, typecheck, prettier, and unit tests pass on the PR branch.
- [ ] Manual smoke in a consumer app: drawer closes when clicking an item, when clicking the logo, and when resizing mobile → tablet → mobile (drawer should be closed on the second mobile entry).
- [ ] Verify `closeDrawerOnClick={false}` keeps the drawer open for an opt-out option.