### PR TITLE
✨ feat: expose package.json in exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     },
     "./*.css": {
       "import": "./dist/*.css"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
Adds `"./package.json": "./package.json"` to the `exports` map in `package.json` so consumers can read the package version at runtime/build time via:

\`\`\`ts
import { version } from '@konstructio/ui/package.json';
\`\`\`

Same pattern is used by `react`, `react-dom`, `react-router-dom`, `@tanstack/react-query` and most other libraries that ship with a restricted `exports` field.

## Motivation
A Module Federation host that registers `@konstructio/ui` as a shared singleton needs the installed version string to pass to `createInstance({ shared: { ... } })`. Without this exports entry the import fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`, and the only workaround today is to hardcode the version constant alongside the bump — fragile and easy to drift.

This came up while wiring `@konstructio/ui` as a host-provided singleton in the Civo dashboard's micro-frontend setup; the host can now dedupe a ~2 MB UI library bundle per MF visit, but to do so it needs to advertise the version it provides.

## Impact
- **Bundle size**: no change. The exports map only describes what paths are reachable; nothing new is bundled.
- **Breaking changes**: none. This is strictly additive.
- **TypeScript**: works out of the box for projects with `resolveJsonModule: true` (the default for most modern setups).

## Test plan
- [x] `bun install` succeeds
- [x] Pre-commit hook (lint + type-check + tests) passes
- [ ] CI passes
- [ ] After merge: verify `import { version } from '@konstructio/ui/package.json'` resolves in a downstream project

## Related
Used by Civo dashboard host: <https://git.civo.com/civo/dashboard/dashboard-manager/-/merge_requests/75>