### PR TITLE
👷 ci: migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -8,13 +8,16 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  bump-version-and-publish:
+  bump-and-publish-github:
     runs-on: self-hosted
 
     permissions:
       packages: write
       contents: write
       actions: write
+
+    outputs:
+      tag: ${{ steps.dist-tag.outputs.tag }}
 
     steps:
       - name: Checkout repository
@@ -49,9 +52,6 @@ jobs:
       - name: Authenticate with GitHub Packages
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_TOKEN }}" > ~/.npmrc
 
-      - name: Authenticate with npmjs
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-
       - name: Determine npm dist-tag
         id: dist-tag
         run: |
@@ -70,13 +70,61 @@ jobs:
             npm dist-tag add @konstructio/ui@${{ github.event.client_payload.version }} latest --registry https://npm.pkg.github.com/
           fi
 
-      - name: Publish to npm
+      - name: Upload built package
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+  # npm Trusted Publishing (OIDC) does not support self-hosted runners yet, so the
+  # npm publish runs on a GitHub-hosted runner. No npm token is used: the npm CLI
+  # exchanges the GitHub OIDC token (id-token: write) for a short-lived publish token.
+  publish-npm:
+    needs: bump-and-publish-github
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      # Do NOT set registry-url here: it writes `_authToken=${NODE_AUTH_TOKEN}` into
+      # .npmrc, and an empty token disables OIDC. publishConfig.registry already
+      # points npm publish at https://registry.npmjs.org/.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Download built package
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      # ignore-scripts=true means no build/prepare runs during publish, so the
+      # downloaded dist is exactly what gets published. Provenance is generated
+      # automatically by trusted publishing. Do not set NODE_AUTH_TOKEN.
+      - name: Publish to npm (OIDC)
         run: |
-          npm publish --registry https://registry.npmjs.org/ --tag ${{ steps.dist-tag.outputs.tag }}
-          if [ "${{ steps.dist-tag.outputs.tag }}" != "latest" ]; then
-            npm dist-tag add @konstructio/ui@${{ github.event.client_payload.version }} latest --registry https://registry.npmjs.org/
+          npm publish --tag ${{ needs.bump-and-publish-github.outputs.tag }}
+          if [ "${{ needs.bump-and-publish-github.outputs.tag }}" != "latest" ]; then
+            npm dist-tag add @konstructio/ui@${{ github.event.client_payload.version }} latest
           fi
 
+  notify-slack:
+    needs: [bump-and-publish-github, publish-npm]
+    runs-on: self-hosted
+
+    steps:
       - name: Send new version of the package to Konstruct Slack
         run: |
           curl --location 'https://n8n-production.mgmt-24.konstruct.io/webhook/konstruct-ui/updates' \


### PR DESCRIPTION
## Problem

Publishing to npm fails at the **Publish to npm** step:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@konstructio%2fui - Not found
npm error 404 ... '@konstructio/ui@0.1.2-alpha.91' could not be found or you do not have permission
```

A `404 PUT` on an existing public **scoped** package is npm's signature for an auth failure (it masks 401/403 as 404). A **Trusted Publisher (OIDC)** is now configured on npm for this package + `release-package.yml`, but the workflow still authenticated with the (now invalid) `NPM_TOKEN` and wasn't wired for OIDC.

npm Trusted Publishing has hard requirements the old workflow violated: GitHub-hosted runners only (it ran on `self-hosted`), `id-token: write` permission, and **no npm token present** (an empty `NODE_AUTH_TOKEN` disables OIDC).

## Change

Split the single job into three:

- **`bump-and-publish-github`** (self-hosted) — build, version bump, GitHub Packages publish. Now uploads `dist/` as an artifact and exposes the dist-tag as a job output. Removed the `NPM_TOKEN` auth step.
- **`publish-npm`** (`ubuntu-latest`, **NEW**) — `id-token: write`; downloads the artifact and runs `npm publish` via OIDC (no token). Does **not** use `setup-node`'s `registry-url` (avoids the empty-`NODE_AUTH_TOKEN` trap); provenance is automatic.
- **`notify-slack`** (self-hosted) — `needs: [both publishes]`, so Slack only fires after npm succeeds (previously it could fire even when the npm publish failed).

npm Trusted Publishing doesn't support self-hosted runners yet, which is why the npm publish is split onto a GitHub-hosted runner.

## After merge

- Trigger a release for `0.1.2-alpha.92` (re-running `.91` would 409 on GitHub Packages, which already has it). npm jumps `.89 → .92`.
- Once OIDC is confirmed, the `NPM_TOKEN` repo secret can be deleted.

## Notes / out of scope

- Version bump is still committed/pushed before the npm publish, so a `publish-npm` failure leaves `main`/GitHub Packages ahead of npm (pre-existing behavior).

## Test plan

- [ ] Trigger a `repository_dispatch` `release` for `0.1.2-alpha.92`
- [ ] Job 1 publishes to GitHub Packages and uploads the `dist` artifact
- [ ] Job 2 exchanges an OIDC token (no token used) and publishes; provenance shows on the npm page
- [ ] `npm view @konstructio/ui version` → `0.1.2-alpha.92`; both `alpha` and `latest` dist-tags point to it
- [ ] Slack/n8n notification fires only after both publishes succeed