### PR TITLE
🔍 ci: fix npm OIDC ENEEDAUTH (+provenance) and always tag latest

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -110,12 +110,28 @@ jobs:
           name: dist
           path: dist
 
+      # Diagnostic only (no secret values printed): confirms whether the GitHub
+      # OIDC token request env is available (it requires id-token: write) and shows
+      # the npm registry/.npmrc state that decides token-vs-OIDC auth.
+      - name: Debug OIDC environment
+        run: |
+          echo "npm: $(npm -v) | node: $(node -v)"
+          [ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ] && echo "ACTIONS_ID_TOKEN_REQUEST_URL: present" || echo "ACTIONS_ID_TOKEN_REQUEST_URL: MISSING"
+          [ -n "$ACTIONS_ID_TOKEN_REQUEST_TOKEN" ] && echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: present" || echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: MISSING"
+          [ -n "$NODE_AUTH_TOKEN" ] && echo "NODE_AUTH_TOKEN: present" || echo "NODE_AUTH_TOKEN: unset"
+          echo "registry: $(npm config get registry)"
+          echo "--- project .npmrc ---"
+          sed 's/\(_authToken=\).*/\1<redacted>/' .npmrc 2>/dev/null || echo "(none)"
+          echo "--- ~/.npmrc ---"
+          sed 's/\(_authToken=\).*/\1<redacted>/' "$HOME/.npmrc" 2>/dev/null || echo "(none)"
+
       # ignore-scripts=true means no build/prepare runs during publish, so the
-      # downloaded dist is exactly what gets published. Provenance is generated
-      # automatically by trusted publishing. Do not set NODE_AUTH_TOKEN.
+      # downloaded dist is exactly what gets published. Do not set NODE_AUTH_TOKEN.
+      # --provenance forces the OIDC/id-token path: if id-token: write is missing it
+      # fails with an explicit error instead of a misleading ENEEDAUTH.
       - name: Publish to npm (OIDC)
         run: |
-          npm publish --tag ${{ needs.bump-and-publish-github.outputs.tag }}
+          npm publish --provenance --tag ${{ needs.bump-and-publish-github.outputs.tag }}
           if [ "${{ needs.bump-and-publish-github.outputs.tag }}" != "latest" ]; then
             npm dist-tag add @konstructio/ui@${{ github.event.client_payload.version }} latest
           fi

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -63,11 +63,13 @@ jobs:
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
+      # Publish as `latest` so the newest version is always latest, regardless of
+      # its prerelease tag; then also point the prerelease tag (e.g. alpha) at it.
       - name: Publish to GitHub Packages
         run: |
-          npm publish --registry https://npm.pkg.github.com/ --tag ${{ steps.dist-tag.outputs.tag }}
+          npm publish --registry https://npm.pkg.github.com/ --tag latest
           if [ "${{ steps.dist-tag.outputs.tag }}" != "latest" ]; then
-            npm dist-tag add @konstructio/ui@${{ github.event.client_payload.version }} latest --registry https://npm.pkg.github.com/
+            npm dist-tag add @konstructio/ui@${{ github.event.client_payload.version }} ${{ steps.dist-tag.outputs.tag }} --registry https://npm.pkg.github.com/
           fi
 
       - name: Upload built package
@@ -129,11 +131,13 @@ jobs:
       # downloaded dist is exactly what gets published. Do not set NODE_AUTH_TOKEN.
       # --provenance forces the OIDC/id-token path: if id-token: write is missing it
       # fails with an explicit error instead of a misleading ENEEDAUTH.
+      # Publish as `latest` so the newest version is always latest, regardless of
+      # its prerelease tag; then also point the prerelease tag (e.g. alpha) at it.
       - name: Publish to npm (OIDC)
         run: |
-          npm publish --provenance --tag ${{ needs.bump-and-publish-github.outputs.tag }}
+          npm publish --provenance --tag latest
           if [ "${{ needs.bump-and-publish-github.outputs.tag }}" != "latest" ]; then
-            npm dist-tag add @konstructio/ui@${{ github.event.client_payload.version }} latest
+            npm dist-tag add @konstructio/ui@${{ github.event.client_payload.version }} ${{ needs.bump-and-publish-github.outputs.tag }}
           fi
 
   notify-slack:


### PR DESCRIPTION
## Why

After migrating to OIDC (#642), the `publish-npm` job fails with:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

Diagnosis from CI logs + npm docs/issues:
- npm in CI is **11.8.0** (≥ 11.5.1) — version is **not** the cause.
- npm CLI [issue #9088](https://github.com/npm/cli/issues/9088) confirms trusted-publishing failures surface as a **misleading `ENEEDAUTH`** instead of a real diagnostic. So OIDC is attempted but the id-token path doesn't complete.

## Changes

1. **`--provenance` on `npm publish`** — forces the OIDC/id-token code path (a known-good Jan-2026 example uses it). If `id-token: write` isn't actually effective at runtime, this fails with an **explicit** error instead of `ENEEDAUTH`.
2. **Debug step** in `publish-npm` — prints (no secret values) whether `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` are present, the npm version, the resolved registry, and the redacted `.npmrc` contents. This definitively tells us if the OIDC env is available.
3. **Always tag the published version as `latest`** — both registries now `npm publish --tag latest` (atomic at publish), then add the prerelease tag (e.g. `alpha`) as a secondary dist-tag. The newest version is always `latest` regardless of its tag, and `@konstructio/ui@alpha` still resolves.

## Next step after merge

Trigger a release (`0.1.2-alpha.93`) and read the `publish-npm` logs:
- If the debug step shows `ACTIONS_ID_TOKEN_REQUEST_URL: MISSING` → the `id-token: write` permission isn't being granted (org/repo Actions setting) — fix there.
- If it's present and `--provenance` still errors → the message will name the real cause (e.g. trusted-publisher config mismatch), which we then correct.
- If it publishes → done; `latest` points to the new version.

The debug step and explicit `--provenance` can be trimmed once publishing is confirmed working.