### PR TITLE
📝 docs: add Storybook stories for components and order sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ coverage
 /.fnpm
 bun.lockb
 bun.lock
+yarn.lock
+pnpm-lock.yaml
+deno.lock

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,6 +18,8 @@ const preview = {
         order: [
           'Documentation',
           ['Introduction', 'Changelog', 'Icons Gallery', '*'],
+          'Components',
+          ['*'],
           'In Review',
           [
             '*',

--- a/lib/components/Alert/Alert.stories.tsx
+++ b/lib/components/Alert/Alert.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Alert } from './Alert';
+
+const meta: Meta<typeof Alert> = {
+  title: 'Components/Alert',
+  component: Alert,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A feedback alert component supporting success, info, warning, and danger types. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    type: {
+      control: { type: 'inline-radio' },
+      options: ['success', 'info', 'warning', 'danger'],
+      description: 'Visual type of the alert',
+    },
+    title: {
+      control: { type: 'text' },
+      description: 'Title text shown in the alert',
+    },
+    description: {
+      control: { type: 'text' },
+      description: 'Optional description text',
+    },
+    isVisible: {
+      control: { type: 'boolean' },
+      description: 'Whether the alert is visible',
+    },
+    showCloseButton: {
+      control: { type: 'boolean' },
+      description: 'Show close button to dismiss the alert',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    type: 'success',
+    title: 'Operation completed!',
+    description: 'Your changes have been saved successfully.',
+    isVisible: true,
+    showCloseButton: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Alert>;
+
+export const Playground: Story = {};

--- a/lib/components/AlertDialog/AlertDialog.stories.tsx
+++ b/lib/components/AlertDialog/AlertDialog.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { AlertDialog } from './AlertDialog';
+
+const meta: Meta<typeof AlertDialog> = {
+  title: 'Components/AlertDialog',
+  component: AlertDialog,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A confirmation dialog with a trigger button, title, description and configurable action buttons. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    buttonTriggerText: {
+      control: { type: 'text' },
+      description: 'Text for the trigger button',
+    },
+    buttonTriggerVariant: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'tertiary', 'danger', 'link'],
+      description: 'Variant for the trigger button',
+    },
+    title: {
+      control: { type: 'text' },
+      description: 'Title text shown in the dialog',
+    },
+    description: {
+      control: { type: 'text' },
+      description: 'Description text shown in the dialog',
+    },
+    showCancelButton: {
+      control: { type: 'boolean' },
+      description: 'Whether to show the cancel button',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onConfirm: { action: 'confirmed', table: { disable: true } },
+    onClick: { action: 'clicked', table: { disable: true } },
+  },
+  args: {
+    buttonTriggerText: 'Open dialog',
+    buttonTriggerVariant: 'primary',
+    title: 'Confirm action',
+    description: 'Are you sure you want to proceed with this action?',
+    showCancelButton: true,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AlertDialog>;
+
+export const Playground: Story = {};

--- a/lib/components/Autocomplete/Autocomplete.stories.tsx
+++ b/lib/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,36 +1,58 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Autocomplete as AutocompleteComponent } from './Autocomplete';
+import { Autocomplete } from './Autocomplete';
 
-type Story = StoryObj<typeof AutocompleteComponent>;
-
-const meta: Meta<typeof AutocompleteComponent> = {
-  title: 'In Review/Autocomplete',
-  component: AutocompleteComponent,
-};
-
-export const Autocomplete: Story = {
+const meta: Meta<typeof Autocomplete> = {
+  title: 'Components/Autocomplete',
+  component: Autocomplete,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A text input with suggestions filtered as the user types. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the input',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text',
+    },
+    options: {
+      control: { type: 'object' },
+      description: 'Array of options to suggest',
+    },
+    placeHolderEmptyValues: {
+      control: { type: 'text' },
+      description: 'Text shown when no options match',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+  },
   args: {
-    placeholder: 'Search...',
+    label: 'Framework',
+    placeholder: 'Search frameworks...',
     options: [
-      { value: 'Option 1' },
-      { value: 'Option 2' },
-      { value: 'Option 3' },
-      { value: 'Option 4' },
-      { value: 'Option 5' },
-      { value: 'Option 6' },
+      { value: 'React' },
+      { value: 'Vue' },
+      { value: 'Angular' },
+      { value: 'Svelte' },
+      { value: 'Solid' },
     ],
   },
-  render: (args) => (
-    <div className="w-[350px] flex flex-col gap-3">
-      <AutocompleteComponent
-        label="Kubefirst colors"
-        theme="kubefirst"
-        {...args}
-      />
-      <AutocompleteComponent label="Civo colors" {...args} />
-    </div>
-  ),
 };
 
 export default meta;
+
+type Story = StoryObj<typeof Autocomplete>;
+
+export const Playground: Story = {};

--- a/lib/components/Badge/Badge.stories.tsx
+++ b/lib/components/Badge/Badge.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Badge } from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Components/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A small status badge with multiple color variants and optional icons. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'danger', 'info', 'success', 'warning', 'violet', 'orange'],
+      description: 'Visual color variant of the badge',
+    },
+    size: {
+      control: { type: 'inline-radio' },
+      options: ['default'],
+      description: 'Badge size',
+    },
+    label: {
+      control: { type: 'text' },
+      description: 'Badge text content',
+    },
+    isSelectable: {
+      control: { type: 'boolean' },
+      description: 'Allow text selection',
+    },
+    loading: {
+      control: { type: 'boolean' },
+      description: 'Show loading spinner',
+    },
+    onClick: { action: 'clicked', table: { disable: true } },
+    onDismiss: { action: 'dismissed', table: { disable: true } },
+  },
+  args: {
+    label: 'Badge',
+    variant: 'default',
+    size: 'default',
+    isSelectable: true,
+    loading: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Playground: Story = {};

--- a/lib/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/lib/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Breadcrumb } from './Breadcrumb';
+
+const meta: Meta<typeof Breadcrumb> = {
+  title: 'Components/Breadcrumb',
+  component: Breadcrumb,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A breadcrumb navigation component for showing hierarchical page locations. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    steps: {
+      control: { type: 'object' },
+      description: 'Array of breadcrumb steps',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    steps: [
+      { label: 'Home', to: '/' },
+      { label: 'Products', to: '/products' },
+      { label: 'Current Page', isActive: true },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Breadcrumb>;
+
+export const Playground: Story = {};

--- a/lib/components/Button/Button.stories.tsx
+++ b/lib/components/Button/Button.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Components/Button',
+  component: Button,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A customizable button component with multiple variants, sizes, shapes and appearances. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'tertiary', 'danger', 'link'],
+      description: 'Visual style of the button',
+      table: { defaultValue: { summary: 'primary' } },
+    },
+    version: {
+      control: { type: 'inline-radio' },
+      options: ['default', 'alternate'],
+      description: 'Variant version (e.g. `danger` + `alternate` renders an outlined danger button)',
+      table: { defaultValue: { summary: 'default' } },
+    },
+    shape: {
+      control: { type: 'inline-radio' },
+      options: [undefined, 'circle'],
+      description: 'Button shape',
+    },
+    size: {
+      control: { type: 'inline-radio' },
+      options: ['medium', 'large'],
+      description: 'Button size (only meaningful when `shape="circle"`)',
+      table: { defaultValue: { summary: 'medium' } },
+    },
+    appearance: {
+      control: { type: 'inline-radio' },
+      options: [undefined, 'compact'],
+      description: 'Density of the button',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the button is disabled',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    asChild: {
+      control: { type: 'boolean' },
+      description: 'Render the child element with button styles instead of a `<button>`',
+    },
+    children: {
+      control: { type: 'text' },
+      description: 'Button content',
+    },
+    onClick: { action: 'clicked', table: { disable: true } },
+  },
+  args: {
+    children: 'Button',
+    variant: 'primary',
+    disabled: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Playground: Story = {};

--- a/lib/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/lib/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ButtonGroup } from './ButtonGroup';
+
+const meta: Meta<typeof ButtonGroup> = {
+  title: 'Components/ButtonGroup',
+  component: ButtonGroup,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A segmented control with an animated selection pill. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name (required for form submission)',
+    },
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the button group',
+    },
+    helperText: {
+      control: { type: 'text' },
+      description: 'Helper text below the button group',
+    },
+    error: {
+      control: { type: 'text' },
+      description: 'Error message to display',
+    },
+    options: {
+      control: { type: 'object' },
+      description: 'Array of button options',
+    },
+    defaultValue: {
+      control: { type: 'text' },
+      description: 'Initially selected value',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Disable the entire group',
+    },
+    isRequired: {
+      control: { type: 'boolean' },
+      description: 'Whether the field is required',
+    },
+    labelAlign: {
+      control: { type: 'inline-radio' },
+      options: ['left', 'center', 'right'],
+      description: 'Horizontal alignment of the label text',
+    },
+    descriptionAlign: {
+      control: { type: 'inline-radio' },
+      options: ['left', 'center', 'right'],
+      description: 'Horizontal alignment of the description text',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onValueChange: { action: 'changed', table: { disable: true } },
+  },
+  args: {
+    name: 'processor',
+    label: 'Processor',
+    defaultValue: 'cpu',
+    disabled: false,
+    isRequired: false,
+    options: [
+      { value: 'cpu', label: 'CPU' },
+      { value: 'gpu', label: 'GPU' },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ButtonGroup>;
+
+export const Playground: Story = {};

--- a/lib/components/Card/Card.stories.tsx
+++ b/lib/components/Card/Card.stories.tsx
@@ -1,111 +1,47 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { FC } from 'react';
-import { Check } from 'react-feather';
 
-import { Button } from '@/components/Button/Button';
+import { Card } from './Card';
 
-import { Card as CardComponent } from './Card';
-import { CardProps } from './Card.types';
-
-type Story = StoryObj<typeof CardComponent>;
-
-const meta: Meta<typeof CardComponent> = {
-  title: 'In Review/Card',
-  component: CardComponent,
-};
-
-export const Card: Story = {
-  render: () => {
-    const Wrapper: FC<Pick<CardProps, 'isActive' | 'canHover' | 'theme'>> = (
-      props,
-    ) => (
-      <div className="max-w-[350px] flex flex-col gap-2 w-[280px]">
-        <CardComponent className="flex flex-col gap-3 p-5" {...props}>
-          <header className="text-center">
-            <h3 className="text-slate-500 text-2xl dark:text-metal-400">
-              Business
-            </h3>
-          </header>
-
-          <div className="flex flex-col gap-3 pb-11">
-            <p className="text-sm text-slate-500 dark:text-metal-100 text-center">
-              Take advantage of our Business Plan to manage more clusters,
-              self-host a private GitOps catalog, unlock unlimited cluster
-              templates, and unify your platform services with a single
-              interface.
-            </p>
-
-            <p className="text-slate-700 text-[22px] text-center dark:text-aurora-500">
-              $0.33 / cluster / hour
-            </p>
-
-            <Button>Contact us</Button>
-
-            <p className="text-slate-500 dark:text-metal-100 text-sm mt-3">
-              Everything in Free plus:
-            </p>
-
-            <ul className="text-slate-500 dark:text-metal-100 text-sm flex flex-col gap-2">
-              <li className="flex items-start gap-1">
-                <Check className="text-green-500 w-4 h-4 mt-0.5 shrink-0" />
-                Full feature access to the User Interface
-              </li>
-              <li className="flex items-start gap-1">
-                <Check className="text-green-500 w-4 h-4 mt-0.5 shrink-0" />
-                Up to 10 physical clusters
-              </li>
-              <li className="flex items-start gap-1">
-                <Check className="text-green-500 w-4 h-4 mt-0.5 shrink-0" />
-                Multi-account provisioning
-              </li>
-              <li className="flex items-start gap-1">
-                <Check className="text-green-500 w-4 h-4 mt-0.5 shrink-0" />
-                Customizable GitOps Catalog
-              </li>
-              <li className="flex items-start gap-1">
-                <Check className="text-green-500 w-4 h-4 mt-0.5 shrink-0" />
-                Slack Connect support
-              </li>
-            </ul>
-          </div>
-        </CardComponent>
-      </div>
-    );
-
-    return (
-      <div className="flex flex-col gap-4">
-        <div className="flex gap-4">
-          <div className="p-4">
-            <Wrapper />
-          </div>
-
-          <div className="bg-metal-900 p-4 rounded-lg" data-theme="dark">
-            <Wrapper />
-          </div>
-        </div>
-
-        <div className="flex gap-4">
-          <div className="p-4">
-            <Wrapper canHover={true} />
-          </div>
-
-          <div className="bg-metal-900 p-4 rounded-lg" data-theme="dark">
-            <Wrapper canHover={true} />
-          </div>
-        </div>
-
-        <div className="flex gap-4">
-          <div className="p-4">
-            <Wrapper isActive={true} />
-          </div>
-
-          <div className="bg-metal-900 p-4 rounded-lg" data-theme="dark">
-            <Wrapper isActive={true} />
-          </div>
-        </div>
-      </div>
-    );
+const meta: Meta<typeof Card> = {
+  title: 'Components/Card',
+  component: Card,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A container card with optional hover and active states. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    canHover: {
+      control: { type: 'boolean' },
+      description: 'Enable hover effect',
+    },
+    isActive: {
+      control: { type: 'boolean' },
+      description: 'Show active/selected state',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    children: {
+      control: { type: 'text' },
+      description: 'Card content',
+    },
+  },
+  args: {
+    children: 'Card content goes here',
+    canHover: false,
+    isActive: false,
   },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+export const Playground: Story = {};

--- a/lib/components/Checkbox/Checkbox.stories.tsx
+++ b/lib/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Checkbox } from './Checkbox';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Components/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'An accessible checkbox with an optional label. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label text displayed next to the checkbox',
+    },
+    defaultChecked: {
+      control: { type: 'boolean' },
+      description: 'Initial checked state',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the checkbox is disabled',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+  },
+  args: {
+    label: 'Accept terms and conditions',
+    defaultChecked: false,
+    disabled: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Playground: Story = {};

--- a/lib/components/Command/Command.stories.tsx
+++ b/lib/components/Command/Command.stories.tsx
@@ -1,97 +1,70 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useContext, useEffect } from 'react';
-import { Sun } from 'react-feather';
+import { useState } from 'react';
 
-import { ThemeProvider, useTheme } from '@/contexts';
+import { Button } from '../Button/Button';
 
-import { Command as CommandComponent } from './Command';
-import {
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandSeparator,
-} from './components';
-import { CommandContext, CommandProvider } from './contexts';
+import { Command } from './Command';
 
-type Story = StoryObj<typeof CommandComponent>;
-
-const meta: Meta<typeof CommandComponent> = {
-  title: 'In Review/Command',
-  component: CommandComponent,
-};
-
-export const Command: Story = {
-  render: () => {
-    const Wrapper = () => {
-      const { theme, setTheme } = useTheme();
-      const { isOpen, setOpen, toggleOpen } = useContext(CommandContext);
-
-      useEffect(() => {
-        const down = (e: KeyboardEvent) => {
-          if ((e.key === 'k' && (e.metaKey || e.ctrlKey)) || e.key === '/') {
-            if (
-              (e.target instanceof HTMLElement && e.target.isContentEditable) ||
-              e.target instanceof HTMLInputElement ||
-              e.target instanceof HTMLTextAreaElement ||
-              e.target instanceof HTMLSelectElement
-            ) {
-              return;
-            }
-
-            e.preventDefault();
-            toggleOpen();
-          }
-        };
-
-        document.addEventListener('keydown', down);
-
-        return () => {
-          document.removeEventListener('keydown', down);
-        };
-      }, [toggleOpen]);
+const meta: Meta<typeof Command> = {
+  title: 'Components/Command',
+  component: Command,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A command palette dialog for keyboard-driven navigation and actions. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text for the search input',
+    },
+    emptyResults: {
+      control: { type: 'text' },
+      description: 'Text shown when no results match the search',
+    },
+    title: {
+      control: { type: 'text' },
+      description: 'Accessible title for the dialog',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    placeholder: 'Type a command or search...',
+    emptyResults: 'No results found.',
+    title: 'Command Palette',
+  },
+  render: (args) => {
+    const Demo = () => {
+      const [open, setOpen] = useState(false);
 
       return (
         <>
-          <div className="flex gap-3 items-center">
-            <p>
-              Current Theme: <span>{theme}</span>
-            </p>
-
-            <kbd className="pointer-events-none h-5 select-none flex items-center gap-1 rounded-md bg-kubefirst-secondary px-1.5 font-mono text-[10px] font-medium opacity-100 text-white">
-              <span className="text-xs">⌘</span>K
-            </kbd>
-          </div>
-
-          <CommandComponent open={isOpen} onOpenChange={setOpen}>
-            <CommandInput placeholder="Type a command or search..." />
-            <CommandGroup heading="Theme">
-              <CommandItem onSelect={() => setTheme!('kubefirst')}>
-                <Sun />
-                Kubefirst
-              </CommandItem>
-            </CommandGroup>
-
-            <CommandSeparator />
-
-            <CommandGroup heading="Theme">
-              <CommandItem onSelect={() => setTheme!('kubefirst')}>
-                <Sun />
-                Kubefirst
-              </CommandItem>
-            </CommandGroup>
-          </CommandComponent>
+          <Button
+            onClick={() => {
+              setOpen(true);
+            }}
+          >
+            Open command palette
+          </Button>
+          <Command {...args} open={open} onOpenChange={setOpen} />
         </>
       );
     };
 
-    return (
-      <ThemeProvider theme="kubefirst">
-        <CommandProvider>
-          <Wrapper />
-        </CommandProvider>
-      </ThemeProvider>
-    );
+    return <Demo />;
   },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof Command>;
+
+export const Playground: Story = {};

--- a/lib/components/Counter/Counter.stories.tsx
+++ b/lib/components/Counter/Counter.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Counter } from './Counter';
+
+const meta: Meta<typeof Counter> = {
+  title: 'Components/Counter',
+  component: Counter,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A numeric input with increment and decrement buttons. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the counter',
+    },
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name',
+    },
+    value: {
+      control: { type: 'number' },
+      description: 'Current numeric value',
+    },
+    min: {
+      control: { type: 'number' },
+      description: 'Minimum allowed value',
+    },
+    max: {
+      control: { type: 'number' },
+      description: 'Maximum allowed value',
+    },
+    isRequired: {
+      control: { type: 'boolean' },
+      description: 'Show required indicator',
+    },
+    canIncrement: {
+      control: { type: 'boolean' },
+      description: 'Allow increment button to be clicked',
+    },
+    canDecrement: {
+      control: { type: 'boolean' },
+      description: 'Allow decrement button to be clicked',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+  },
+  args: {
+    label: 'Quantity',
+    name: 'quantity',
+    value: 1,
+    min: 0,
+    max: 10,
+    isRequired: false,
+    canIncrement: true,
+    canDecrement: true,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Counter>;
+
+export const Playground: Story = {};

--- a/lib/components/DateRangePicker/DateRangePicker.stories.tsx
+++ b/lib/components/DateRangePicker/DateRangePicker.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { DateRangePicker } from './DateRangePicker';
+
+const meta: Meta<typeof DateRangePicker> = {
+  title: 'Components/DateRangePicker',
+  component: DateRangePicker,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A range picker with optional time inputs and preset options. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label for the component',
+    },
+    showTime: {
+      control: { type: 'boolean' },
+      description: 'Whether to show time inputs',
+    },
+    showPresets: {
+      control: { type: 'boolean' },
+      description: 'Whether to show the preset panel',
+    },
+    timeFormat: {
+      control: { type: 'inline-radio' },
+      options: ['12', '24'],
+      description: 'Time format',
+    },
+    navigationMode: {
+      control: { type: 'inline-radio' },
+      options: ['independent', 'together'],
+      description: 'Navigation mode for the calendar months',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Disabled state',
+    },
+    isRequired: {
+      control: { type: 'boolean' },
+      description: 'Whether the field is required',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onRangeChange: { action: 'rangeChanged', table: { disable: true } },
+    onDateChange: { action: 'dateChanged', table: { disable: true } },
+  },
+  args: {
+    label: 'Date range',
+    showTime: true,
+    showPresets: true,
+    timeFormat: '12',
+    navigationMode: 'independent',
+    disabled: false,
+    isRequired: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DateRangePicker>;
+
+export const Playground: Story = {};

--- a/lib/components/Datepicker/DatePicker.stories.tsx
+++ b/lib/components/Datepicker/DatePicker.stories.tsx
@@ -1,29 +1,43 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { DatePicker as DatepickerComponent } from './DatePicker';
+import { DatePicker } from './DatePicker';
 
-type Story = StoryObj<typeof DatepickerComponent>;
-
-const meta: Meta<typeof DatepickerComponent> = {
-  title: 'In Review/Datepicker',
-  component: DatepickerComponent,
-};
-
-export const Datepicker: Story = {
-  render: () => (
-    <>
-      <div className="max-w-[350px] flex justify-center gap-2">
-        <DatepickerComponent />
-      </div>
-
-      <div
-        className="max-w-[350px] flex justify-center gap-2 mt-6 rounded-lg bg-metal-900"
-        data-theme="dark"
-      >
-        <DatepickerComponent />
-      </div>
-    </>
-  ),
+const meta: Meta<typeof DatePicker> = {
+  title: 'Components/Datepicker',
+  component: DatePicker,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A date picker built on react-day-picker for single date selection. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    defaultSelected: {
+      control: { type: 'date' },
+      description: 'Initial selected date',
+    },
+    showOutsideDays: {
+      control: { type: 'boolean' },
+      description: 'Show days from the previous and next months',
+    },
+    animate: {
+      control: { type: 'boolean' },
+      description: 'Animate month transitions',
+    },
+    onSelect: { action: 'selected', table: { disable: true } },
+  },
+  args: {
+    defaultSelected: new Date(),
+    showOutsideDays: true,
+    animate: true,
+  },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof DatePicker>;
+
+export const Playground: Story = {};

--- a/lib/components/Divider/Divider.stories.tsx
+++ b/lib/components/Divider/Divider.stories.tsx
@@ -1,28 +1,39 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Divider as DividerComponent } from './Divider';
+import { Divider } from './Divider';
 
-type Story = StoryObj<typeof DividerComponent>;
-
-const meta: Meta<typeof DividerComponent> = {
-  title: 'In Review/Divider',
-  component: DividerComponent,
-};
-
-export const Divider: Story = {
-  render: () => (
-    <div className="flex w-full flex-col gap-4">
-      <div className="w-[350px] space-y-4">
-        <DividerComponent />
+const meta: Meta<typeof Divider> = {
+  title: 'Components/Divider',
+  component: Divider,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A simple horizontal separator line. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    className: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes',
+    },
+  },
+  args: {},
+  render: (args) => {
+    return (
+      <div className="w-80 flex flex-col gap-2">
+        <p className="text-sm">Section above</p>
+        <Divider {...args} />
+        <p className="text-sm">Section below</p>
       </div>
-      <div className="w-[600px] space-y-4">
-        <DividerComponent className="bg-zinc-300" />
-      </div>
-      <div className="w-full space-y-4">
-        <DividerComponent className="bg-zinc-400" />
-      </div>
-    </div>
-  ),
+    );
+  },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof Divider>;
+
+export const Playground: Story = {};

--- a/lib/components/Drawer/Drawer.stories.tsx
+++ b/lib/components/Drawer/Drawer.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Button } from '../Button/Button';
+
+import { Drawer } from './Drawer';
+
+const meta: Meta<typeof Drawer> = {
+  title: 'Components/Drawer',
+  component: Drawer,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A panel component that slides in from the side of the screen. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    position: {
+      control: { type: 'inline-radio' },
+      options: ['left', 'right'],
+      description: 'Position of the drawer',
+    },
+    showCloseButton: {
+      control: { type: 'boolean' },
+      description: 'Show the X close button in the corner',
+    },
+    canResize: {
+      control: { type: 'boolean' },
+      description: 'Enable resizable drawer',
+    },
+    defaultWidth: {
+      control: { type: 'number' },
+      description: 'Default width of the drawer in pixels',
+    },
+    minWidth: {
+      control: { type: 'number' },
+      description: 'Minimum width when resizable',
+    },
+    maxWidth: {
+      control: { type: 'number' },
+      description: 'Maximum width when resizable',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onClose: { action: 'closed', table: { disable: true } },
+  },
+  args: {
+    position: 'right',
+    showCloseButton: true,
+    canResize: false,
+    defaultWidth: 500,
+    minWidth: 400,
+    maxWidth: 800,
+  },
+  render: (args) => {
+    const Demo = () => {
+      const [isOpen, setIsOpen] = useState(false);
+
+      return (
+        <>
+          <Button
+            onClick={() => {
+              setIsOpen(true);
+            }}
+          >
+            Open drawer
+          </Button>
+          <Drawer
+            {...args}
+            isOpen={isOpen}
+            onClose={() => {
+              setIsOpen(false);
+            }}
+          >
+            <Drawer.Header>Drawer title</Drawer.Header>
+            <Drawer.Body>Some drawer content goes here.</Drawer.Body>
+            <Drawer.Footer>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  setIsOpen(false);
+                }}
+              >
+                Close
+              </Button>
+            </Drawer.Footer>
+          </Drawer>
+        </>
+      );
+    };
+
+    return <Demo />;
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Drawer>;
+
+export const Playground: Story = {};

--- a/lib/components/DropdownButton/DropdownButton.stories.tsx
+++ b/lib/components/DropdownButton/DropdownButton.stories.tsx
@@ -1,32 +1,44 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { DropdownButton as DropdownButtonComponent } from './DropdownButton';
+import { DropdownButton } from './DropdownButton';
 
-type Story = StoryObj<typeof DropdownButtonComponent>;
-
-const meta: Meta<typeof DropdownButtonComponent> = {
-  title: 'In Review/DropdownButton',
-  component: DropdownButtonComponent,
-};
-
-export const DropdownButton: Story = {
+const meta: Meta<typeof DropdownButton> = {
+  title: 'Components/DropdownButton',
+  component: DropdownButton,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A button with an attached dropdown menu for selecting actions. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    options: {
+      control: { type: 'object' },
+      description: 'Array of options to display in the dropdown',
+    },
+    className: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes for the wrapper',
+    },
+    buttonClassName: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes for the trigger button',
+    },
+  },
   args: {
     options: [
-      {
-        label: 'PDF',
-      },
-      {
-        label: 'CSV',
-      },
+      { label: 'PDF' },
+      { label: 'CSV' },
+      { label: 'Excel' },
     ],
-  },
-  render: (args) => {
-    return (
-      <div className="max-w-50" data-theme="civo">
-        <DropdownButtonComponent {...args} />
-      </div>
-    );
   },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof DropdownButton>;
+
+export const Playground: Story = {};

--- a/lib/components/Filter/Filter.stories.tsx
+++ b/lib/components/Filter/Filter.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Filter } from './Filter';
+
+const meta: Meta<typeof Filter> = {
+  title: 'Components/Filter',
+  component: Filter,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A compound component for building filter interfaces with multi-select dropdowns and a reset button. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    closeOnApply: {
+      control: { type: 'boolean' },
+      description: 'Whether to close the filter dropdown automatically when Apply is clicked',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    closeOnApply: true,
+  },
+  render: (args) => {
+    return (
+      <Filter {...args}>
+        <Filter.BadgeMultiSelect
+          label="Status"
+          options={[
+            { id: 'active', label: 'Active', variant: 'success' },
+            { id: 'pending', label: 'Pending', variant: 'warning' },
+            { id: 'inactive', label: 'Inactive', variant: 'default' },
+          ]}
+        />
+        <Filter.ResetButton />
+      </Filter>
+    );
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Filter>;
+
+export const Playground: Story = {};

--- a/lib/components/ImageUpload/ImageUpload.stories.tsx
+++ b/lib/components/ImageUpload/ImageUpload.stories.tsx
@@ -1,277 +1,80 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
 
-import { ImageUpload as ImageUploadComponent } from './ImageUpload';
+import { ImageUpload } from './ImageUpload';
 import { ImageUploadStatus } from './ImageUpload.types';
-import { Typography } from '../Typography/Typography';
 
-type Story = StoryObj<typeof ImageUploadComponent>;
-
-const meta: Meta<typeof ImageUploadComponent> = {
-  title: 'In Review/ImageUpload',
-  component: ImageUploadComponent,
-};
-
-export const ImageUpload: Story = {
-  args: {
-    label: 'Item logo',
-    isRequired: true,
-    uploadButtonText: 'Upload logo',
+const meta: Meta<typeof ImageUpload> = {
+  title: 'Components/ImageUpload',
+  component: ImageUpload,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A file input for uploading images with preview, validation, and status states. Use the **Controls** panel below to interact with the props.',
+      },
+    },
   },
-  render: (args) => (
-    <>
-      <div className="w-125 flex flex-col gap-8">
-        <div className="flex flex-col gap-6">
-          <div>
-            <Typography variant="body2" className="mb-2 text-slate-600">
-              Default State
-            </Typography>
-            <ImageUploadComponent
-              {...args}
-              status={ImageUploadStatus.Default}
-            />
-          </div>
-
-          <div>
-            <Typography variant="body2" className="mb-2 text-slate-600">
-              Uploading State
-            </Typography>
-            <ImageUploadComponent
-              {...args}
-              status={ImageUploadStatus.Uploading}
-              fileName="metaphor_logo.svg"
-              fileSize="27.33KB"
-            />
-          </div>
-
-          <div>
-            <Typography variant="body2" className="mb-2 text-slate-600">
-              Complete State
-            </Typography>
-            <ImageUploadComponent
-              {...args}
-              status={ImageUploadStatus.Complete}
-              fileName="metaphor_logo.svg"
-              fileSize="27.33KB"
-              fileUrl="https://placehold.co/32"
-            />
-          </div>
-
-          <div>
-            <Typography variant="body2" className="mb-2 text-slate-600">
-              Error State
-            </Typography>
-            <ImageUploadComponent
-              {...args}
-              status={ImageUploadStatus.Error}
-              error="Invalid file format. Accepted file type is SVG, PNG, JPEG. Max file size is 5MB."
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="w-125 mt-10 bg-slate-950 p-4 rounded-sm">
-        <div className="flex flex-col gap-6">
-          <div>
-            <Typography variant="body2" className="mb-2 text-slate-200">
-              Default State
-            </Typography>
-            <ImageUploadComponent
-              {...args}
-              status={ImageUploadStatus.Default}
-              theme="dark"
-            />
-          </div>
-
-          <div>
-            <Typography variant="body2" className="mb-2 text-slate-200">
-              Uploading State
-            </Typography>
-            <ImageUploadComponent
-              {...args}
-              status={ImageUploadStatus.Uploading}
-              fileName="metaphor_logo.svg"
-              fileSize="27.33KB"
-              theme="dark"
-            />
-          </div>
-
-          <div>
-            <Typography variant="body2" className="mb-2 text-slate-200">
-              Complete State
-            </Typography>
-            <ImageUploadComponent
-              {...args}
-              status={ImageUploadStatus.Complete}
-              fileName="metaphor_logo.svg"
-              fileSize="27.33KB"
-              fileUrl="https://placehold.co/32"
-              theme="dark"
-            />
-          </div>
-
-          <div>
-            <Typography variant="body2" className="mb-2 text-slate-200">
-              Error State
-            </Typography>
-            <ImageUploadComponent
-              {...args}
-              status={ImageUploadStatus.Error}
-              error="Invalid file format. Accepted file type is SVG, PNG, JPEG. Max file size is 5MB."
-              theme="dark"
-            />
-          </div>
-        </div>
-      </div>
-    </>
-  ),
-};
-
-export const Interactive: Story = {
-  args: {
-    label: 'Company Logo',
-    isRequired: true,
-    uploadButtonText: 'Upload logo',
-    helperText:
-      'Logo should be 32 x 32 pixels with transparent background (larger images will be downscaled proportionally to fit). Accepted file type is SVG, PNG, JPEG. Max file size is 5MB.',
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the input',
+    },
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name',
+    },
+    accept: {
+      control: { type: 'text' },
+      description: 'Accepted file MIME types',
+    },
+    maxSize: {
+      control: { type: 'number' },
+      description: 'Maximum file size in bytes',
+    },
+    helperText: {
+      control: { type: 'text' },
+      description: 'Helper text displayed below the input',
+    },
+    error: {
+      control: { type: 'text' },
+      description: 'Error message to display',
+    },
+    isRequired: {
+      control: { type: 'boolean' },
+      description: 'Whether the field is required',
+    },
+    status: {
+      control: { type: 'select' },
+      options: Object.values(ImageUploadStatus),
+      description: 'Current upload status',
+    },
+    uploadButtonText: {
+      control: { type: 'text' },
+      description: 'Text displayed on the upload button',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+    onRemove: { action: 'removed', table: { disable: true } },
   },
-  render: function InteractiveStory(args) {
-    const [file, setFile] = useState<File | undefined>(undefined);
-    const [fileUrl, setFileUrl] = useState<string | undefined>(undefined);
-    const [fileName, setFileName] = useState<string | undefined>(undefined);
-    const [fileSize, setFileSize] = useState<string | undefined>(undefined);
-    const [status, setStatus] = useState<ImageUploadStatus>(
-      ImageUploadStatus.Default,
-    );
-    const [error, setError] = useState<string | undefined>(undefined);
-
-    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      const selectedFile = event.target.files?.[0];
-      if (!selectedFile) return;
-
-      console.log('File selected:', {
-        name: selectedFile.name,
-        size: selectedFile.size,
-        type: selectedFile.type,
-        lastModified: selectedFile.lastModified,
-        file: selectedFile,
-      });
-
-      setError(undefined);
-      setStatus(ImageUploadStatus.Uploading);
-      setFile(selectedFile);
-      setFileName(selectedFile.name);
-
-      const sizeInKB = (selectedFile.size / 1024).toFixed(2);
-      setFileSize(`${sizeInKB}KB`);
-
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setTimeout(() => {
-          const dataUrl = reader.result as string;
-          setFileUrl(dataUrl);
-          setStatus(ImageUploadStatus.Complete);
-          console.log('File uploaded successfully:', {
-            file: selectedFile,
-            dataUrl,
-            fileName: selectedFile.name,
-            fileSize: selectedFile.size,
-          });
-        }, 500);
-      };
-      reader.readAsDataURL(selectedFile);
-    };
-
-    const handleRemove = () => {
-      console.log('File removed');
-      setFile(undefined);
-      setFileUrl(undefined);
-      setFileName(undefined);
-      setFileSize(undefined);
-      setStatus(ImageUploadStatus.Default);
-      setError(undefined);
-    };
-
-    return (
-      <div className="w-150 flex flex-col gap-8">
-        <div>
-          <Typography variant="h6" className="mb-4" theme="kubefirst">
-            Interactive ImageUpload - Light Mode
-          </Typography>
-          <ImageUploadComponent
-            {...args}
-            status={status}
-            fileUrl={fileUrl}
-            fileName={fileName}
-            fileSize={fileSize}
-            error={error}
-            onChange={handleFileChange}
-            onRemove={handleRemove}
-          />
-        </div>
-
-        <div className="bg-slate-950 p-6 rounded-sm">
-          <Typography variant="h6" className="mb-4 text-slate-50">
-            Interactive ImageUpload - Dark Mode
-          </Typography>
-          <ImageUploadComponent
-            {...args}
-            theme="dark"
-            status={status}
-            fileUrl={fileUrl}
-            fileName={fileName}
-            fileSize={fileSize}
-            error={error}
-            onChange={handleFileChange}
-            onRemove={handleRemove}
-          />
-        </div>
-
-        <div className="mt-4 p-4 bg-slate-100 dark:bg-slate-800 rounded">
-          <Typography variant="body2" className="mb-2 font-semibold">
-            Current State:
-          </Typography>
-          <pre className="text-xs text-slate-700 dark:text-slate-300 overflow-auto max-h-64">
-            {JSON.stringify(
-              {
-                status,
-                file: file
-                  ? {
-                      name: file.name,
-                      size: file.size,
-                      type: file.type,
-                      lastModified: new Date(file.lastModified).toISOString(),
-                    }
-                  : null,
-                fileName,
-                fileSize,
-                fileUrl: fileUrl ? `${fileUrl.substring(0, 50)}...` : null,
-                hasFile: !!file,
-              },
-              null,
-              2,
-            )}
-          </pre>
-          {file && (
-            <div className="mt-4 pt-4 border-t border-slate-300 dark:border-slate-600">
-              <Typography variant="body2" className="mb-2 font-semibold">
-                File Object Available:
-              </Typography>
-              <Typography
-                variant="body2"
-                className="text-xs text-slate-600 dark:text-slate-400"
-              >
-                You can access the File object in your code via the onChange
-                handler.
-                <br />
-                Check the browser console for detailed file information.
-              </Typography>
-            </div>
-          )}
-        </div>
-      </div>
-    );
+  args: {
+    label: 'Logo',
+    name: 'logo',
+    accept: 'image/png,image/svg+xml,image/jpeg',
+    maxSize: 2 * 1024 * 1024,
+    helperText: 'PNG, SVG or JPEG up to 2 MB',
+    isRequired: false,
+    status: ImageUploadStatus.Default,
+    uploadButtonText: 'Upload image',
   },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof ImageUpload>;
+
+export const Playground: Story = {};

--- a/lib/components/Input/Input.stories.tsx
+++ b/lib/components/Input/Input.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Input } from './Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'Components/Input',
+  component: Input,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A text input with label, helper text, error state and search variant. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: { type: 'inline-radio' },
+      options: ['default', 'error'],
+      description: 'Visual variant of the input',
+    },
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the input',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text',
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['text', 'email', 'password', 'number', 'tel', 'url'],
+      description: 'HTML input type',
+    },
+    helperText: {
+      control: { type: 'text' },
+      description: 'Helper text displayed below the input',
+    },
+    error: {
+      control: { type: 'text' },
+      description: 'Error message to display below the input',
+    },
+    isRequired: {
+      control: { type: 'boolean' },
+      description: 'Show required indicator',
+    },
+    isSearch: {
+      control: { type: 'boolean' },
+      description: 'Show search icon inside the input',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the input is disabled',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+    onBlur: { action: 'blurred', table: { disable: true } },
+  },
+  args: {
+    label: 'Email',
+    placeholder: 'Enter your email',
+    type: 'email',
+    isRequired: false,
+    isSearch: false,
+    disabled: false,
+    variant: 'default',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Playground: Story = {};

--- a/lib/components/LineChart/LineChart.stories.tsx
+++ b/lib/components/LineChart/LineChart.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { LineChart } from './LineChart';
+
+const meta: Meta<typeof LineChart> = {
+  title: 'Components/LineChart',
+  component: LineChart,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A line chart built on Chart.js for data visualization. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    title: {
+      control: { type: 'text' },
+      description: 'Chart title text',
+    },
+    labels: {
+      control: { type: 'object' },
+      description: 'X-axis labels',
+    },
+    datasets: {
+      control: { type: 'object' },
+      description: 'One or more datasets (lines)',
+    },
+    showLegend: {
+      control: { type: 'boolean' },
+      description: 'Show legend (auto-shown when datasets > 1)',
+    },
+    smooth: {
+      control: { type: 'boolean' },
+      description: 'Smooth lines',
+    },
+    showGrid: {
+      control: { type: 'boolean' },
+      description: 'Show horizontal grid lines',
+    },
+    showAxisBorder: {
+      control: { type: 'boolean' },
+      description: 'Show axis border lines',
+    },
+    height: {
+      control: { type: 'number' },
+      description: 'Chart height in px',
+    },
+    lineWidth: {
+      control: { type: 'number' },
+      description: 'Line thickness in px',
+    },
+  },
+  args: {
+    title: 'Disk Usage %',
+    labels: ['11:20', '11:25', '11:30', '11:35', '11:40'],
+    datasets: [
+      {
+        label: 'Usage',
+        data: [6, 3, 8, 5, 7],
+      },
+    ],
+    smooth: true,
+    showGrid: true,
+    showAxisBorder: false,
+    height: 300,
+    lineWidth: 2,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LineChart>;
+
+export const Playground: Story = {};

--- a/lib/components/Loading/Loading.stories.tsx
+++ b/lib/components/Loading/Loading.stories.tsx
@@ -1,25 +1,35 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Loading as LoadingComponent } from './Loading';
+import { Loading } from './Loading';
 
-type Story = StoryObj<typeof LoadingComponent>;
-
-const meta = {
-  title: 'In Review/Loading',
-  component: LoadingComponent,
-} satisfies Meta<typeof LoadingComponent>;
-
-export const Loading = {
-  render: () => (
-    <>
-      <div className="w-[350px]">
-        <LoadingComponent theme="kubefirst" />
-      </div>
-      <div className="w-[350px]">
-        <LoadingComponent />
-      </div>
-    </>
-  ),
-} satisfies Story;
+const meta: Meta<typeof Loading> = {
+  title: 'Components/Loading',
+  component: Loading,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A spinning loading indicator. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    className: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {},
+};
 
 export default meta;
+
+type Story = StoryObj<typeof Loading>;
+
+export const Playground: Story = {};

--- a/lib/components/Modal/Modal.stories.tsx
+++ b/lib/components/Modal/Modal.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Button } from '../Button/Button';
+
+import { Modal } from './Modal';
+
+const meta: Meta<typeof Modal> = {
+  title: 'Components/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A modal dialog with Header, Body, and Footer sub-components and Escape-to-close support. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    showCloseButton: {
+      control: { type: 'boolean' },
+      description: 'Show the X close button in the corner',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onClose: { action: 'closed', table: { disable: true } },
+  },
+  args: {
+    showCloseButton: true,
+  },
+  render: (args) => {
+    const Demo = () => {
+      const [isOpen, setIsOpen] = useState(false);
+
+      return (
+        <>
+          <Button
+            onClick={() => {
+              setIsOpen(true);
+            }}
+          >
+            Open modal
+          </Button>
+          <Modal
+            {...args}
+            isOpen={isOpen}
+            onClose={() => {
+              setIsOpen(false);
+            }}
+          >
+            <Modal.Header>Confirm action</Modal.Header>
+            <Modal.Body>Are you sure you want to proceed?</Modal.Body>
+            <Modal.Footer>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  setIsOpen(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={() => {
+                  setIsOpen(false);
+                }}
+              >
+                Confirm
+              </Button>
+            </Modal.Footer>
+          </Modal>
+        </>
+      );
+    };
+
+    return <Demo />;
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+export const Playground: Story = {};

--- a/lib/components/MultiSelectDropdown/MultiSelectDropdown.stories.tsx
+++ b/lib/components/MultiSelectDropdown/MultiSelectDropdown.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { MultiSelectDropdown } from './MultiSelectDropdown';
+import {
+  MultiSelectDropdownOption,
+  Props,
+} from './MultiSelectDropdown.types';
+
+const meta: Meta<typeof MultiSelectDropdown> = {
+  title: 'Components/MultiSelectDropdown',
+  component: MultiSelectDropdown,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A dropdown that allows selecting one or multiple options with search. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the dropdown',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text when no selection',
+    },
+    multiselect: {
+      control: { type: 'boolean' },
+      description: 'Whether multiple options can be selected',
+    },
+    isLoading: {
+      control: { type: 'boolean' },
+      description: 'Whether the dropdown is in a loading state',
+    },
+    isRequired: {
+      control: { type: 'boolean' },
+      description: 'Whether the field is required',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the dropdown is disabled',
+    },
+    noOptionsText: {
+      control: { type: 'text' },
+      description: 'Text shown when no options match the search',
+    },
+    options: {
+      control: { type: 'object' },
+      description: 'Available options to select from',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+    onBlur: { action: 'blurred', table: { disable: true } },
+  },
+  args: {
+    label: 'Users',
+    placeholder: 'Search users...',
+    multiselect: true,
+    isLoading: false,
+    isRequired: false,
+    disabled: false,
+    noOptionsText: 'No matches found',
+    options: [
+      { id: 1, label: 'John Doe', badge: 'Admin' },
+      { id: 2, label: 'Jane Smith', badge: 'User' },
+      { id: 3, label: 'Alex Brown', badge: 'User' },
+    ],
+  },
+  render: (args) => {
+    const Demo = () => {
+      const [value, setValue] = useState<MultiSelectDropdownOption[]>([]);
+
+      return (
+        <div className="w-80">
+          <MultiSelectDropdown
+            {...(args as Props)}
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+          />
+        </div>
+      );
+    };
+
+    return <Demo />;
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MultiSelectDropdown>;
+
+export const Playground: Story = {};

--- a/lib/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/lib/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { PhoneNumberInput } from './PhoneNumberInput';
+
+const meta: Meta<typeof PhoneNumberInput> = {
+  title: 'Components/PhoneNumberInput',
+  component: PhoneNumberInput,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'An input with country code selector and phone number formatting. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the input',
+    },
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name',
+    },
+    defaultCountryCode: {
+      control: { type: 'text' },
+      description: 'Default country code',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text for the input',
+    },
+    helperText: {
+      control: { type: 'text' },
+      description: 'Helper text displayed below the input',
+    },
+    error: {
+      control: { type: 'text' },
+      description: 'Error message to display',
+    },
+    isRequired: {
+      control: { type: 'boolean' },
+      description: 'Whether the field is required',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the input is disabled',
+    },
+    showFlagOnSearch: {
+      control: { type: 'boolean' },
+      description: 'Show country flags in the search dropdown',
+    },
+    showInputFilter: {
+      control: { type: 'boolean' },
+      description: 'Show the country filter input',
+    },
+    showNameOnSearch: {
+      control: { type: 'boolean' },
+      description: 'Show country names in the search dropdown',
+    },
+    showPlaceHolder: {
+      control: { type: 'boolean' },
+      description: 'Show the placeholder text',
+    },
+  },
+  args: {
+    label: 'Phone Number',
+    name: 'phone',
+    defaultCountryCode: 'US',
+    placeholder: 'Enter phone number',
+    showFlagOnSearch: true,
+    showInputFilter: true,
+    showNameOnSearch: true,
+    showPlaceHolder: true,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PhoneNumberInput>;
+
+export const Playground: Story = {};

--- a/lib/components/PieChart/PieChart.stories.tsx
+++ b/lib/components/PieChart/PieChart.stories.tsx
@@ -1,33 +1,75 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { PieChart as PieChartComponent } from './PieChart';
+import { PieChart } from './PieChart';
 
-type Story = StoryObj<typeof PieChartComponent>;
-
-const meta = {
-  title: 'In Review/PieChart',
-  component: PieChartComponent,
-} satisfies Meta<typeof PieChartComponent>;
-
-export const PieChart = {
-  render: () => {
-    const values = [20, 80];
-
-    return (
-      <div className="w-[115px] h-[115px]">
-        <PieChartComponent
-          subtitle="Total IPs"
-          subtitleColor="#62748E"
-          subtitleFontSize={14}
-          title="10/256"
-          titleColor="#1D283D"
-          titleFontSize={14}
-          titleFontWeight="normal"
-          values={values}
-        />
-      </div>
-    );
+const meta: Meta<typeof PieChart> = {
+  title: 'Components/PieChart',
+  component: PieChart,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A doughnut/pie chart built on Chart.js for data visualization. Use the **Controls** panel below to interact with the props.',
+      },
+    },
   },
-} satisfies Story;
+  argTypes: {
+    values: {
+      control: { type: 'object' },
+      description: 'Array of numeric values for each segment',
+    },
+    colors: {
+      control: { type: 'object' },
+      description: 'Array of colors for filling the segments',
+    },
+    title: {
+      control: { type: 'text' },
+      description: 'Title text displayed in the center',
+    },
+    subtitle: {
+      control: { type: 'text' },
+      description: 'Subtitle text displayed in the center',
+    },
+    cutoutPercentage: {
+      control: { type: 'number' },
+      description: 'Percentage of the chart center cut out (donut effect)',
+    },
+    borderWidth: {
+      control: { type: 'number' },
+      description: 'Width of segment borders in pixels',
+    },
+    titleFontSize: {
+      control: { type: 'number' },
+      description: 'Font size for the title in pixels',
+    },
+    subtitleFontSize: {
+      control: { type: 'number' },
+      description: 'Font size for the subtitle in pixels',
+    },
+    titleFontWeight: {
+      control: { type: 'inline-radio' },
+      options: ['bold', 'normal'],
+      description: 'Font weight for the title',
+    },
+    subtitleFontWeight: {
+      control: { type: 'inline-radio' },
+      options: ['bold', 'normal'],
+      description: 'Font weight for the subtitle',
+    },
+  },
+  args: {
+    values: [30, 70],
+    colors: ['#ef4444', '#22c55e'],
+    title: '70%',
+    subtitle: 'Complete',
+    cutoutPercentage: 75,
+    borderWidth: 0,
+  },
+};
 
 export default meta;
+
+type Story = StoryObj<typeof PieChart>;
+
+export const Playground: Story = {};

--- a/lib/components/ProgressBar/ProgressBar.stories.tsx
+++ b/lib/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ProgressBar } from './ProgressBar';
+
+const meta: Meta<typeof ProgressBar> = {
+  title: 'Components/ProgressBar',
+  component: ProgressBar,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A horizontal progress indicator with optional left and right content. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    percent: {
+      control: { type: 'number', min: 0, max: 100 },
+      description: 'Progress percentage (0-100)',
+    },
+    status: {
+      control: { type: 'inline-radio' },
+      options: ['default', 'success', 'warning', 'error'],
+      description: 'Status color of the bar fill',
+    },
+    leftContent: {
+      control: { type: 'text' },
+      description: 'Content displayed on the left side',
+    },
+    rightContent: {
+      control: { type: 'text' },
+      description: 'Content displayed on the right side',
+    },
+    fillClassName: {
+      control: { type: 'text' },
+      description: 'Custom CSS class for the bar fill',
+    },
+    trackClassName: {
+      control: { type: 'text' },
+      description: 'Custom CSS class for the track background',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    percent: 60,
+    status: 'default',
+    leftContent: '60%',
+    rightContent: '300/500 GB',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProgressBar>;
+
+export const Playground: Story = {};

--- a/lib/components/Radio/Radio.stories.tsx
+++ b/lib/components/Radio/Radio.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Radio } from './Radio';
+
+const meta: Meta<typeof Radio> = {
+  title: 'Components/Radio',
+  component: Radio,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A single radio button with optional label and description. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name',
+    },
+    value: {
+      control: { type: 'text' },
+      description: 'Value submitted when selected',
+    },
+    label: {
+      control: { type: 'text' },
+      description: 'Label text',
+    },
+    description: {
+      control: { type: 'text' },
+      description: 'Description text below the label',
+    },
+    defaultChecked: {
+      control: { type: 'boolean' },
+      description: 'Initial checked state',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the radio is disabled',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+  },
+  args: {
+    name: 'plan',
+    value: 'basic',
+    label: 'Basic Plan',
+    description: '$9 / month',
+    defaultChecked: false,
+    disabled: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Radio>;
+
+export const Playground: Story = {};

--- a/lib/components/RadioCard/RadioCard.stories.tsx
+++ b/lib/components/RadioCard/RadioCard.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { RadioCard } from './RadioCard';
+
+const meta: Meta<typeof RadioCard> = {
+  title: 'Components/RadioCard',
+  component: RadioCard,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A card-style radio option that combines Card styling with Radio functionality. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name',
+    },
+    value: {
+      control: { type: 'text' },
+      description: 'Value submitted when selected',
+    },
+    label: {
+      control: { type: 'text' },
+      description: 'Label text',
+    },
+    description: {
+      control: { type: 'text' },
+      description: 'Description text below the label',
+    },
+    defaultChecked: {
+      control: { type: 'boolean' },
+      description: 'Initial checked state',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the radio is disabled',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+  },
+  args: {
+    name: 'plan',
+    value: 'pro',
+    label: 'Pro Plan',
+    description: '$29 / month',
+    defaultChecked: false,
+    disabled: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RadioCard>;
+
+export const Playground: Story = {};

--- a/lib/components/RadioGroup/RadioGroup.stories.tsx
+++ b/lib/components/RadioGroup/RadioGroup.stories.tsx
@@ -1,16 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { RadioCardGroup } from './RadioCardGroup';
+import { RadioGroup } from './RadioGroup';
 
-const meta: Meta<typeof RadioCardGroup> = {
-  title: 'Components/RadioCardGroup',
-  component: RadioCardGroup,
+const meta: Meta<typeof RadioGroup> = {
+  title: 'Components/RadioGroup',
+  component: RadioGroup,
   tags: ['autodocs'],
   parameters: {
     docs: {
       description: {
         component:
-          'A group of card-style radio options. Use the **Controls** panel below to interact with the props.',
+          'A group of radio button options. Use the **Controls** panel below to interact with the props.',
       },
     },
   },
@@ -18,6 +18,10 @@ const meta: Meta<typeof RadioCardGroup> = {
     name: {
       control: { type: 'text' },
       description: 'Form field name (shared by all radios)',
+    },
+    label: {
+      control: { type: 'text' },
+      description: 'Label for the group',
     },
     direction: {
       control: { type: 'inline-radio' },
@@ -30,7 +34,7 @@ const meta: Meta<typeof RadioCardGroup> = {
     },
     options: {
       control: { type: 'object' },
-      description: 'Array of radio card options',
+      description: 'Array of radio options',
     },
     theme: {
       control: { type: 'select' },
@@ -40,19 +44,20 @@ const meta: Meta<typeof RadioCardGroup> = {
     onValueChange: { action: 'changed', table: { disable: true } },
   },
   args: {
-    name: 'pricing',
+    name: 'plan',
+    label: 'Choose a plan',
     direction: 'col',
-    defaultChecked: 'pro',
+    defaultChecked: 'basic',
     options: [
-      { value: 'basic', label: 'Basic', description: '$9 / month' },
-      { value: 'pro', label: 'Pro', description: '$29 / month' },
-      { value: 'enterprise', label: 'Enterprise', description: 'Custom pricing' },
+      { value: 'basic', label: 'Basic' },
+      { value: 'pro', label: 'Pro' },
+      { value: 'enterprise', label: 'Enterprise' },
     ],
   },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof RadioCardGroup>;
+type Story = StoryObj<typeof RadioGroup>;
 
 export const Playground: Story = {};

--- a/lib/components/Range/Range.stories.tsx
+++ b/lib/components/Range/Range.stories.tsx
@@ -1,30 +1,67 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Range as RangeComponent } from './Range';
+import { Range } from './Range';
 
-type Story = StoryObj<typeof RangeComponent>;
-
-const meta: Meta<typeof RangeComponent> = {
-  title: 'In Review/Range',
-  component: RangeComponent,
-};
-
-export const Range: Story = {
-  args: {
-    min: 0,
-    max: 100,
-    showValue: true,
+const meta: Meta<typeof Range> = {
+  title: 'Components/Range',
+  component: Range,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A dual-thumb slider for selecting a value range. Use the **Controls** panel below to interact with the props.',
+      },
+    },
   },
-  render: (args) => (
-    <div className="max-w-[350px]">
-      <RangeComponent
-        theme="kubefirst"
-        label="Range with Kubefirst theme"
-        defaultValue={[10, 77]}
-        {...args}
-      />
-    </div>
-  ),
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the range slider',
+    },
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name for the hidden input',
+    },
+    min: {
+      control: { type: 'number' },
+      description: 'Minimum value',
+    },
+    max: {
+      control: { type: 'number' },
+      description: 'Maximum value',
+    },
+    defaultValue: {
+      control: { type: 'object' },
+      description: 'Initial range values [min, max]',
+    },
+    showValue: {
+      control: { type: 'boolean' },
+      description: 'Display the current range values',
+    },
+    size: {
+      control: { type: 'inline-radio' },
+      options: ['sm', 'md', 'lg'],
+      description: 'Size of the slider track and thumbs',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    label: 'Price range',
+    min: 0,
+    max: 1000,
+    defaultValue: [100, 500],
+    showValue: true,
+    size: 'md',
+  },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof Range>;
+
+export const Playground: Story = {};

--- a/lib/components/Select/Select.stories.tsx
+++ b/lib/components/Select/Select.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Select } from './Select';
+
+const meta: Meta<typeof Select> = {
+  title: 'Components/Select',
+  component: Select,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A dropdown select with optional search, grouping, and infinite scroll. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the select',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text',
+    },
+    helperText: {
+      control: { type: 'text' },
+      description: 'Helper text displayed below the select',
+    },
+    error: {
+      control: { type: 'text' },
+      description: 'Error message to display',
+    },
+    isRequired: {
+      control: { type: 'boolean' },
+      description: 'Whether the field is required',
+    },
+    isLoading: {
+      control: { type: 'boolean' },
+      description: 'Show loading state',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the select is disabled',
+    },
+    searchable: {
+      control: { type: 'boolean' },
+      description: 'Enable search functionality',
+    },
+    highlightSearch: {
+      control: { type: 'boolean' },
+      description: 'Highlight matching text in options',
+    },
+    options: {
+      control: { type: 'object' },
+      description: 'Array of options or option groups',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+  },
+  args: {
+    label: 'Country',
+    placeholder: 'Select a country',
+    isRequired: false,
+    isLoading: false,
+    disabled: false,
+    searchable: false,
+    highlightSearch: false,
+    options: [
+      { value: 'us', label: 'United States' },
+      { value: 'uk', label: 'United Kingdom' },
+      { value: 'br', label: 'Brazil' },
+      { value: 'de', label: 'Germany' },
+    ],
+  },
+  render: (args) => {
+    const Demo = () => {
+      const [value, setValue] = useState<string | undefined>();
+
+      return (
+        <div className="w-80">
+          <Select
+            {...args}
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+          />
+        </div>
+      );
+    };
+
+    return <Demo />;
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+export const Playground: Story = {};

--- a/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/lib/components/Sidebar/Sidebar.stories.tsx
@@ -1,198 +1,85 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import debounce from 'lodash/debounce';
-import { useEffect, useState } from 'react';
-import { Star } from 'react-feather';
+import { Home, Settings } from 'lucide-react';
 
-import {
-  CloudIcon,
-  PhotoLibraryIcon,
-  ReceiptLongIcon,
-  ScatterPlotIcon,
-} from '@/assets/icons/components';
-import { Theme } from '@/domain/theme';
+import { Sidebar } from './Sidebar';
 
-import { Typography } from '../Typography/Typography';
-import {
-  Footer,
-  Label,
-  Logo,
-  Navigation,
-  NavigationGroup,
-  NavigationOption,
-  Sidebar as SidebarPrimitive,
-} from './Sidebar';
-
-type Story = StoryObj<typeof SidebarPrimitive>;
-
-const meta = {
-  title: 'In Review/Sidebar',
-  component: SidebarPrimitive,
-  decorators: [
-    (Story) => {
-      const [height, setHeight] = useState(window.innerHeight);
-      const debounced = debounce(() => setHeight(window.innerHeight), 150);
-
-      useEffect(() => {
-        const panel = window.parent.document.getElementById(
-          'storybook-panel-root',
-        );
-
-        if (!panel) {
-          return;
-        }
-
-        const observer = new ResizeObserver(debounced);
-
-        observer.observe(panel);
-
-        return () => {
-          observer.disconnect();
-        };
-      }, [debounced]);
-
-      useEffect(() => {
-        const callback = (node?: Node) => {
-          const sidebar = (node as HTMLElement)?.querySelector(
-            '.sidebar-container',
-          );
-
-          if (sidebar) {
-            debounced();
-          }
-        };
-
-        const mutationCallback: MutationCallback = (mutationsList) => {
-          mutationsList.forEach((mutation) => {
-            mutation.addedNodes.forEach(callback);
-            mutation.removedNodes.forEach(callback);
-          });
-        };
-
-        const mutationObserver = new MutationObserver(mutationCallback);
-
-        mutationObserver.observe(window.parent.document.body, {
-          childList: true,
-          subtree: true,
-        });
-      }, [debounced]);
-
-      return (
-        <div style={{ margin: '-1rem', height }}>
-          <Story />
-        </div>
-      );
+const meta: Meta<typeof Sidebar> = {
+  title: 'Components/Sidebar',
+  component: Sidebar,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A compound component for building application sidebars with navigation. Use the **Controls** panel below to interact with the props.',
+      },
     },
-  ],
-} satisfies Meta<typeof SidebarPrimitive>;
-
-const renderSidebarContent = (
-  theme: Theme,
-  onThemeChange: (next: Theme) => void,
-) => (
-  <>
-    <Logo>
-      <a className="flex items-center w-full">
-        <img
-          className="hidden group-data-[mode=expanded]/sidebar:block w-auto h-auto max-w-full"
-          src="./logo-kubefirst.svg"
-          alt="Company logo"
-        />
-        <img
-          className="block h-10 w-12 group-data-[mode=expanded]/sidebar:hidden"
-          src="./ray.svg"
-          alt="Company logo"
-        />
-      </a>
-      <Typography variant="labelSmall" className="text-[#ABADC6] lowercase">
-        v1.11.1
-      </Typography>
-    </Logo>
-
-    <Navigation className="mt-4 group-data-[mode=expanded]/sidebar:mt-0">
-      <NavigationGroup>
-        <NavigationOption>
-          <a>
-            <ScatterPlotIcon className="w-6 h-6 shrink-0" />
-            <Label>Clusters</Label>
-          </a>
-        </NavigationOption>
-
-        <NavigationOption
-          role="button"
-          onClick={() => onThemeChange('kubefirst')}
-          isActive={theme === 'kubefirst'}
-        >
-          <a>
-            <PhotoLibraryIcon className="w-6 h-6 shrink-0" />
-            <Label>Environments</Label>
-          </a>
-        </NavigationOption>
-      </NavigationGroup>
-
-      <NavigationGroup title="Admin settings" titleClassName="uppercase">
-        <NavigationOption
-          role="button"
-          onClick={() => onThemeChange('light')}
-          isActive={theme === 'light'}
-        >
-          <a>
-            <ReceiptLongIcon className="w-6 h-6 shrink-0" />
-            <Label>Plans & Billing</Label>
-          </a>
-        </NavigationOption>
-
-        <NavigationOption>
-          <a>
-            <CloudIcon className="w-6 h-6 shrink-0" />
-            <Label>Cloud accounts</Label>
-          </a>
-        </NavigationOption>
-      </NavigationGroup>
-    </Navigation>
-
-    <Footer>
-      <span className="text-[#81e2b4] flex items-center gap-2 justify-center font-semibold cursor-pointer">
-        <Star className="w-5 h-5" />
-        <Label>Upgrade to Business</Label>
-      </span>
-    </Footer>
-  </>
-);
-
-export const Sidebar = {
-  render: function SidebarStory() {
-    const [theme, setTheme] = useState<Theme>('kubefirst');
-
+  },
+  argTypes: {
+    mode: {
+      control: { type: 'select' },
+      options: ['auto', 'expanded', 'collapsed', 'drawer'],
+      description: 'Controls the responsive mode of the sidebar',
+    },
+    canResize: {
+      control: { type: 'boolean' },
+      description: 'Whether the sidebar can be resized by dragging',
+    },
+    expandOnHover: {
+      control: { type: 'boolean' },
+      description: 'Expand hovered option when in collapsed mode',
+    },
+    minWith: {
+      control: { type: 'number' },
+      description: 'Minimum width when resizing in pixels',
+    },
+    maxWith: {
+      control: { type: 'number' },
+      description: 'Maximum width when resizing in pixels',
+    },
+    initialWidth: {
+      control: { type: 'number' },
+      description: 'Initial width in pixels when entering expanded mode',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    mode: 'expanded',
+    canResize: false,
+    expandOnHover: true,
+    minWith: 240,
+    maxWith: 300,
+    initialWidth: 256,
+  },
+  render: (args) => {
     return (
-      <SidebarPrimitive theme={theme}>
-        {renderSidebarContent(theme, setTheme)}
-      </SidebarPrimitive>
+      <div style={{ height: 500, display: 'flex' }}>
+        <Sidebar {...args}>
+          <Sidebar.Navigation>
+            <Sidebar.NavigationGroup title="Main">
+              <Sidebar.NavigationOption>
+                <Home size={18} />
+                <Sidebar.Label>Dashboard</Sidebar.Label>
+              </Sidebar.NavigationOption>
+              <Sidebar.NavigationOption>
+                <Settings size={18} />
+                <Sidebar.Label>Settings</Sidebar.Label>
+              </Sidebar.NavigationOption>
+            </Sidebar.NavigationGroup>
+          </Sidebar.Navigation>
+          <Sidebar.Footer>v1.0.0</Sidebar.Footer>
+        </Sidebar>
+      </div>
     );
   },
-} satisfies Story;
-
-export const CollapsedMode = {
-  render: function CollapsedStory() {
-    const [theme, setTheme] = useState<Theme>('kubefirst');
-
-    return (
-      <SidebarPrimitive theme={theme} mode="collapsed">
-        {renderSidebarContent(theme, setTheme)}
-      </SidebarPrimitive>
-    );
-  },
-} satisfies Story;
-
-export const DrawerMode = {
-  render: function DrawerStory() {
-    const [theme, setTheme] = useState<Theme>('kubefirst');
-
-    return (
-      <SidebarPrimitive theme={theme} mode="drawer">
-        {renderSidebarContent(theme, setTheme)}
-      </SidebarPrimitive>
-    );
-  },
-} satisfies Story;
+};
 
 export default meta;
+
+type Story = StoryObj<typeof Sidebar>;
+
+export const Playground: Story = {};

--- a/lib/components/Slider/Slider.stories.tsx
+++ b/lib/components/Slider/Slider.stories.tsx
@@ -1,28 +1,67 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Slider as SliderComponent } from './Slider';
+import { Slider } from './Slider';
 
-type Story = StoryObj<typeof SliderComponent>;
-
-const meta: Meta<typeof SliderComponent> = {
-  title: 'In Review/Slider',
-  component: SliderComponent,
-};
-
-export const Slider: Story = {
-  args: {
-    showValue: true,
+const meta: Meta<typeof Slider> = {
+  title: 'Components/Slider',
+  component: Slider,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A single-thumb slider for selecting a single numeric value. Use the **Controls** panel below to interact with the props.',
+      },
+    },
   },
-  render: (args) => (
-    <div className="max-w-[350px]">
-      <SliderComponent
-        theme="kubefirst"
-        label="Slider with Kubefirst theme"
-        defaultValue={[50]}
-        {...args}
-      />
-    </div>
-  ),
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the slider',
+    },
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name for the hidden input',
+    },
+    min: {
+      control: { type: 'number' },
+      description: 'Minimum value',
+    },
+    max: {
+      control: { type: 'number' },
+      description: 'Maximum value',
+    },
+    defaultValue: {
+      control: { type: 'object' },
+      description: 'Initial value as single-element array',
+    },
+    showValue: {
+      control: { type: 'boolean' },
+      description: 'Display the current value',
+    },
+    size: {
+      control: { type: 'inline-radio' },
+      options: ['sm', 'md', 'lg'],
+      description: 'Size of the slider track and thumb',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    label: 'Volume',
+    min: 0,
+    max: 100,
+    defaultValue: [50],
+    showValue: true,
+    size: 'md',
+  },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof Slider>;
+
+export const Playground: Story = {};

--- a/lib/components/Spinner/Spinner.stories.tsx
+++ b/lib/components/Spinner/Spinner.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Spinner } from './Spinner';
+
+const meta: Meta<typeof Spinner> = {
+  title: 'Components/Spinner',
+  component: Spinner,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A loading spinner with optional text and configurable sizes. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      control: { type: 'inline-radio' },
+      options: ['sm', 'md', 'lg'],
+      description: 'Spinner size',
+    },
+    text: {
+      control: { type: 'text' },
+      description: 'Optional text shown below the spinner',
+    },
+    srLabel: {
+      control: { type: 'text' },
+      description: 'Accessible label for screen readers',
+    },
+    textVariant: {
+      control: { type: 'select' },
+      options: [
+        'body1',
+        'body2',
+        'body3',
+        'subtitle1',
+        'subtitle2',
+        'subtitle3',
+      ],
+      description: 'Typography variant for the text',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    size: 'md',
+    text: 'Loading...',
+    srLabel: 'Loading',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Spinner>;
+
+export const Playground: Story = {};

--- a/lib/components/Stepper/Stepper.stories.tsx
+++ b/lib/components/Stepper/Stepper.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Stepper } from './Stepper';
+
+const meta: Meta<typeof Stepper> = {
+  title: 'Components/Stepper',
+  component: Stepper,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A multi-step progress indicator with inline, stacked or horizontal layouts. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    steps: {
+      control: { type: 'object' },
+      description: 'Array of steps to display',
+    },
+    currentStep: {
+      control: { type: 'number' },
+      description: 'Index of the current active step (0-based)',
+    },
+    variant: {
+      control: { type: 'inline-radio' },
+      options: ['inline', 'stacked', 'horizontal'],
+      description: 'Layout variant',
+    },
+    orientation: {
+      control: { type: 'inline-radio' },
+      options: ['vertical', 'horizontal'],
+      description: 'Stepper orientation',
+    },
+    size: {
+      control: { type: 'inline-radio' },
+      options: ['sm', 'md', 'lg'],
+      description: 'Size of the step indicators',
+    },
+    clickable: {
+      control: { type: 'boolean' },
+      description: 'Whether steps are clickable',
+    },
+    showConnector: {
+      control: { type: 'boolean' },
+      description: 'Show connector lines between steps',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onStepClick: { action: 'stepClicked', table: { disable: true } },
+  },
+  args: {
+    currentStep: 1,
+    variant: 'inline',
+    orientation: 'vertical',
+    size: 'sm',
+    clickable: false,
+    showConnector: true,
+    steps: [
+      { id: '1', label: 'Account', description: 'Create an account' },
+      { id: '2', label: 'Profile', description: 'Add your details' },
+      { id: '3', label: 'Confirm', description: 'Review and submit' },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Stepper>;
+
+export const Playground: Story = {};

--- a/lib/components/Switch/Switch.stories.tsx
+++ b/lib/components/Switch/Switch.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Switch } from './Switch';
+
+const meta: Meta<typeof Switch> = {
+  title: 'Components/Switch',
+  component: Switch,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A toggle switch for boolean values with an optional label. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label text displayed next to the switch',
+    },
+    helperText: {
+      control: { type: 'text' },
+      description: 'Helper text displayed below the label',
+    },
+    alignment: {
+      control: { type: 'inline-radio' },
+      options: ['horizontal', 'vertical'],
+      description: 'Layout direction',
+    },
+    defaultChecked: {
+      control: { type: 'boolean' },
+      description: 'Initial checked state',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the switch is disabled',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+  },
+  args: {
+    label: 'Enable notifications',
+    alignment: 'horizontal',
+    defaultChecked: false,
+    disabled: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Switch>;
+
+export const Playground: Story = {};

--- a/lib/components/Table/Table.stories.tsx
+++ b/lib/components/Table/Table.stories.tsx
@@ -1,79 +1,61 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Table as TableComponent } from './Table';
-import { Typography } from '../Typography/Typography';
-import { useState } from 'react';
-import { Button } from '../Button/Button';
+import { Table } from './Table';
 
-type Story = StoryObj<typeof TableComponent>;
-
-const meta = {
-  title: 'In Review/Table',
-  component: TableComponent,
-} satisfies Meta<typeof TableComponent>;
-
-const data = [
-  { name: 'John Doe', age: 30, email: 'john.doe@example.com' },
-  { name: 'Jane Doe', age: 25, email: 'jane.doe@example.com' },
-];
-
-export const Table = {
-  render: function TableStory() {
-    const [filter, setFilter] = useState('');
-
-    const filteredData = data.filter((item) =>
-      item.name.toLowerCase().includes(filter.toLowerCase()),
-    );
+const meta: Meta<typeof Table> = {
+  title: 'Components/Table',
+  component: Table,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A semantic HTML table with Head, Body, and Row sub-components. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {},
+  render: (args) => {
+    const data = [
+      { name: 'John Doe', email: 'john@example.com', role: 'Admin' },
+      { name: 'Jane Smith', email: 'jane@example.com', role: 'User' },
+      { name: 'Alex Brown', email: 'alex@example.com', role: 'User' },
+    ];
 
     return (
-      <div className="w-full kubefirst-table">
-        <TableComponent.Filter
-          placeholder="Search"
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-        >
-          <Button variant="primary">Add cloud account</Button>
-        </TableComponent.Filter>
-
-        <TableComponent className="">
-          <TableComponent.Head>
-            <TableComponent.Row width="100px">
-              <th className="w-[100px]">
-                <Typography variant="labelMedium" className="text-slate-500">
-                  Name
-                </Typography>
-              </th>
-              <th>
-                <Typography variant="labelMedium" className="text-slate-500">
-                  Age
-                </Typography>
-              </th>
-              <th>
-                <Typography variant="labelMedium" className="text-slate-500">
-                  Email
-                </Typography>
-              </th>
-            </TableComponent.Row>
-          </TableComponent.Head>
-          <TableComponent.Body>
-            {filteredData.map((item) => (
-              <TableComponent.Row key={item.name}>
-                <td>
-                  <Typography variant="body2">{item.name}</Typography>
-                </td>
-                <td>
-                  <Typography variant="body2">30</Typography>
-                </td>
-                <td>
-                  <Typography variant="body2">john.doe@example.com</Typography>
-                </td>
-              </TableComponent.Row>
-            ))}
-          </TableComponent.Body>
-        </TableComponent>
-      </div>
+      <Table {...args}>
+        <Table.Head>
+          <Table.Row>
+            <th className="px-3 py-2 text-left text-sm font-medium">Name</th>
+            <th className="px-3 py-2 text-left text-sm font-medium">Email</th>
+            <th className="px-3 py-2 text-left text-sm font-medium">Role</th>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          {data.map((row) => {
+            return (
+              <Table.Row key={row.email}>
+                <td className="px-3 py-2 text-sm">{row.name}</td>
+                <td className="px-3 py-2 text-sm">{row.email}</td>
+                <td className="px-3 py-2 text-sm">{row.role}</td>
+              </Table.Row>
+            );
+          })}
+        </Table.Body>
+      </Table>
     );
   },
-} satisfies Story;
+};
 
 export default meta;
+
+type Story = StoryObj<typeof Table>;
+
+export const Playground: Story = {};

--- a/lib/components/Tabs/Tabs.stories.tsx
+++ b/lib/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Tabs } from './Tabs';
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Components/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A tabs container with List, Trigger, and Content sub-components built on Radix UI. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    defaultValue: {
+      control: { type: 'text' },
+      description: 'Default active tab',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    defaultValue: 'tab1',
+  },
+  render: (args) => {
+    const Demo = () => {
+      const [value, setValue] = useState(args.defaultValue ?? 'tab1');
+
+      return (
+        <Tabs {...args} value={value} onValueChange={setValue}>
+          <Tabs.List orientation="horizontal">
+            <Tabs.Trigger tab="tab1" label="Overview" isActive={value === 'tab1'} />
+            <Tabs.Trigger tab="tab2" label="Activity" isActive={value === 'tab2'} />
+            <Tabs.Trigger tab="tab3" label="Settings" isActive={value === 'tab3'} />
+          </Tabs.List>
+          <Tabs.Content value="tab1">Overview content</Tabs.Content>
+          <Tabs.Content value="tab2">Activity content</Tabs.Content>
+          <Tabs.Content value="tab3">Settings content</Tabs.Content>
+        </Tabs>
+      );
+    };
+
+    return <Demo />;
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tabs>;
+
+export const Playground: Story = {};

--- a/lib/components/Tag/Tag.stories.tsx
+++ b/lib/components/Tag/Tag.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Tag } from './Tag';
+
+const meta: Meta<typeof Tag> = {
+  title: 'Components/Tag',
+  component: Tag,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A small label component for categorization or status display. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Text displayed in the tag',
+    },
+    color: {
+      control: { type: 'select' },
+      options: [
+        'gray',
+        'gray-800',
+        'cyan',
+        'gold',
+        'green',
+        'light blue',
+        'lime',
+        'pink',
+        'purple',
+        'emerald',
+        'fuscia',
+        'indigo',
+        'light-orange',
+        'dark-sky-blue',
+        'mistery',
+      ],
+      description: 'Color variant for the tag',
+    },
+    isSelected: {
+      control: { type: 'boolean' },
+      description: 'Whether the tag is in a selected state',
+    },
+  },
+  args: {
+    id: 'tag-1',
+    label: 'Active',
+    color: 'green',
+    isSelected: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tag>;
+
+export const Playground: Story = {};

--- a/lib/components/TagSelect/TagSelect.stories.tsx
+++ b/lib/components/TagSelect/TagSelect.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TagSelect } from './TagSelect';
+
+const meta: Meta<typeof TagSelect> = {
+  title: 'Components/TagSelect',
+  component: TagSelect,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'An input that allows selecting from a list of tags. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the input',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text when no selection',
+    },
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name',
+    },
+    multiselect: {
+      control: { type: 'boolean' },
+      description: 'Whether multiple tags can be selected',
+    },
+    options: {
+      control: { type: 'object' },
+      description: 'Available tag options',
+    },
+  },
+  args: {
+    label: 'Categories',
+    placeholder: 'Select categories...',
+    multiselect: true,
+    options: [
+      { id: 1, label: 'Frontend', color: 'light blue' },
+      { id: 2, label: 'Backend', color: 'green' },
+      { id: 3, label: 'DevOps', color: 'purple' },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TagSelect>;
+
+export const Playground: Story = {};

--- a/lib/components/TextArea/TextArea.stories.tsx
+++ b/lib/components/TextArea/TextArea.stories.tsx
@@ -1,26 +1,61 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { TextArea as TextAreaComponent } from './TextArea';
+import { TextArea } from './TextArea';
 
-type Story = StoryObj<typeof TextAreaComponent>;
-
-const meta: Meta<typeof TextAreaComponent> = {
-  title: 'In Review/TextArea',
-  component: TextAreaComponent,
-};
-
-export const TextArea: Story = {
-  args: {
-    placeholder: 'Type your message here.',
+const meta: Meta<typeof TextArea> = {
+  title: 'Components/TextArea',
+  component: TextArea,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A multi-line text input with optional label and rows. Use the **Controls** panel below to interact with the props.',
+      },
+    },
   },
-  render: (args) => (
-    <div className="w-[350px] flex flex-col gap-3">
-      <TextAreaComponent
-        {...args}
-        label="This is a textarea with Kubefirst theme"
-      />
-    </div>
-  ),
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the textarea',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text',
+    },
+    rows: {
+      control: { type: 'number' },
+      description: 'Number of visible text rows',
+    },
+    initialValue: {
+      control: { type: 'text' },
+      description: 'Initial/default value',
+    },
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the textarea is disabled',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+  },
+  args: {
+    label: 'Description',
+    placeholder: 'Enter a description...',
+    rows: 4,
+    disabled: false,
+  },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof TextArea>;
+
+export const Playground: Story = {};

--- a/lib/components/TimePicker/TimePicker.stories.tsx
+++ b/lib/components/TimePicker/TimePicker.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TimePicker } from './TimePicker';
+
+const meta: Meta<typeof TimePicker> = {
+  title: 'Components/TimePicker',
+  component: TimePicker,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A scrollable time picker with 12 and 24 hour format support. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'Label displayed above the picker',
+    },
+    name: {
+      control: { type: 'text' },
+      description: 'Form field name',
+    },
+    format: {
+      control: { type: 'inline-radio' },
+      options: ['12', '24'],
+      description: 'Time format',
+    },
+    mode: {
+      control: { type: 'inline-radio' },
+      options: ['select', 'input'],
+      description: 'Input mode',
+    },
+    showList: {
+      control: { type: 'boolean' },
+      description: 'Whether to show the dropdown list',
+    },
+    listPosition: {
+      control: { type: 'inline-radio' },
+      options: ['top', 'bottom'],
+      description: 'Direction to open the dropdown list',
+    },
+    isRequired: {
+      control: { type: 'boolean' },
+      description: 'Whether the field is required',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the picker is disabled',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text for input mode',
+    },
+    onChange: { action: 'changed', table: { disable: true } },
+  },
+  args: {
+    label: 'Meeting time',
+    name: 'meetingTime',
+    format: '12',
+    mode: 'select',
+    showList: true,
+    listPosition: 'bottom',
+    isRequired: false,
+    disabled: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TimePicker>;
+
+export const Playground: Story = {};

--- a/lib/components/Toast/Toast.stories.tsx
+++ b/lib/components/Toast/Toast.stories.tsx
@@ -3,85 +3,78 @@ import { useState } from 'react';
 
 import { Button } from '../Button/Button';
 
-import { Toast as ToastComponent } from './Toast';
+import { Toast } from './Toast';
 
-type Story = StoryObj<typeof ToastComponent>;
-
-const meta: Meta<typeof ToastComponent> = {
-  title: 'In Review/Toast',
-  component: ToastComponent,
-};
-
-export const Success: Story = {
+const meta: Meta<typeof Toast> = {
+  title: 'Components/Toast',
+  component: Toast,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A toast notification with auto-dismiss and configurable variants. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: { type: 'inline-radio' },
+      options: ['success', 'error', 'warning', 'info'],
+      description: 'Toast color variant',
+    },
+    title: {
+      control: { type: 'text' },
+      description: 'Toast title',
+    },
+    description: {
+      control: { type: 'text' },
+      description: 'Toast description',
+    },
+    duration: {
+      control: { type: 'number' },
+      description: 'Auto-dismiss duration in ms',
+    },
+    showCloseButton: {
+      control: { type: 'boolean' },
+      description: 'Show close button',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
   args: {
-    duration: 5000,
     variant: 'success',
-    title: <span>This is an success toast!</span>,
-  },
-  render: function ToastStory(args) {
-    const [open, setOpen] = useState(false);
-
-    return (
-      <div className="w-87.5 flex flex-col gap-3">
-        <Button onClick={() => setOpen(true)}>Open Success Toast</Button>
-        <ToastComponent {...args} open={open} setOpen={setOpen} />
-      </div>
-    );
-  },
-};
-
-export const Error: Story = {
-  args: {
+    title: 'Success',
+    description: 'Your changes have been saved.',
     duration: 5000,
-    variant: 'error',
-    title: <span>This is an error toast!</span>,
+    showCloseButton: true,
   },
-  render: function ToastStory(args) {
-    const [open, setOpen] = useState(false);
+  render: (args) => {
+    const Demo = () => {
+      const [open, setOpen] = useState(false);
 
-    return (
-      <div className="w-87.5 flex flex-col gap-3">
-        <Button onClick={() => setOpen(true)}>Open Error Toast</Button>
-        <ToastComponent {...args} open={open} setOpen={setOpen} />
-      </div>
-    );
-  },
-};
+      return (
+        <Toast {...args} open={open} setOpen={setOpen}>
+          <Button
+            onClick={() => {
+              setOpen(true);
+            }}
+          >
+            Show toast
+          </Button>
+        </Toast>
+      );
+    };
 
-export const Warning: Story = {
-  args: {
-    duration: 5000,
-    variant: 'warning',
-    title: <span>This is a warning toast!</span>,
-  },
-  render: function ToastStory(args) {
-    const [open, setOpen] = useState(false);
-
-    return (
-      <div className="w-87.5 flex flex-col gap-3">
-        <Button onClick={() => setOpen(true)}>Open Warning Toast</Button>
-        <ToastComponent {...args} open={open} setOpen={setOpen} />
-      </div>
-    );
-  },
-};
-
-export const Info: Story = {
-  args: {
-    duration: 5000,
-    variant: 'info',
-    title: <span>This is an info toast!</span>,
-  },
-  render: function ToastStory(args) {
-    const [open, setOpen] = useState(false);
-
-    return (
-      <div className="w-87.5 flex flex-col gap-3">
-        <Button onClick={() => setOpen(true)}>Open Info Toast</Button>
-        <ToastComponent {...args} open={open} setOpen={setOpen} />
-      </div>
-    );
+    return <Demo />;
   },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof Toast>;
+
+export const Playground: Story = {};

--- a/lib/components/Tooltip/Tooltip.stories.tsx
+++ b/lib/components/Tooltip/Tooltip.stories.tsx
@@ -1,95 +1,67 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Button } from '@/components/Button/Button';
+import { Button } from '../Button/Button';
 
-import { Tooltip as TooltipComponent } from './Tooltip';
+import { Tooltip } from './Tooltip';
 
-type Story = StoryObj<typeof TooltipComponent>;
-
-const meta: Meta<typeof TooltipComponent> = {
-  title: 'In Review/Tooltip',
-  component: TooltipComponent,
-};
-
-export const Default: Story = {
-  render: () => (
-    <div className="flex items-center justify-center h-50">
-      <TooltipComponent content="This is a tooltip">
-        <Button>Hover me</Button>
-      </TooltipComponent>
-    </div>
-  ),
-};
-
-export const Positions: Story = {
-  render: () => (
-    <div className="flex items-center justify-center gap-8 h-50">
-      <TooltipComponent content="Top tooltip" side="top">
-        <Button>Top</Button>
-      </TooltipComponent>
-
-      <TooltipComponent content="Bottom tooltip" side="bottom">
-        <Button>Bottom</Button>
-      </TooltipComponent>
-
-      <TooltipComponent content="Left tooltip" side="left">
-        <Button>Left</Button>
-      </TooltipComponent>
-
-      <TooltipComponent content="Right tooltip" side="right">
-        <Button>Right</Button>
-      </TooltipComponent>
-    </div>
-  ),
-};
-
-export const CustomColors: Story = {
-  render: () => (
-    <div className="flex items-center justify-center gap-8 h-50">
-      <TooltipComponent
-        content="Danger tooltip"
-        bgClassName="bg-red-500"
-        arrowClassName="fill-red-500"
-        textClassName="text-white"
-      >
-        <Button variant="danger">Red</Button>
-      </TooltipComponent>
-
-      <TooltipComponent
-        content="Success tooltip"
-        bgClassName="bg-green-600"
-        arrowClassName="fill-green-600"
-        textClassName="text-white"
-      >
-        <Button>Green</Button>
-      </TooltipComponent>
-
-      <TooltipComponent
-        content="Info tooltip"
-        bgClassName="bg-blue-500"
-        arrowClassName="fill-blue-500"
-        textClassName="text-white"
-      >
-        <Button variant="secondary">Blue</Button>
-      </TooltipComponent>
-    </div>
-  ),
-};
-
-export const WithReactNodeContent: Story = {
-  render: () => (
-    <div className="flex items-center justify-center h-50">
-      <TooltipComponent
-        content={
-          <span className="font-semibold">
-            Rich <em>content</em> tooltip
-          </span>
-        }
-      >
-        <Button>ReactNode content</Button>
-      </TooltipComponent>
-    </div>
-  ),
+const meta: Meta<typeof Tooltip> = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A tooltip that appears on hover or focus over a trigger element. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    content: {
+      control: { type: 'text' },
+      description: 'Tooltip text or content',
+    },
+    side: {
+      control: { type: 'inline-radio' },
+      options: ['top', 'bottom', 'left', 'right'],
+      description: 'Tooltip position relative to trigger',
+    },
+    sideOffset: {
+      control: { type: 'number' },
+      description: 'Distance from trigger in px',
+    },
+    delayDuration: {
+      control: { type: 'number' },
+      description: 'Delay before showing tooltip in ms',
+    },
+    bgClassName: {
+      control: { type: 'text' },
+      description: 'Background color class for tooltip',
+    },
+    textClassName: {
+      control: { type: 'text' },
+      description: 'Text color class',
+    },
+  },
+  args: {
+    content: 'Click to perform action',
+    side: 'top',
+    sideOffset: 4,
+    delayDuration: 200,
+  },
+  render: (args) => {
+    return (
+      <div className="p-12 flex items-center justify-center">
+        <Tooltip {...args}>
+          <Button>Hover me</Button>
+        </Tooltip>
+      </div>
+    );
+  },
 };
 
 export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Playground: Story = {};

--- a/lib/components/Typography/Typography.stories.tsx
+++ b/lib/components/Typography/Typography.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Typography } from './Typography';
+
+const meta: Meta<typeof Typography> = {
+  title: 'Components/Typography',
+  component: Typography,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A flexible text component with semantic variants and theming. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: [
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'subtitle1',
+        'subtitle2',
+        'subtitle3',
+        'labelLarge',
+        'labelMedium',
+        'labelSmall',
+        'buttonSmall',
+        'body1',
+        'body2',
+        'body3',
+        'tooltip',
+      ],
+      description: 'Visual variant of the text',
+    },
+    component: {
+      control: { type: 'select' },
+      options: [undefined, 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span', 'label'],
+      description: 'Override the rendered HTML element',
+    },
+    children: {
+      control: { type: 'text' },
+      description: 'Text content to display',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: [undefined, 'kubefirst', 'light', 'kubefirst-dark', 'dark'],
+      description: 'Theme override for this instance',
+    },
+  },
+  args: {
+    variant: 'body1',
+    children: 'The quick brown fox jumps over the lazy dog.',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Typography>;
+
+export const Playground: Story = {};

--- a/lib/components/VirtualizedTable/VirtualizedTable.stories.tsx
+++ b/lib/components/VirtualizedTable/VirtualizedTable.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { VirtualizedTable } from './VirtualizedTable';
+import type { ColumnDef } from './VirtualizedTable.types';
+
+type Row = {
+  id: number;
+  name: string;
+  email: string;
+  role: string;
+};
+
+const data: Row[] = Array.from({ length: 50 }, (_, i) => {
+  return {
+    id: i + 1,
+    name: `User ${i + 1}`,
+    email: `user${i + 1}@example.com`,
+    role: i % 3 === 0 ? 'Admin' : 'User',
+  };
+});
+
+const columns: ColumnDef<Row>[] = [
+  { accessorKey: 'id', header: 'ID' },
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'email', header: 'Email' },
+  { accessorKey: 'role', header: 'Role' },
+];
+
+const meta: Meta<typeof VirtualizedTable<Row>> = {
+  title: 'Components/VirtualizedTable',
+  component: VirtualizedTable,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A feature-rich virtualized data table with optional filtering, pagination, and sorting. Use the **Controls** panel below to interact with the props.',
+      },
+    },
+  },
+  argTypes: {
+    isLoading: {
+      control: { type: 'boolean' },
+      description: 'Whether the table is in a loading state',
+    },
+    enableHoverRow: {
+      control: { type: 'boolean' },
+      description: 'Highlight rows on hover',
+    },
+  },
+  args: {
+    id: 'users-table',
+    ariaLabel: 'Users list',
+    columns,
+    data,
+    isLoading: false,
+    enableHoverRow: true,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof VirtualizedTable<Row>>;
+
+export const Playground: Story = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12274,22 +12274,6 @@
         }
       }
     },
-    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",


### PR DESCRIPTION
## What

Adds and updates Storybook stories across the component library, and tidies up Storybook/repo configuration.

- **New stories** for many components (Alert, AlertDialog, Badge, Breadcrumb, Button, ButtonGroup, Checkbox, Counter, DateRangePicker, Drawer, Filter, Input, LineChart, Modal, MultiSelectDropdown, PhoneNumberInput, ProgressBar, Radio, RadioCard, RadioGroup, Select, Spinner, Stepper, Switch, Tabs, Tag, TagSelect, TimePicker, Typography, VirtualizedTable).
- **Updated stories** for existing components (Autocomplete, Card, Command, Datepicker, Divider, DropdownButton, ImageUpload, Loading, PieChart, RadioCardGroup, Range, Sidebar, Slider, Table, TextArea, Toast, Tooltip).
- **Sidebar ordering** (`.storybook/preview.tsx`): adds a dedicated `Components` section right after `Documentation`.
- **.gitignore**: ignore `yarn.lock`, `pnpm-lock.yaml`, and `deno.lock`.

## Why

Improves Storybook coverage and discoverability of the component library, giving each component a browsable, documented example set.

## Notes for reviewers

- 50 files changed; the bulk are `*.stories.tsx` additions/updates.
- No runtime/library source changes — stories and config only.
