### PR TITLE
✨ feat: VirtualizedTable emptyState prop and table-scoped reset filters event

### DIFF
--- a/lib/components/VirtualizedTable/VirtualizedTable.tsx
+++ b/lib/components/VirtualizedTable/VirtualizedTable.tsx
@@ -17,6 +17,7 @@ import { TableProvider } from './contexts';
 import {
   sendCollapseRowEvent,
   sendExpandRowEvent,
+  sendResetFiltersEvent,
   sendToggleRowEvent,
 } from './events';
 
@@ -58,6 +59,7 @@ const VirtualizedTableInner = <TData extends RowData>({
   classNameTable,
   classNameWrapperTable,
   isLoading,
+  emptyState,
   getRowId,
   fetchData,
   queryOptions,
@@ -133,6 +135,7 @@ const VirtualizedTableInner = <TData extends RowData>({
       <section className={cn('w-full min-w-fit', className)}>
         {showFilter && (
           <Filter
+            id={id}
             actions={filterActions}
             filters={filters}
             multiSelectFilter={multiSelectFilter}
@@ -162,7 +165,11 @@ const VirtualizedTableInner = <TData extends RowData>({
               classNameArrows={classNameHeaderArrows}
               classNameActiveArrows={classNameHeaderActiveArrows}
             />
-            <Body isLoading={isLoading} showPagination={showPagination} />
+            <Body
+              isLoading={isLoading}
+              showPagination={showPagination}
+              emptyState={emptyState}
+            />
           </table>
         </WrapperBody>
 
@@ -192,6 +199,7 @@ type VirtualizedTableCompound = (<TData extends RowData>(
     sendExpandRowEvent: (tableId: string, rowId: string) => void;
     sendCollapseRowEvent: (tableId: string, rowId: string) => void;
     sendToggleRowEvent: (tableId: string, rowId: string) => void;
+    sendResetFiltersEvent: (tableId: string) => void;
   };
   displayName?: string;
 };
@@ -206,6 +214,7 @@ VirtualizedTable.Events = {
   sendExpandRowEvent,
   sendCollapseRowEvent,
   sendToggleRowEvent,
+  sendResetFiltersEvent,
 };
 
 export { TruncateText, VirtualizedTable };

--- a/lib/components/VirtualizedTable/VirtualizedTable.types.ts
+++ b/lib/components/VirtualizedTable/VirtualizedTable.types.ts
@@ -196,6 +196,8 @@ export type Props<TData extends RowDataPrimitive> = VariantProps<
     'queryKey' | 'queryFn'
   >;
   isLoading?: boolean;
+  /** Rendered in place of rows when the table has no data (and is not loading). */
+  emptyState?: ReactNode;
   getRowId?: (originalRow: TData, index: number) => string;
   fetchData?: (
     params: Record<string, string | number | string[] | number[] | undefined>,

--- a/lib/components/VirtualizedTable/components/Body/Body.tsx
+++ b/lib/components/VirtualizedTable/components/Body/Body.tsx
@@ -13,6 +13,7 @@ import { BodyProps } from './Body.types';
 export const Body = <TData extends RowData = RowData>({
   isLoading,
   showPagination,
+  emptyState,
 }: BodyProps<TData>) => {
   const {
     table,
@@ -35,6 +36,46 @@ export const Body = <TData extends RowData = RowData>({
   }
 
   const rows = table.getRowModel().rows ?? [];
+
+  if (rows.length === 0 && emptyState) {
+    const colSpan = table.getVisibleLeafColumns().length;
+
+    return (
+      <tbody
+        className={cn(
+          'text-slate-800',
+          'text-sm',
+          'font-normal',
+          'relative',
+          'dark:border-x',
+        )}
+      >
+        <tr
+          className={cn(
+            'border-b',
+            'border-b-gray-200',
+            'dark:border-b-metal-700',
+            'bg-transparent',
+          )}
+          data-empty-row
+        >
+          <td
+            colSpan={colSpan}
+            className={cn(
+              'p-0',
+              'bg-white',
+              'dark:bg-metal-900',
+              'dark:border',
+              'dark:border-metal-700',
+              'rounded-b-lg',
+            )}
+          >
+            <div className="flex items-center justify-center">{emptyState}</div>
+          </td>
+        </tr>
+      </tbody>
+    );
+  }
 
   return (
     <tbody

--- a/lib/components/VirtualizedTable/components/Body/Body.types.ts
+++ b/lib/components/VirtualizedTable/components/Body/Body.types.ts
@@ -1,6 +1,9 @@
+import { ReactNode } from 'react';
+
 import { RowData } from '../../VirtualizedTable.types';
 
 export type BodyProps<_TData extends RowData = RowData> = {
   isLoading?: boolean;
   showPagination?: boolean;
+  emptyState?: ReactNode;
 };

--- a/lib/components/VirtualizedTable/components/Filter/Filter.tsx
+++ b/lib/components/VirtualizedTable/components/Filter/Filter.tsx
@@ -1,17 +1,30 @@
 import debounce from 'lodash/debounce';
-import { ChangeEvent, FC, useCallback, useMemo, useRef } from 'react';
+import {
+  ChangeEvent,
+  FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 
 import { Button } from '@/components/Button/Button';
 import { Filter as FilterPrimitive } from '@/components/Filter/Filter';
+import { resetEvent } from '@/components/Filter/events';
 import { Input } from '@/components/Input/Input';
 import { cn } from '@/utils';
 
 import { useTableContext } from '../../contexts';
+import {
+  VirtualizedTableEvent,
+  VirtualizedTableEventDetail,
+} from '../../events';
 import { FilterConfig } from '../../VirtualizedTable.types';
 
 import { Option, Props } from './Filter.types';
 
 export const Filter: FC<Props> = ({
+  id,
   actions,
   filters,
   multiSelectFilter,
@@ -65,6 +78,36 @@ export const Filter: FC<Props> = ({
       inputRef.current.value = '';
     }
   }, [onChangeTermOfSearch]);
+
+  useEffect(() => {
+    const tableId = Array.isArray(id) ? id.join(',') : String(id);
+    const controller = new AbortController();
+
+    document.addEventListener(
+      VirtualizedTableEvent.RESET_FILTERS,
+      (event) => {
+        const { detail } = event as CustomEvent<VirtualizedTableEventDetail>;
+
+        if (detail.tableId !== tableId) {
+          return;
+        }
+
+        // Scoped: clear this table's search term + reset its page to 0.
+        onChangeTermOfSearch('');
+
+        if (inputRef.current) {
+          inputRef.current.value = '';
+        }
+
+        // Clear all dropdowns (multiselect/date/dateRange/time) and their
+        // provider state via each dropdown's FilterEvent.RESET listener.
+        resetEvent();
+      },
+      { signal: controller.signal },
+    );
+
+    return () => controller.abort();
+  }, [id, onChangeTermOfSearch]);
 
   const handleChangeTermOfSearch = useMemo(
     () =>

--- a/lib/components/VirtualizedTable/components/Filter/Filter.types.ts
+++ b/lib/components/VirtualizedTable/components/Filter/Filter.types.ts
@@ -9,6 +9,7 @@ export type { Option } from '@/components/Filter/Filter.types';
 export type FilterAction = ActionFilterConfig;
 
 export type Props = {
+  id: string | string[] | number | number[];
   filters?: FilterConfig[];
   /** @deprecated Use `filters` instead */
   multiSelectFilter?: MultiSelectFilter[];

--- a/lib/components/VirtualizedTable/contexts/table.provider.tsx
+++ b/lib/components/VirtualizedTable/contexts/table.provider.tsx
@@ -222,26 +222,36 @@ export const TableProvider = <TData extends RowData = RowData>({
 
     const handleExpand = (e: Event) => {
       const { detail } = e as CustomEvent<VirtualizedTableEventDetail>;
+      const { rowId } = detail;
 
-      if (detail.tableId !== tableId) return;
+      if (detail.tableId !== tableId || !rowId) {
+        return;
+      }
 
       handleExpandedChange((prev) => {
-        if (typeof prev === 'boolean') return { [detail.rowId]: true };
+        if (typeof prev === 'boolean') {
+          return { [rowId]: true };
+        }
 
-        return { ...prev, [detail.rowId]: true };
+        return { ...prev, [rowId]: true };
       });
     };
 
     const handleCollapse = (e: Event) => {
       const { detail } = e as CustomEvent<VirtualizedTableEventDetail>;
+      const { rowId } = detail;
 
-      if (detail.tableId !== tableId) return;
+      if (detail.tableId !== tableId || !rowId) {
+        return;
+      }
 
       handleExpandedChange((prev) => {
-        if (typeof prev === 'boolean') return {};
+        if (typeof prev === 'boolean') {
+          return {};
+        }
 
         const next = { ...prev };
-        delete next[detail.rowId];
+        delete next[rowId];
 
         return next;
       });
@@ -249,19 +259,24 @@ export const TableProvider = <TData extends RowData = RowData>({
 
     const handleToggle = (e: Event) => {
       const { detail } = e as CustomEvent<VirtualizedTableEventDetail>;
+      const { rowId } = detail;
 
-      if (detail.tableId !== tableId) return;
+      if (detail.tableId !== tableId || !rowId) {
+        return;
+      }
 
       handleExpandedChange((prev) => {
-        if (typeof prev === 'boolean') return { [detail.rowId]: !prev };
+        if (typeof prev === 'boolean') {
+          return { [rowId]: !prev };
+        }
 
-        const isExpanded = !!prev[detail.rowId];
+        const isExpanded = !!prev[rowId];
         const next = { ...prev };
 
         if (isExpanded) {
-          delete next[detail.rowId];
+          delete next[rowId];
         } else {
-          next[detail.rowId] = true;
+          next[rowId] = true;
         }
 
         return next;

--- a/lib/components/VirtualizedTable/events/index.ts
+++ b/lib/components/VirtualizedTable/events/index.ts
@@ -2,11 +2,12 @@ export enum VirtualizedTableEvent {
   EXPAND_ROW = '@konstructio/VirtualizedTable/event-EXPAND_ROW',
   COLLAPSE_ROW = '@konstructio/VirtualizedTable/event-COLLAPSE_ROW',
   TOGGLE_ROW = '@konstructio/VirtualizedTable/event-TOGGLE_ROW',
+  RESET_FILTERS = '@konstructio/VirtualizedTable/event-RESET_FILTERS',
 }
 
 export type VirtualizedTableEventDetail = {
   tableId: string;
-  rowId: string;
+  rowId?: string;
 };
 
 export const sendExpandRowEvent = (tableId: string, rowId: string) => {
@@ -32,6 +33,15 @@ export const sendToggleRowEvent = (tableId: string, rowId: string) => {
     new CustomEvent<VirtualizedTableEventDetail>(
       VirtualizedTableEvent.TOGGLE_ROW,
       { detail: { tableId, rowId } },
+    ),
+  );
+};
+
+export const sendResetFiltersEvent = (tableId: string) => {
+  document.dispatchEvent(
+    new CustomEvent<VirtualizedTableEventDetail>(
+      VirtualizedTableEvent.RESET_FILTERS,
+      { detail: { tableId } },
     ),
   );
 };

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -55,6 +55,7 @@ export {
   sendExpandRowEvent,
   sendCollapseRowEvent,
   sendToggleRowEvent,
+  sendResetFiltersEvent,
   VirtualizedTableEvent,
 } from './VirtualizedTable/events';
 export type { VirtualizedTableEventDetail } from './VirtualizedTable/events';


### PR DESCRIPTION
## Summary

Adds two related capabilities to `VirtualizedTable` so consumers can render a proper empty state and reset a table's filters programmatically.

### 1. `emptyState` prop
A new optional `emptyState?: ReactNode` prop. When the table has no rows (and is not loading/fetching), it renders the node as a single full-width row that:
- keeps the table's frame — theme-aware borders (`border-gray-200` in light / `dark:border-metal-700` in dark) and rounded bottom corners, matching how normal rows are drawn under `border-collapse` (light) vs `dark:border-separate` (dark);
- has **no hover effect** (the empty row never gets `group/row`).

Backward compatible: when `emptyState` is omitted, the body renders as before (empty `<tbody>`).

### 2. `VirtualizedTable.Events.sendResetFiltersEvent(tableId)`
A new table-scoped event to clear a specific table's filters from anywhere in app code (e.g. a "Reset filters" button inside an empty state):
- clears that table's **search term** + resets its page to 0 (scoped by `tableId`);
- clears the filter **dropdowns** (multiselect / date / dateRange / time) and their provider state via the existing internal `FilterEvent.RESET`.

Implementation details:
- Threads the table `id` into the `Filter` wrapper so the reset listener can scope by `tableId`.
- `VirtualizedTableEventDetail.rowId` is now optional (only the row events use it).
- `sendResetFiltersEvent` is exposed on `VirtualizedTable.Events` and re-exported from the components barrel for parity with the row event helpers.

> Note: the search-term + page reset is table-scoped; the dropdown reset reuses the page-global `FilterEvent.RESET`. On pages with multiple filtered tables, resetting one also clears the others' dropdown UI/state (not their search terms). Fully scoping dropdowns would require threading `tableId` through every dropdown hook.

## Usage

```tsx
<VirtualizedTable
  id="instances-table"
  // ...
  emptyState={
    <NoResults
      onResetFilters={() =>
        VirtualizedTable.Events.sendResetFiltersEvent('instances-table')
      }
    />
  }
/>
```

## Test plan
- [x] `npm run build` passes
- [x] lint / type-check / prettier / tests pass (pre-commit)
- [x] Verified in a consuming app (compute-micro-frontend): empty state renders inside the table frame in both light and dark mode, with no row hover; "Reset filters" clears the search input + dropdowns and re-runs the query.