### PR TITLE
🐛 fix: VirtualizedTable shows skeleton only on initial load, not on background refetch

### DIFF
--- a/lib/components/VirtualizedTable/components/Body/Body.test.tsx
+++ b/lib/components/VirtualizedTable/components/Body/Body.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { ReactNode } from 'react';
+
+import { Body } from './Body';
+
+const { useTableContextMock } = vi.hoisted(() => ({
+  useTableContextMock: vi.fn(),
+}));
+
+vi.mock('../../contexts', async (importActual) => ({
+  ...(await importActual<typeof import('../../contexts')>()),
+  useTableContext: useTableContextMock,
+}));
+
+type ContextOverrides = {
+  tableLoading?: boolean;
+  tableFetching?: boolean;
+  rows?: unknown[];
+};
+
+const buildContext = ({
+  tableLoading = false,
+  tableFetching = false,
+  rows = [],
+}: ContextOverrides) => ({
+  table: {
+    getRowModel: () => ({ rows }),
+    getVisibleLeafColumns: () => [{ id: 'name' }],
+    getAllColumns: () => [{ id: 'name', columnDef: {} }],
+  },
+  pageSize: 3,
+  tableLoading,
+  tableFetching,
+  enableExpandedRow: false,
+  isBorderOnAdjacentCell: false,
+  isExpandColumnVisible: false,
+});
+
+const setup = (
+  overrides: ContextOverrides,
+  props?: { isLoading?: boolean; emptyState?: ReactNode },
+) => {
+  useTableContextMock.mockReturnValue(buildContext(overrides));
+
+  return render(
+    <table>
+      <Body
+        isLoading={props?.isLoading}
+        emptyState={props?.emptyState ?? <span>No results</span>}
+      />
+    </table>,
+  );
+};
+
+describe('VirtualizedTable / Body', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the skeleton (not the empty state) while loading the initial data', () => {
+    setup({ tableLoading: true, rows: [] });
+
+    expect(screen.queryByText('No results')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state when there is no data and it is not loading', () => {
+    setup({ tableLoading: false, rows: [] });
+
+    expect(screen.getByText('No results')).toBeInTheDocument();
+  });
+
+  it('keeps the empty state during a background refetch (isFetching without isLoading)', () => {
+    // Regression guard: a background refetch (refetchInterval / keepPreviousData)
+    // sets isFetching=true but isLoading=false. The body must stay on the empty
+    // state instead of flashing back to the skeleton — otherwise consumers that
+    // suppress fetch-state re-renders never see the empty state settle.
+    setup({ tableLoading: false, tableFetching: true, rows: [] });
+
+    expect(screen.getByText('No results')).toBeInTheDocument();
+  });
+
+  it('renders the skeleton when the external isLoading prop is set', () => {
+    setup({ tableLoading: false, rows: [] }, { isLoading: true });
+
+    expect(screen.queryByText('No results')).not.toBeInTheDocument();
+  });
+
+  it('has no accessibility violations on the empty state', async () => {
+    const { container } = setup({ tableLoading: false, rows: [] });
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/lib/components/VirtualizedTable/components/Body/Body.tsx
+++ b/lib/components/VirtualizedTable/components/Body/Body.tsx
@@ -18,7 +18,7 @@ export const Body = <TData extends RowData = RowData>({
   const {
     table,
     pageSize,
-    tableFetching,
+    tableLoading,
     enableExpandedRow,
     classNameExpandedRow,
     classNameExpandedCell,
@@ -31,7 +31,13 @@ export const Body = <TData extends RowData = RowData>({
     isExpandColumnVisible,
   } = useTableContext<TData>();
 
-  if (isLoading || tableFetching) {
+  // Skeleton only on the initial load (no data yet). `tableLoading`
+  // (queryResult.isLoading) is true only while fetching with no data to show;
+  // background refetches (refetchInterval / keepPreviousData) keep
+  // `tableLoading` false so existing rows stay visible and refresh silently —
+  // and an empty result still falls through to the `emptyState` below instead
+  // of being masked by a transient fetch.
+  if (isLoading || tableLoading) {
     return <Skeleton numberOfRows={pageSize} table={table} />;
   }
 


### PR DESCRIPTION
## Problem

`VirtualizedTable`'s `Body` gated the loading **Skeleton** on `tableFetching` (`queryResult.isFetching`), which is `true` on **any** fetch — including background refetches from `refetchInterval` polling or `placeholderData: keepPreviousData`. Consequences:

1. **Flicker:** every background refetch replaced the current rows with the Skeleton.
2. **Empty state never settles:** consumers that set `notifyOnChangeProps: ['data','error']` to avoid that flicker could get stuck — the render where data settles to `[]` coincided with `isFetching: true`, so the Skeleton showed and `emptyState` never appeared (no further re-render to settle it).

This surfaced in the Compute micro-frontend: searching with no results showed a blank area instead of the "No results" empty state on first load (only appearing after a hard refresh).

## Fix

Gate the Skeleton on **`tableLoading`** (`queryResult.isLoading`) instead of `tableFetching`. `isLoading` is `true` only while fetching with **no data to show** (the genuine initial load); background refetches keep `isLoading` `false`, so:

- Background refetches keep the current rows and refresh **silently** (no flicker).
- An empty result reliably falls through to `emptyState`.
- The external `isLoading` prop still forces the Skeleton (unchanged for static-data consumers).

`tableLoading` was already exposed by the provider alongside `tableFetching`/`isFirstLoad`; `Body` simply used the wrong one.

## Tests

Adds `Body.test.tsx`:
- initial load (`tableLoading`) → Skeleton (no empty state)
- no data + not loading → `emptyState`
- **regression guard:** background refetch (`isFetching` true, `isLoading` false) → `emptyState` stays (no Skeleton)
- external `isLoading` prop → Skeleton
- jest-axe a11y on the empty state

`8/8` VirtualizedTable tests pass, lint clean.

## Notes for consumers

Consumers that added `notifyOnChangeProps: ['data','error']` purely to suppress the polling flicker can drop it after upgrading (the Body no longer flashes on background refetch).