### PR TITLE
🐛 fix: prevent actions menu closing on diagonal hover

### DIFF
--- a/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
@@ -1,0 +1,100 @@
+import { CellContext } from '@tanstack/react-table';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Actions } from './Actions';
+import { Action, Props } from './Actions.types';
+
+type Row = { id: number; name: string };
+
+const row: Row = { id: 1, name: 'Pikachu' };
+
+const buildProps = (actions: Action<Row>[] | undefined): Props<Row> => {
+  return {
+    ...({ row: { original: row } } as unknown as CellContext<Row, unknown>),
+    actions: actions as Action<Row>[],
+  };
+};
+
+describe('Actions', () => {
+  it('should render the trigger and the action labels', () => {
+    render(
+      <Actions
+        {...buildProps([
+          { label: 'Edit', onClick: vi.fn() },
+          { label: 'Delete', onClick: vi.fn() },
+        ])}
+      />,
+    );
+
+    expect(screen.getByText('Show Actions')).toBeInTheDocument();
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('should render nothing when no actions are provided', () => {
+    const { container } = render(<Actions {...buildProps(undefined)} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should call the action onClick with the row data when an option is clicked', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+
+    render(<Actions {...buildProps([{ label: 'Edit', onClick: onEdit }])} />);
+
+    await user.click(screen.getByText('Edit'));
+
+    expect(onEdit).toHaveBeenCalledWith(row);
+  });
+
+  it('should open the panel downward by default', () => {
+    const { container } = render(
+      <Actions {...buildProps([{ label: 'Edit', onClick: vi.fn() }])} />,
+    );
+
+    const panel = container.querySelector('.absolute');
+
+    expect(panel?.className).toContain('top-full');
+    expect(panel?.className).not.toContain('bottom-full');
+  });
+
+  it('should open the panel upward when there is not enough space below the clipping container', () => {
+    const { container } = render(
+      <div data-testid="clip">
+        <Actions
+          {...buildProps([
+            { label: 'Edit', onClick: vi.fn() },
+            { label: 'Delete', onClick: vi.fn() },
+          ])}
+        />
+      </div>,
+    );
+
+    const clip = screen.getByTestId('clip');
+    const root = container.querySelector('.group') as HTMLElement;
+    const panel = container.querySelector('.absolute') as HTMLElement;
+
+    clip.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 100 }) as DOMRect;
+    root.getBoundingClientRect = () =>
+      ({ top: 90, bottom: 98 }) as DOMRect;
+
+    const getComputedStyleSpy = vi
+      .spyOn(window, 'getComputedStyle')
+      .mockImplementation(
+        (element: Element) =>
+          ({
+            overflowY: element === clip ? 'hidden' : 'visible',
+          }) as CSSStyleDeclaration,
+      );
+
+    fireEvent.mouseEnter(root);
+
+    getComputedStyleSpy.mockRestore();
+
+    expect(panel.className).toContain('bottom-full');
+    expect(panel.className).not.toContain('top-full');
+  });
+});

--- a/lib/components/VirtualizedTable/components/Actions/Actions.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.tsx
@@ -1,4 +1,5 @@
 import { EllipsisVertical } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
 
 import { Button } from '@/components/Button/Button';
 import { cn } from '@/utils';
@@ -6,6 +7,9 @@ import { cn } from '@/utils';
 import { RowData } from '../../VirtualizedTable.types';
 
 import { Props } from './Actions.types';
+
+const ITEM_HEIGHT = 36;
+const LIST_PADDING = 16;
 
 export const Actions = <TData extends RowData>({
   actions,
@@ -16,12 +20,52 @@ export const Actions = <TData extends RowData>({
   wrapperContentActionsClassName,
   ...delegated
 }: Props<TData>) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [openUp, setOpenUp] = useState(false);
+
+  const updateDirection = useCallback(() => {
+    const root = rootRef.current;
+
+    if (!root || !actions) {
+      return;
+    }
+
+    const triggerRect = root.getBoundingClientRect();
+    const menuHeight = actions.length * ITEM_HEIGHT + LIST_PADDING;
+
+    let clipTop = 0;
+    let clipBottom = window.innerHeight;
+    let node = root.parentElement;
+
+    while (node) {
+      const { overflowY } = window.getComputedStyle(node);
+
+      if (['auto', 'scroll', 'hidden'].includes(overflowY)) {
+        const rect = node.getBoundingClientRect();
+        clipTop = rect.top;
+        clipBottom = rect.bottom;
+        break;
+      }
+
+      node = node.parentElement;
+    }
+
+    const spaceBelow = clipBottom - triggerRect.bottom;
+    const spaceAbove = triggerRect.top - clipTop;
+
+    setOpenUp(spaceBelow < menuHeight && spaceAbove > spaceBelow);
+  }, [actions]);
+
   if (!actions) {
     return null;
   }
 
   return (
-    <div className={cn('relative group', wrapperClassName)}>
+    <div
+      ref={rootRef}
+      className={cn('relative group', wrapperClassName)}
+      onMouseEnter={updateDirection}
+    >
       <Button
         variant="link"
         shape="circle"
@@ -47,26 +91,31 @@ export const Actions = <TData extends RowData>({
       <div
         className={cn(
           'absolute',
-          'top-full',
           'right-0',
           'w-53.75',
-          'hidden',
-          'group-hover:block',
           'z-10',
+          openUp ? 'bottom-full' : 'top-full',
+          openUp ? 'pb-1' : 'pt-1',
+          'invisible',
+          'opacity-0',
+          'transition-[opacity,visibility]',
+          'duration-150',
+          'delay-150',
+          'group-hover:visible',
+          'group-hover:opacity-100',
+          'group-hover:delay-0',
+          'group-hover:duration-75',
           wrapperActionsClassName,
         )}
       >
         <div
           className={cn(
             'bg-white',
-            'mt-0.5',
             'py-2',
             'rounded-lg',
             'shadow-lg',
             'border',
             'border-zinc-100',
-            'animate-in',
-            'fade-in-0',
             'dark:bg-metal-800',
             'dark:border-metal-700',
             wrapperContentActionsClassName,


### PR DESCRIPTION
The row actions (kebab) menu closed when moving the cursor diagonally toward the options. The gap between the trigger and the panel used a margin that collapsed outside the hoverable area, and the menu toggled via display with no grace period.

- Replace the margin gap with padding on the toggled wrapper so the trigger, bridge and panel form a continuous hover region.
- Toggle via visibility/opacity with a 200ms close delay: opens instantly on hover, waits before closing so diagonal moves re-enter.
- Add a RowActions example under In Review/Table for review.

