### PR TITLE
🎨 style: fix prettier formatting in Actions test

### DIFF
--- a/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
@@ -76,10 +76,8 @@ describe('Actions', () => {
     const root = container.querySelector('.group') as HTMLElement;
     const panel = container.querySelector('.absolute') as HTMLElement;
 
-    clip.getBoundingClientRect = () =>
-      ({ top: 0, bottom: 100 }) as DOMRect;
-    root.getBoundingClientRect = () =>
-      ({ top: 90, bottom: 98 }) as DOMRect;
+    clip.getBoundingClientRect = () => ({ top: 0, bottom: 100 }) as DOMRect;
+    root.getBoundingClientRect = () => ({ top: 90, bottom: 98 }) as DOMRect;
 
     const getComputedStyleSpy = vi
       .spyOn(window, 'getComputedStyle')


### PR DESCRIPTION
## Summary
Fixes the prettier formatting error that broke the `release` workflow on `main` (run [28806525916](https://github.com/konstructio/konstruct-ui/actions/runs/28806525916)).

`npm run check:prettier` was failing on `lib/components/VirtualizedTable/components/Actions/Actions.test.tsx` — two `getBoundingClientRect` mock arrow functions were wrapped onto a second line when prettier expects them on a single line.

## Changes
- Ran `prettier --write` on the failing file (formatting only, no logic changes).

## Verification
- `npm run check:prettier` passes.
- All 460 tests pass.