### PR TITLE
🐛 fix: keep loading Badge mounted when its spinner animation ends

### DIFF
--- a/lib/components/Badge/Badge.test.tsx
+++ b/lib/components/Badge/Badge.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
@@ -65,6 +65,18 @@ describe('Badge', () => {
     const badge = await getBadge();
 
     expect(badge).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('should stay mounted when the loading spinner animation ends', async () => {
+    const { getBadge, component } = setup({ loading: true });
+
+    const badge = await getBadge();
+    const spinner = component.querySelector('svg');
+
+    // animationend bubbles; only the badge's own exit animation may remove it.
+    fireEvent.animationEnd(spinner!);
+
+    expect(badge).toBeInTheDocument();
   });
 
   it('should show the badge label', async () => {

--- a/lib/components/Badge/Badge.tsx
+++ b/lib/components/Badge/Badge.tsx
@@ -65,19 +65,29 @@ export const Badge: FC<Props> = ({
   );
 
   useEffect(() => {
-    const controller = new AbortController();
+    if (isVisible !== 'hidden') {
+      return;
+    }
 
-    badgeRef.current?.addEventListener(
+    const controller = new AbortController();
+    const badge = badgeRef.current;
+
+    badge?.addEventListener(
       'animationend',
-      () => {
-        badgeRef.current?.style.setProperty('display', 'none');
-        badgeRef.current?.remove();
+      (event) => {
+        // Animation events bubble; only the badge's own exit animation may remove it.
+        if (event.target !== badge) {
+          return;
+        }
+
+        badge.style.setProperty('display', 'none');
+        badge.remove();
       },
       { signal: controller.signal },
     );
 
     return () => controller.abort();
-  }, []);
+  }, [isVisible]);
 
   return (
     <span


### PR DESCRIPTION
## Problem

A `<Badge loading />` never renders — the status cell stays empty. Badges with an icon (non-loading) render fine.

## Cause

The `useEffect` registers an `animationend` listener that sets `display: none` and calls `.remove()` on the badge. It was registered **unconditionally**, and animation events **bubble**. In loading mode the spinner child (`LoaderIcon` with `animate-spin`) runs an animation; its `animationend` events bubble up to the badge's listener and remove the badge.

## Fix

- Register the listener only while the badge is in the `hidden` (exiting) state.
- Ignore events whose `target` is not the badge element itself, so a child's animation can never remove it.

## Test

Adds a regression test that fires `animationend` from the loading spinner and asserts the badge stays mounted. It fails on the previous code and passes with the fix. Full Badge suite green.