### PR TITLE
👷 ci: add lint, types and coverage gates to PR workflow

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -1,15 +1,20 @@
-name: Run Tests on Pull Request
+name: Storybook Build Check
 
 on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'lib/**'
+      - '.storybook/**'
+      - 'package.json'
+      - 'package-lock.json'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  test:
+  build-storybook:
     runs-on: self-hosted
 
     steps:
@@ -24,14 +29,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Type check
-        run: npm run check:types
-
-      - name: Prettier check
-        run: npm run check:prettier
-
-      - name: Run tests with coverage
-        run: npm run test
+      - name: Build Storybook
+        run: npm run build:storybook

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,12 @@ export default defineConfig({
         'lib/styles.ts',
         'lib/vite-env.d.ts',
       ],
+      thresholds: {
+        statements: 63,
+        branches: 56,
+        functions: 60,
+        lines: 64,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

Second PR of the audit series, stacked on #670 (its coverage excludes feed the threshold values here). Until now, PR CI ran only `vitest run` — lint, type errors and formatting were caught only by the local (bypassable) husky hook.

## Changes

- **tests.yml**: adds `Lint`, `Type check` and `Prettier check` steps, and switches the test step to `npm run test` (vitest with coverage) — the exact mirror of the pre-commit hook, now enforced server-side. The `ci` script was deliberately left untouched: the release workflow depends on its current semantics.
- **Coverage thresholds** in vitest.config.ts as a regression ratchet, set 1–2 points below the measured post-exclusion values (64.95% stmts / 58.31% branch / 61.66% funcs / 65.57% lines → floors 63/56/60/64). These apply to local `npm run test` and the pre-commit hook too.
- **storybook-check.yml**: new workflow that builds Storybook on PRs touching `lib/**`, `.storybook/**` or the package manifests. Today a broken Storybook build is only discovered at deploy time (post-publish). Note: not intended as a required check — path-filtered runs show as skipped.

## Testing
- `npx vitest run --coverage` passes with the new thresholds.
- Full `npm run ci` green locally.