### PR TITLE
♿️ fix: trap focus in Modal and Drawer and fix menu semantics

### DIFF
--- a/lib/components/Autocomplete/components/List/List.tsx
+++ b/lib/components/Autocomplete/components/List/List.tsx
@@ -5,7 +5,6 @@ import { useNavigationUlList } from '../../hooks';
 
 import { Props } from './List.types';
 import {
-  buttonVariants,
   emptyListVariants,
   listItemVariants,
   listVariants,
@@ -44,17 +43,15 @@ export const List: FC<Props> = ({
         <li
           key={value}
           role="option"
+          aria-selected={false}
           tabIndex={0}
-          className={cn(listItemVariants())}
+          className={cn(
+            listItemVariants(),
+            'cursor-pointer px-3 py-1.5 w-full text-left',
+          )}
+          onClick={() => onClick(value)}
         >
-          <button
-            type="button"
-            role="button"
-            className={cn(buttonVariants())}
-            onClick={() => onClick(value)}
-          >
-            {value}
-          </button>
+          {value}
         </li>
       ))}
     </ul>

--- a/lib/components/Autocomplete/components/List/List.variants.ts
+++ b/lib/components/Autocomplete/components/List/List.variants.ts
@@ -22,16 +22,3 @@ export const listItemVariants = cva([
   'focus:bg-aurora-50',
   'hover:bg-aurora-50',
 ]);
-
-export const buttonVariants = cva([
-  'cursor-pointer',
-  'focus-visible:outline-none',
-  'px-3',
-  'py-1.5',
-  'w-full',
-  'text-left',
-  'focus:bg-aurora-50',
-  'hover:bg-aurora-50',
-  'kubefirst:focus:bg-purple-100',
-  'kubefirst:hover:bg-purple-100',
-]);

--- a/lib/components/Autocomplete/hooks/useNavigationList.ts
+++ b/lib/components/Autocomplete/hooks/useNavigationList.ts
@@ -72,9 +72,9 @@ export const useNavigationUlList = ({
             break;
           }
 
-          case 'Enter': {
-            const button = items[index.current].querySelector('button');
-            button?.click();
+          case 'Enter':
+          case ' ': {
+            items[index.current].click();
 
             break;
           }

--- a/lib/components/Drawer/Drawer.test.tsx
+++ b/lib/components/Drawer/Drawer.test.tsx
@@ -205,4 +205,45 @@ describe('Drawer', () => {
 
     expect(resizeHandle).toBeInTheDocument();
   });
+
+  it('should move focus into the drawer when it opens', async () => {
+    const { user, findButton, findCloseButton } = setup();
+
+    await user.click(await findButton());
+
+    const closeButton = await findCloseButton();
+
+    await waitFor(() => {
+      expect(closeButton).toHaveFocus();
+    });
+  });
+
+  it('should keep focus inside the drawer when tabbing', async () => {
+    const { user, findButton, findCloseButton } = setup();
+
+    await user.click(await findButton());
+
+    const closeButton = await findCloseButton();
+
+    await waitFor(() => {
+      expect(closeButton).toHaveFocus();
+    });
+
+    await user.tab();
+
+    expect(closeButton).toHaveFocus();
+  });
+
+  it('should restore focus to the trigger when the drawer closes', async () => {
+    const { user, findButton, findCloseButton } = setup();
+
+    const trigger = await findButton();
+
+    await user.click(trigger);
+    await user.click(await findCloseButton());
+
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
 });

--- a/lib/components/Drawer/Drawer.tsx
+++ b/lib/components/Drawer/Drawer.tsx
@@ -3,6 +3,7 @@ import { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { FC, useId, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { X as Close } from 'react-feather';
+import FocusLock from 'react-focus-lock';
 import { RemoveScroll } from 'react-remove-scroll';
 
 import { cn } from '@/utils';
@@ -123,54 +124,56 @@ const Drawer: FC<Props> & {
           />
 
           {/* Drawer panel */}
-          <div
-            className={cn(
-              drawerVariants({ position }),
-              translateClass,
-              classNames?.panel,
-              className,
-            )}
-            style={{ width: canResize ? width : defaultWidth }}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby={headerId}
-          >
-            {/* Resize handle */}
-            {canResize && (
-              <button
-                type="button"
-                aria-label="Resize drawer"
-                className={cn(
-                  resizeHandleVariants({ position }),
-                  classNames?.resizeHandle,
-                )}
-                onMouseDown={handleMouseDown}
-                onKeyDown={handleKeyDown}
-              />
-            )}
-
-            {/* Close button */}
-            {showCloseButton && (
-              <button
-                className={cn(buttonCloseVariants(), classNames?.closeButton)}
-                onClick={onClose}
-                type="button"
-              >
-                <Close size={20} />
-                <VisuallyHidden>Dismiss drawer</VisuallyHidden>
-              </button>
-            )}
-
-            {/* Content */}
+          <FocusLock returnFocus className="contents">
             <div
               className={cn(
-                'flex flex-1 flex-col h-full overflow-hidden',
-                classNames?.content,
+                drawerVariants({ position }),
+                translateClass,
+                classNames?.panel,
+                className,
               )}
+              style={{ width: canResize ? width : defaultWidth }}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={headerId}
             >
-              {children}
+              {/* Resize handle */}
+              {canResize && (
+                <button
+                  type="button"
+                  aria-label="Resize drawer"
+                  className={cn(
+                    resizeHandleVariants({ position }),
+                    classNames?.resizeHandle,
+                  )}
+                  onMouseDown={handleMouseDown}
+                  onKeyDown={handleKeyDown}
+                />
+              )}
+
+              {/* Close button */}
+              {showCloseButton && (
+                <button
+                  className={cn(buttonCloseVariants(), classNames?.closeButton)}
+                  onClick={onClose}
+                  type="button"
+                >
+                  <Close size={20} />
+                  <VisuallyHidden>Dismiss drawer</VisuallyHidden>
+                </button>
+              )}
+
+              {/* Content */}
+              <div
+                className={cn(
+                  'flex flex-1 flex-col h-full overflow-hidden',
+                  classNames?.content,
+                )}
+              >
+                {children}
+              </div>
             </div>
-          </div>
+          </FocusLock>
         </div>
       </RemoveScroll>
     </DrawerContext.Provider>

--- a/lib/components/DropdownButton/DropdownButton.test.tsx
+++ b/lib/components/DropdownButton/DropdownButton.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { DropdownButton } from './DropdownButton';
+
+describe('DropdownButton', () => {
+  const setup = () => {
+    const onPdf = vi.fn();
+    const onCsv = vi.fn();
+
+    const { container: component } = render(
+      <DropdownButton
+        label="Download as"
+        options={[
+          { label: 'PDF', onClick: onPdf },
+          { label: 'CSV', onClick: onCsv },
+        ]}
+      />,
+    );
+
+    const user = userEvent.setup();
+    const getTrigger = () => {
+      return screen.getByRole('button', { name: /download as/i });
+    };
+
+    return { component, user, onPdf, onCsv, getTrigger };
+  };
+
+  it('should render the trigger with menu semantics', () => {
+    const { getTrigger } = setup();
+
+    expect(getTrigger()).toHaveAttribute('aria-haspopup', 'menu');
+    expect(getTrigger()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('should open the menu and fire the option callback once', async () => {
+    const { user, getTrigger, onPdf } = setup();
+
+    await user.click(getTrigger());
+    await user.click(await screen.findByRole('menuitem', { name: /pdf/i }));
+
+    expect(onPdf).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('should support keyboard navigation', async () => {
+    const { user, getTrigger, onCsv } = setup();
+
+    getTrigger().focus();
+    await user.keyboard('{Enter}');
+    await screen.findByRole('menu');
+    await user.keyboard('{ArrowDown}{Enter}');
+
+    expect(onCsv).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close the menu on Escape', async () => {
+    const { user, getTrigger } = setup();
+
+    await user.click(getTrigger());
+    await screen.findByRole('menu');
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it("shouldn't have accessibility violations with the menu open", async () => {
+    const { component, user, getTrigger } = setup();
+
+    await user.click(getTrigger());
+    await screen.findByRole('menu');
+
+    const results = await axe(component);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/DropdownButton/DropdownButton.tsx
+++ b/lib/components/DropdownButton/DropdownButton.tsx
@@ -1,123 +1,78 @@
-import { FC, useCallback, useEffect, useRef, useState } from 'react';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { FC } from 'react';
 import { ChevronDown } from 'react-feather';
 
-import { useClickOutside } from '@/hooks';
 import { cn } from '@/utils';
 
 import { Button } from '../Button/Button';
 
-import { Props, Option } from './DropdownButton.types';
+import { Props } from './DropdownButton.types';
 
 /**
  * A button with an attached dropdown menu for selecting actions.
- * Closes automatically on outside click, Escape key, or tab visibility change.
+ * Built on Radix DropdownMenu: closes on outside click or Escape, and
+ * supports full keyboard navigation.
  *
  * @example
  * ```tsx
  * <DropdownButton
+ *   label="Download Invoice as"
  *   options={[
- *     { label: 'Download PDF', onClick: handlePdf },
- *     { label: 'Download CSV', onClick: handleCsv },
+ *     { label: 'PDF', onClick: () => downloadPdf() },
+ *     { label: 'CSV', onClick: () => downloadCsv() },
  *   ]}
- *   buttonClassName="w-64"
  * />
  * ```
- *
- * @see {@link https://konstructio.github.io/konstruct-ui/?path=/docs/components-dropdownbutton--docs Storybook}
  */
 export const DropdownButton: FC<Props> = ({
   buttonClassName,
   className,
   itemClassName,
+  label = 'Download Invoice as',
   listClassName,
   options,
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const buttonRef = useRef(null);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  const toggleDropdown = useCallback(() => setIsOpen((prev) => !prev), []);
-  const handleOptionClick = useCallback((onClick?: Option['onClick']) => {
-    setIsOpen(false);
-    onClick?.();
-  }, []);
-
-  const handleClickOutside = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-
-  useClickOutside(wrapperRef, handleClickOutside);
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const handleKeyboard = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyboard, {
-      signal: controller.signal,
-    });
-
-    document.addEventListener(
-      'visibilitychange',
-      () => {
-        if (document.hidden) {
-          setIsOpen(false);
-        }
-      },
-      {
-        signal: controller.signal,
-      },
-    );
-
-    return () => {
-      controller.abort();
-    };
-  }, []);
-
   return (
-    <div ref={wrapperRef} className={cn('relative w-full', className)}>
-      <Button
-        ref={buttonRef}
-        className={cn(
-          'flex gap-2 items-center justify-between w-full',
-          buttonClassName,
-        )}
-        onClick={toggleDropdown}
-      >
-        Download Invoice as
-        <ChevronDown
-          className={cn({
-            'transform rotate-180': isOpen,
-            'transition-transform duration-200': true,
-          })}
-        />
-      </Button>
+    <DropdownMenu.Root modal={false}>
+      <div className={cn('relative w-full', className)}>
+        <DropdownMenu.Trigger asChild>
+          <Button
+            className={cn(
+              'group flex gap-2 items-center justify-between w-full',
+              buttonClassName,
+            )}
+          >
+            {label}
+            <ChevronDown className="transition-transform duration-200 group-data-[state=open]:rotate-180" />
+          </Button>
+        </DropdownMenu.Trigger>
 
-      {isOpen && (
-        <ul
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={4}
+          loop
           className={cn(
-            'absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded shadow-xs animate-in fade-in-0 py-2',
+            'z-10 bg-white border border-gray-200 rounded shadow-xs animate-in fade-in-0 py-2',
             listClassName,
           )}
+          style={{ width: 'var(--radix-dropdown-menu-trigger-width)' }}
         >
           {options.map((option, index) => (
-            <li
+            <DropdownMenu.Item
               key={index}
               className={cn(
-                'hover:bg-gray-50 px-6 py-1.5 hover:cursor-pointer',
+                'hover:bg-gray-50 focus:bg-gray-50 outline-none px-6 py-1.5 hover:cursor-pointer',
                 itemClassName,
               )}
-              onClick={() => handleOptionClick(option.onClick)}
+              onSelect={() => {
+                option.onClick?.();
+              }}
             >
               {option.label}
-            </li>
+            </DropdownMenu.Item>
           ))}
-        </ul>
-      )}
-    </div>
+        </DropdownMenu.Content>
+      </div>
+    </DropdownMenu.Root>
   );
 };

--- a/lib/components/DropdownButton/DropdownButton.types.ts
+++ b/lib/components/DropdownButton/DropdownButton.types.ts
@@ -31,6 +31,8 @@ export type Props = {
   className?: string;
   /** Additional CSS classes for each dropdown item */
   itemClassName?: string;
+  /** Content of the trigger button */
+  label?: string | ReactNode;
   /** Additional CSS classes for the dropdown list */
   listClassName?: string;
   /** Array of options to display in the dropdown */

--- a/lib/components/Loading/Loading.test.tsx
+++ b/lib/components/Loading/Loading.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { Loading } from './Loading';
+
+describe('Loading', () => {
+  it('should expose a status role with an accessible name', () => {
+    render(<Loading />);
+
+    expect(screen.getByRole('status')).toHaveAccessibleName('Loading');
+  });
+
+  it('should allow overriding the accessible name', () => {
+    render(<Loading aria-label="Fetching results" />);
+
+    expect(screen.getByRole('status')).toHaveAccessibleName('Fetching results');
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = render(<Loading />);
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/Loading/Loading.tsx
+++ b/lib/components/Loading/Loading.tsx
@@ -29,6 +29,8 @@ import { loadingVariants } from './Loading.variants';
 const Loading: FC<Props> = ({ className, theme, ...delegated }) => (
   <LoaderCircle
     data-theme={theme}
+    role="status"
+    aria-label="Loading"
     className={cn(
       loadingVariants({
         className,

--- a/lib/components/Modal/Modal.test.tsx
+++ b/lib/components/Modal/Modal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { useState } from 'react';
@@ -146,5 +146,46 @@ describe('Modal', () => {
     const modal = await screen.findByRole('dialog');
 
     expect(themeContainer).toContainElement(modal);
+  });
+
+  it('should move focus into the modal when it opens', async () => {
+    const { user, getButton, getCloseButton } = setup();
+
+    await user.click(await getButton());
+
+    const closeButton = await getCloseButton();
+
+    await waitFor(() => {
+      expect(closeButton).toHaveFocus();
+    });
+  });
+
+  it('should keep focus inside the modal when tabbing', async () => {
+    const { user, getButton, getCloseButton } = setup();
+
+    await user.click(await getButton());
+
+    const closeButton = await getCloseButton();
+
+    await waitFor(() => {
+      expect(closeButton).toHaveFocus();
+    });
+
+    await user.tab();
+
+    expect(closeButton).toHaveFocus();
+  });
+
+  it('should restore focus to the trigger when the modal closes', async () => {
+    const { user, getButton, getCloseButton } = setup();
+
+    const trigger = await getButton();
+
+    await user.click(trigger);
+    await user.click(await getCloseButton());
+
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
   });
 });

--- a/lib/components/Modal/components/Wrapper/Wrapper.tsx
+++ b/lib/components/Modal/components/Wrapper/Wrapper.tsx
@@ -2,6 +2,7 @@ import { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { motion } from 'motion/react';
 import { Children, FC, isValidElement } from 'react';
 import { X as Close } from 'react-feather';
+import FocusLock from 'react-focus-lock';
 import { RemoveScroll } from 'react-remove-scroll';
 
 import { Modal } from '@/components/Modal/Modal';
@@ -56,37 +57,39 @@ export const Wrapper: FC<Props> = ({
           role="presentation"
         />
 
-        <motion.div
-          className={cn(
-            modalVariants({
-              className,
-            }),
-          )}
-          role="dialog"
-          aria-modal="true"
-          layout="size"
-          transition={transition ?? { duration: 0.25, ease: 'easeInOut' }}
-        >
-          {header}
+        <FocusLock returnFocus className="contents">
+          <motion.div
+            className={cn(
+              modalVariants({
+                className,
+              }),
+            )}
+            role="dialog"
+            aria-modal="true"
+            layout="size"
+            transition={transition ?? { duration: 0.25, ease: 'easeInOut' }}
+          >
+            {header}
 
-          {showCloseButton && (
-            <button
-              className={cn(
-                buttonCloseVariants({
-                  className: buttonCloseClassName,
-                }),
-              )}
-              onClick={onClose}
-            >
-              <Close />
-              <VisuallyHidden>Dismiss modal</VisuallyHidden>
-            </button>
-          )}
+            {showCloseButton && (
+              <button
+                className={cn(
+                  buttonCloseVariants({
+                    className: buttonCloseClassName,
+                  }),
+                )}
+                onClick={onClose}
+              >
+                <Close />
+                <VisuallyHidden>Dismiss modal</VisuallyHidden>
+              </button>
+            )}
 
-          {body ?? others}
+            {body ?? others}
 
-          {footer}
-        </motion.div>
+            {footer}
+          </motion.div>
+        </FocusLock>
       </div>
     </RemoveScroll>
   );

--- a/lib/components/ProgressBar/ProgressBar.test.tsx
+++ b/lib/components/ProgressBar/ProgressBar.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { ProgressBar } from './ProgressBar';
+
+describe('ProgressBar', () => {
+  it('should expose progressbar semantics with the current value', () => {
+    render(<ProgressBar percent={40} ariaLabel="Storage usage" />);
+
+    const progressbar = screen.getByRole('progressbar');
+
+    expect(progressbar).toHaveAccessibleName('Storage usage');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '40');
+    expect(progressbar).toHaveAttribute('aria-valuemin', '0');
+    expect(progressbar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('should clamp values above 100', () => {
+    render(<ProgressBar percent={150} />);
+
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '100',
+    );
+  });
+
+  it('should clamp negative values to 0', () => {
+    render(<ProgressBar percent={-20} />);
+
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '0',
+    );
+  });
+
+  it('should announce the status as hidden text', () => {
+    render(<ProgressBar percent={80} status="warning" />);
+
+    expect(screen.getByRole('progressbar')).toHaveTextContent('warning');
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = render(
+      <ProgressBar percent={40} ariaLabel="Storage usage" />,
+    );
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/ProgressBar/ProgressBar.tsx
+++ b/lib/components/ProgressBar/ProgressBar.tsx
@@ -1,3 +1,4 @@
+import { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import type { FC } from 'react';
 
 import { cn } from '@/utils';
@@ -9,6 +10,7 @@ import {
 } from './ProgressBar.variants';
 
 export const ProgressBar: FC<Props> = ({
+  ariaLabel,
   className,
   fillClassName,
   leftContent,
@@ -39,7 +41,14 @@ export const ProgressBar: FC<Props> = ({
         </div>
       )}
 
-      <div className={progressBarTrackVariants({ className: trackClassName })}>
+      <div
+        className={progressBarTrackVariants({ className: trackClassName })}
+        role="progressbar"
+        aria-label={ariaLabel}
+        aria-valuenow={clampedPercent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
         <div
           className={progressBarFillVariants({
             status: fillClassName ? null : status,
@@ -47,6 +56,7 @@ export const ProgressBar: FC<Props> = ({
           })}
           style={{ width: `${clampedPercent}%` }}
         />
+        {status && <VisuallyHidden>{status}</VisuallyHidden>}
       </div>
     </div>
   );

--- a/lib/components/ProgressBar/ProgressBar.types.ts
+++ b/lib/components/ProgressBar/ProgressBar.types.ts
@@ -7,6 +7,8 @@ import { Theme } from '@/domain/theme';
 import { progressBarFillVariants } from './ProgressBar.variants';
 
 export interface Props extends VariantProps<typeof progressBarFillVariants> {
+  /** Accessible name announced for the progress bar */
+  ariaLabel?: string;
   /** Additional CSS classes for the outer wrapper */
   className?: string;
   /** Custom CSS class for the progress bar fill (e.g., "bg-purple-500") */

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-alert-dialog": "^1.1.20",
         "@radix-ui/react-checkbox": "^1.3.8",
         "@radix-ui/react-dialog": "^1.1.20",
+        "@radix-ui/react-dropdown-menu": "^2.1.22",
         "@radix-ui/react-popover": "^1.1.20",
         "@radix-ui/react-slider": "^1.4.4",
         "@radix-ui/react-slot": "^1.3.0",
@@ -2713,6 +2714,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
@@ -2767,6 +2797,46 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.20",
     "@radix-ui/react-checkbox": "^1.3.8",
     "@radix-ui/react-dialog": "^1.1.20",
+    "@radix-ui/react-dropdown-menu": "^2.1.22",
     "@radix-ui/react-popover": "^1.1.20",
     "@radix-ui/react-slider": "^1.4.4",
     "@radix-ui/react-slot": "^1.3.0",


### PR DESCRIPTION
## Summary

Third PR of the audit series (stacked on #671). Fixes the accessibility issues found in the audit, with tests for each.

## Changes

### Focus management
- **Modal** and **Drawer** panels are now wrapped in `FocusLock` (`react-focus-lock` was already a dependency, previously unused): focus moves into the dialog on open, Tab/Shift+Tab are trapped inside, and focus returns to the trigger on close. The wrapper uses `className="contents"` so it doesn't affect grid/positioned layout. `useModal`'s manual `closeBtnRef` restore was left untouched — it isn't wired into the library's own render path and removing it could affect consumers using the hook directly.

### DropdownButton rewritten on Radix DropdownMenu (new dep: `@radix-ui/react-dropdown-menu`)
The previous hand-rolled menu was unusable by keyboard or screen reader (`<li onClick>` without role/tabIndex/key handlers, trigger without `aria-haspopup`/`aria-expanded`). Radix provides roving focus, typeahead, ARIA wiring and Escape/outside-click for free. Public props are unchanged; the hardcoded "Download Invoice as" trigger text is now a `label` prop that defaults to the old string (flagged for removal later). Content renders without a Portal so `listClassName` consumers keep the same DOM position; width matches the trigger via Radix's CSS var.

### Semantics
- **Loading**: `role="status"` + `aria-label="Loading"` (overridable via delegated props) — previously invisible to assistive tech.
- **ProgressBar**: `role="progressbar"` with `aria-valuenow/min/max` (clamped), optional `ariaLabel` prop, and the `status` announced as visually-hidden text instead of color-only.
- **Autocomplete**: removed the invalid `button` nested inside `role="option"`; the option itself is now the single interactive element, and keyboard Enter/Space activates it via the navigation hook.

## Testing
- New: focus-trap tests for Modal and Drawer (focus-in, Tab trap, restore), DropdownButton (menu semantics, mouse + keyboard selection, Escape, axe), Loading and ProgressBar (roles, clamping, axe).
- Full suite green: 530 tests, lint, types, coverage thresholds.