### PR TITLE
✅ test: add tests for PhoneNumberInput, Input and Command

### DIFF
--- a/lib/components/Command/Command.test.tsx
+++ b/lib/components/Command/Command.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { FC, useContext } from 'react';
+
+import { Button } from '../Button/Button';
+
+import { Command, CommandGroup, CommandItem } from './Command';
+import { CommandInput, CommandList } from './components';
+import { CommandContext, CommandProvider } from './contexts';
+
+describe('Command', () => {
+  const setup = (onSelectHome = vi.fn(), onSelectSettings = vi.fn()) => {
+    const Palette: FC = () => {
+      const { isOpen, setOpen } = useContext(CommandContext);
+
+      return (
+        <>
+          <Button
+            onClick={() => {
+              setOpen(true);
+            }}
+          >
+            Open palette
+          </Button>
+          <Command open={isOpen} onOpenChange={setOpen} title="Commands">
+            <CommandInput placeholder="Type a command or search..." />
+            <CommandList>
+              <CommandGroup heading="Navigation">
+                <CommandItem onSelect={onSelectHome}>Home</CommandItem>
+                <CommandItem onSelect={onSelectSettings}>Settings</CommandItem>
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </>
+      );
+    };
+
+    const { container: component } = render(
+      <CommandProvider>
+        <Palette />
+      </CommandProvider>,
+    );
+
+    const user = userEvent.setup();
+    const getTrigger = () => {
+      return screen.getByRole('button', { name: /open palette/i });
+    };
+
+    return { component, user, getTrigger, onSelectHome, onSelectSettings };
+  };
+
+  it('should open the palette and list the items', async () => {
+    const { user, getTrigger } = setup();
+
+    await user.click(getTrigger());
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('should filter items when typing in the search input', async () => {
+    const { user, getTrigger } = setup();
+
+    await user.click(getTrigger());
+    await user.keyboard('sett');
+
+    expect(screen.queryByText('Home')).not.toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('should fire onSelect when choosing an item with the keyboard', async () => {
+    const onSelectHome = vi.fn();
+    const { user, getTrigger } = setup(onSelectHome);
+
+    await user.click(getTrigger());
+    await screen.findByRole('dialog');
+    await user.keyboard('{Enter}');
+
+    expect(onSelectHome).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close the palette on Escape', async () => {
+    const { user, getTrigger } = setup();
+
+    await user.click(getTrigger());
+    await screen.findByRole('dialog');
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { user, getTrigger } = setup();
+
+    await user.click(getTrigger());
+    await screen.findByRole('dialog');
+
+    const results = await axe(document.body);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/Input/Input.test.tsx
+++ b/lib/components/Input/Input.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { Input } from './Input';
+
+describe('Input', () => {
+  it('should associate the label with the input', () => {
+    render(<Input label="Email" />);
+
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+  });
+
+  it('should mark the label when the field is required', () => {
+    render(<Input label="Email" isRequired />);
+
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('should call onChange when typing', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<Input label="Email" onChange={onChange} />);
+
+    await user.type(screen.getByLabelText('Email'), 'abc');
+
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(screen.getByLabelText('Email')).toHaveValue('abc');
+  });
+
+  it('should show the error message and flag the input', () => {
+    render(<Input label="Email" error="Invalid email" />);
+
+    expect(screen.getByText('Invalid email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toHaveAttribute(
+      'data-error',
+      'true',
+    );
+  });
+
+  it('should show the helper text only when there is no error', () => {
+    const { rerender } = render(
+      <Input label="Email" helperText="We never share it" />,
+    );
+
+    expect(screen.getByText('We never share it')).toBeInTheDocument();
+
+    rerender(
+      <Input label="Email" helperText="We never share it" error="Invalid" />,
+    );
+
+    expect(screen.queryByText('We never share it')).not.toBeInTheDocument();
+    expect(screen.getByText('Invalid')).toBeInTheDocument();
+  });
+
+  it('should toggle password visibility', async () => {
+    const user = userEvent.setup();
+
+    const { container } = render(<Input label="Password" type="password" />);
+
+    const input = screen.getByLabelText('Password');
+
+    expect(input).toHaveAttribute('type', 'password');
+
+    const toggle = container.querySelector('svg.cursor-pointer');
+
+    await user.click(toggle as Element);
+
+    expect(input).toHaveAttribute('type', 'text');
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = render(
+      <Input label="Email" helperText="We never share it" />,
+    );
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/PhoneNumberInput/PhoneNumberInput.test.tsx
+++ b/lib/components/PhoneNumberInput/PhoneNumberInput.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { PhoneNumberInput } from './PhoneNumberInput';
+import { Props } from './PhoneNumberInput.types';
+
+describe('PhoneNumberInput', () => {
+  const defaultProps = {
+    label: 'Phone Number',
+    name: 'phone',
+  } satisfies Props;
+
+  const setup = (props?: Partial<Props>) => {
+    const { container: component } = render(
+      <PhoneNumberInput {...defaultProps} {...props} />,
+    );
+
+    const user = userEvent.setup();
+    const getInput = () =>
+      screen.getByRole('textbox', { name: 'Phone Number' });
+    const getTrigger = () =>
+      screen.getByRole('button', { name: /select country/i });
+    const getSearchInput = () => screen.getByPlaceholderText('Search');
+    const querySearchInput = () => screen.queryByPlaceholderText('Search');
+
+    return {
+      component,
+      user,
+      getInput,
+      getTrigger,
+      getSearchInput,
+      querySearchInput,
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(400);
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(400);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should render the label and the default country prefix', () => {
+    const { getInput } = setup();
+
+    expect(screen.getByText('Phone Number')).toBeInTheDocument();
+    expect(getInput()).toHaveValue('+1 ');
+  });
+
+  it('should update the prefix when a different country is selected', async () => {
+    const { user, getInput, getTrigger, getSearchInput, querySearchInput } =
+      setup();
+
+    await user.click(getTrigger());
+    await user.type(getSearchInput(), 'andorra');
+
+    const option = await screen.findByRole('button', { name: /andorra/i });
+
+    await user.click(option);
+
+    expect(getInput()).toHaveValue('+376 ');
+    expect(querySearchInput()).not.toBeInTheDocument();
+  });
+
+  it('should call onChange when typing a phone number', async () => {
+    const onChange = vi.fn();
+    const { user, getInput } = setup({ onChange });
+
+    await user.type(getInput(), '2025550123');
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('should close the country selector when pressing Escape', async () => {
+    const { user, getTrigger, getSearchInput, querySearchInput } = setup();
+
+    await user.click(getTrigger());
+
+    expect(getSearchInput()).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(querySearchInput()).not.toBeInTheDocument();
+  });
+
+  it('should close the country selector when clicking outside', async () => {
+    const { user, getTrigger, getSearchInput, querySearchInput } = setup();
+
+    await user.click(getTrigger());
+
+    expect(getSearchInput()).toBeInTheDocument();
+
+    await user.click(document.body);
+
+    expect(querySearchInput()).not.toBeInTheDocument();
+  });
+
+  it("should doesn't have violations", async () => {
+    const { component } = setup();
+
+    const results = await axe(component);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/PhoneNumberInput/components/FlagContent/FlagContent.tsx
+++ b/lib/components/PhoneNumberInput/components/FlagContent/FlagContent.tsx
@@ -14,6 +14,8 @@ export const FlagContent: FC = () => {
   return (
     <button
       type="button"
+      aria-label={`Select country, ${selectedCountry.name}`}
+      aria-expanded={isOpenSelector}
       className="flex items-center gap-2 cursor-pointer"
       onClick={() => handleOpenSelector(!isOpenSelector)}
     >

--- a/lib/components/PhoneNumberInput/components/Wrapper.tsx
+++ b/lib/components/PhoneNumberInput/components/Wrapper.tsx
@@ -134,7 +134,7 @@ export const Wrapper: ForwardRefExoticComponent<
         {label ? (
           <div className={cn(labelWrapperClassName)}>
             <label
-              id={id}
+              htmlFor={id}
               className={labelVariants({ className: labelClassName })}
               onClick={() => !disabled && inputRef.current?.focus()}
             >


### PR DESCRIPTION
## Summary

Fourth PR of the audit series (stacked on #672). Adds behavior tests for the three riskiest components that shipped with zero coverage.

## Changes

- **PhoneNumberInput** (652 LOC, previously untested): default prefix rendering, country selection through the flag selector (search + pick, prefix updates), typing fires `onChange`, Escape and outside-click close the selector, axe check. The country list is virtualized (TanStack Virtual), so the tests mock `offsetHeight/offsetWidth` for jsdom.
- **Two real a11y bugs surfaced by the axe test, fixed here**: the flag selector `<button>` had no accessible name (now `aria-label="Select country, <name>"` + `aria-expanded`), and the `<label>` used `id={id}` instead of `htmlFor={id}` so it never associated with the input (and duplicated the input's id).
- **Input**: label association via `useId`, required marker, `onChange`, error state + `data-error`, error/helper-text precedence, password visibility toggle, axe.
- **Command**: palette open, cmdk filtering, keyboard selection, Escape close (composed with `CommandProvider`/`CommandInput`/`CommandList` as the stories do), axe.

## Testing
18 new tests, full suite green (lint, types, prettier, coverage thresholds).