### PR TITLE
♻️ refactor: remove useCallback/useMemo that provide no real benefit

### DIFF
--- a/lib/components/Alert/Alert.tsx
+++ b/lib/components/Alert/Alert.tsx
@@ -1,12 +1,5 @@
 'use client';
-import {
-  ComponentRef,
-  FC,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { ComponentRef, FC, useEffect, useRef, useState } from 'react';
 import { X } from 'react-feather';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
@@ -63,13 +56,13 @@ export const Alert: FC<Props> = ({
   const wrapperRef = useRef<ComponentRef<'div'>>(null);
   const [isVisibleComponent, setIsVisibleComponent] = useState(isVisible);
 
-  const handleCloseClick = useCallback(() => {
+  const handleCloseClick = () => {
     const wrapper = wrapperRef.current;
 
     if (wrapper) {
       wrapper.setAttribute('data-state', 'hidden');
     }
-  }, []);
+  };
 
   useEffect(() => {
     const controller = new AbortController();

--- a/lib/components/AlertDialog/hooks/useAlertDialog.ts
+++ b/lib/components/AlertDialog/hooks/useAlertDialog.ts
@@ -1,16 +1,22 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 import { UseAlertiDialogProps } from '../AlertDialog.types';
 
 export const useAlertDialog = ({ onConfirm }: UseAlertiDialogProps) => {
   const [isOpen, setOpen] = useState(false);
 
-  const handleOpen = useCallback(() => setOpen(true), []);
-  const handleCancel = useCallback(() => setOpen(false), []);
-  const handleConfirm = useCallback(() => {
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleCancel = () => {
+    setOpen(false);
+  };
+
+  const handleConfirm = () => {
     onConfirm?.();
     setOpen(false);
-  }, [onConfirm]);
+  };
 
   return { isOpen, handleCancel, handleConfirm, handleOpen };
 };

--- a/lib/components/Autocomplete/hooks/useAutocomplete.ts
+++ b/lib/components/Autocomplete/hooks/useAutocomplete.ts
@@ -85,40 +85,31 @@ export const useAutocomplete = ({
     };
   }, [wrapperRef]);
 
-  const handleFilter = useCallback(
-    (value: string) => {
-      if (value.length === 0) {
-        setOptions(options);
-      } else {
-        const optionsParsed = options.map(({ value }) => value);
-        const optionsFiltered = filterByValue(optionsParsed, value).map(
-          (value) => ({ value }),
-        );
+  const handleFilter = (value: string) => {
+    if (value.length === 0) {
+      setOptions(options);
+    } else {
+      const optionsParsed = options.map(({ value }) => value);
+      const optionsFiltered = filterByValue(optionsParsed, value).map(
+        (value) => ({ value }),
+      );
 
-        setOptions(optionsFiltered);
-      }
-    },
-    [options],
-  );
+      setOptions(optionsFiltered);
+    }
+  };
 
-  const handleChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      setValue(event.target.value);
-      handleFilter(event.target.value);
-      onChange?.(event.target.value);
-    },
-    [handleFilter, onChange],
-  );
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+    handleFilter(event.target.value);
+    onChange?.(event.target.value);
+  };
 
-  const handleSelectValue = useCallback(
-    (value: string) => {
-      setValue(value);
-      handleFilter(value);
-      onChange?.(value);
-      setShowOptions(false);
-    },
-    [handleFilter, onChange],
-  );
+  const handleSelectValue = (value: string) => {
+    setValue(value);
+    handleFilter(value);
+    onChange?.(value);
+    setShowOptions(false);
+  };
 
   return {
     inputRef,

--- a/lib/components/Badge/Badge.tsx
+++ b/lib/components/Badge/Badge.tsx
@@ -1,5 +1,5 @@
 import { X } from 'lucide-react';
-import { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 
 import { LoaderIcon } from '@/assets/icons/components';
 import { cn } from '@/utils';
@@ -55,14 +55,11 @@ export const Badge: FC<Props> = ({
   const badgeRef = useRef<HTMLSpanElement>(null);
   const [isVisible, setIsVisible] = useState<'visible' | 'hidden'>('visible');
 
-  const handleDismiss = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      onDismiss?.();
-      setIsVisible('hidden');
-    },
-    [onDismiss],
-  );
+  const handleDismiss = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDismiss?.();
+    setIsVisible('hidden');
+  };
 
   useEffect(() => {
     if (isVisible !== 'hidden') {

--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import { Indicator, Root } from '@radix-ui/react-checkbox';
-import { FC, forwardRef, useCallback, useId } from 'react';
+import { FC, forwardRef, useId } from 'react';
 import { Check } from 'react-feather';
 
 import { useToggle } from '@/hooks';
@@ -53,13 +53,10 @@ const Checkbox: FC<Props> = forwardRef<HTMLButtonElement, Props>(
     const [checked, setChecked] = useToggle(defaultChecked ?? false);
     const defaultId = useId();
 
-    const handleChange = useCallback(
-      (checked: boolean) => {
-        setChecked(checked);
-        onChange?.(checked);
-      },
-      [onChange, setChecked],
-    );
+    const handleChange = (checked: boolean) => {
+      setChecked(checked);
+      onChange?.(checked);
+    };
 
     return (
       <div

--- a/lib/components/Counter/Counter.tsx
+++ b/lib/components/Counter/Counter.tsx
@@ -1,13 +1,6 @@
 'use client';
 import { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
-import {
-  ChangeEvent,
-  FC,
-  forwardRef,
-  useCallback,
-  useId,
-  useState,
-} from 'react';
+import { ChangeEvent, FC, forwardRef, useId, useState } from 'react';
 import { Minus, Plus } from 'react-feather';
 
 import { cn } from '@/utils';
@@ -80,7 +73,7 @@ export const Counter: FC<Props> = forwardRef<HTMLInputElement, Props>(
     const [draft, setDraft] = useState<string | null>(null);
     const displayed = draft ?? String(count);
 
-    const handleDecrement = useCallback(() => {
+    const handleDecrement = () => {
       let newValue: number = 0;
 
       if (min === Infinity) {
@@ -91,9 +84,9 @@ export const Counter: FC<Props> = forwardRef<HTMLInputElement, Props>(
 
       setDraft(null);
       onChange?.({ target: { value: newValue } });
-    }, [count, min, onChange]);
+    };
 
-    const handleIncrement = useCallback(() => {
+    const handleIncrement = () => {
       let newValue: number = 0;
 
       if (max === -Infinity) {
@@ -104,25 +97,22 @@ export const Counter: FC<Props> = forwardRef<HTMLInputElement, Props>(
 
       setDraft(null);
       onChange?.({ target: { value: newValue } });
-    }, [count, max, onChange]);
+    };
 
-    const handleChange = useCallback(
-      (event: ChangeEvent<HTMLInputElement>) => {
-        const raw = event.target.value;
-        setDraft(raw);
-        if (raw === '') {
-          return;
-        }
-        const parsed = Number(raw);
-        if (!Number.isFinite(parsed)) {
-          return;
-        }
-        onChange?.({ target: { value: parsed } });
-      },
-      [onChange],
-    );
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      const raw = event.target.value;
+      setDraft(raw);
+      if (raw === '') {
+        return;
+      }
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed)) {
+        return;
+      }
+      onChange?.({ target: { value: parsed } });
+    };
 
-    const handleBlur = useCallback(() => {
+    const handleBlur = () => {
       setDraft(null);
       const lowerBound = min === Infinity ? -Infinity : min;
       const upperBound = max === -Infinity ? Infinity : max;
@@ -130,7 +120,7 @@ export const Counter: FC<Props> = forwardRef<HTMLInputElement, Props>(
       if (clamped !== count) {
         onChange?.({ target: { value: clamped } });
       }
-    }, [count, min, max, onChange]);
+    };
 
     return (
       <div className="flex flex-col gap-2" data-theme={theme}>

--- a/lib/components/DateRangePicker/components/CalendarPanel/components/IndependentModeCalendar/IndependentModeCalendar.tsx
+++ b/lib/components/DateRangePicker/components/CalendarPanel/components/IndependentModeCalendar/IndependentModeCalendar.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'motion/react';
-import { FC, useCallback, useMemo } from 'react';
+import { FC } from 'react';
 import { DateRange as DayPickerDateRange } from 'react-day-picker';
 
 import { cn } from '@/utils';
@@ -61,30 +61,19 @@ export const IndependentModeCalendar: FC<Props> = ({
     getRightTransform,
   } = useIndependentCarousel(carouselProps);
 
-  const handleRangeSelect = useCallback(
-    (selectedRange: DayPickerDateRange | undefined) => {
-      if (selectedRange) {
-        onRangeSelect({
-          from: selectedRange.from,
-          to: selectedRange.to,
-        });
-      }
-    },
-    [onRangeSelect],
-  );
+  const handleRangeSelect = (selectedRange: DayPickerDateRange | undefined) => {
+    if (selectedRange) {
+      onRangeSelect({
+        from: selectedRange.from,
+        to: selectedRange.to,
+      });
+    }
+  };
 
-  const dayPickerClassNames = useMemo(
-    () => classNames?.dayPicker,
-    [classNames?.dayPicker],
-  );
-
-  const monthClassNames = useMemo(
-    () => ({
-      monthTitle: classNames?.monthTitle,
-      dayPicker: dayPickerClassNames,
-    }),
-    [classNames?.monthTitle, dayPickerClassNames],
-  );
+  const monthClassNames = {
+    monthTitle: classNames?.monthTitle,
+    dayPicker: classNames?.dayPicker,
+  };
 
   return (
     <div className={cn(calendarPanelVariants({ className }), classNames?.root)}>

--- a/lib/components/DateRangePicker/components/CalendarPanel/components/TogetherModeCalendar/TogetherModeCalendar.tsx
+++ b/lib/components/DateRangePicker/components/CalendarPanel/components/TogetherModeCalendar/TogetherModeCalendar.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'motion/react';
-import { FC, useCallback, useMemo } from 'react';
+import { FC } from 'react';
 import { DateRange as DayPickerDateRange } from 'react-day-picker';
 
 import { cn } from '@/utils';
@@ -45,22 +45,14 @@ export const TogetherModeCalendar: FC<Props> = ({
     getTransform,
   } = useTogetherCarousel(carouselProps);
 
-  const handleRangeSelect = useCallback(
-    (selectedRange: DayPickerDateRange | undefined) => {
-      if (selectedRange) {
-        onRangeSelect({
-          from: selectedRange.from,
-          to: selectedRange.to,
-        });
-      }
-    },
-    [onRangeSelect],
-  );
-
-  const dayPickerClassNames = useMemo(
-    () => classNames?.dayPicker,
-    [classNames?.dayPicker],
-  );
+  const handleRangeSelect = (selectedRange: DayPickerDateRange | undefined) => {
+    if (selectedRange) {
+      onRangeSelect({
+        from: selectedRange.from,
+        to: selectedRange.to,
+      });
+    }
+  };
 
   return (
     <div className={cn(calendarPanelVariants({ className }), classNames?.root)}>
@@ -134,7 +126,7 @@ export const TogetherModeCalendar: FC<Props> = ({
               showOutsideDays={showOutsideDays}
               classNames={{
                 monthTitle: classNames?.monthTitle,
-                dayPicker: dayPickerClassNames,
+                dayPicker: classNames?.dayPicker,
               }}
             />
           ))}

--- a/lib/components/DateRangePicker/components/CalendarPanel/hooks/useIndependentCarousel.ts
+++ b/lib/components/DateRangePicker/components/CalendarPanel/hooks/useIndependentCarousel.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 
 import { SlideDirection } from '../CalendarPanel.types';
 import { SINGLE_MONTH_WIDTH, MS_PER_MONTH } from '../constants';
@@ -236,7 +236,7 @@ export const useIndependentCarousel = ({
   ]);
 
   // Calculate transforms
-  const getLeftTransform = useCallback(() => {
+  const getLeftTransform = () => {
     let offset = -SINGLE_MONTH_WIDTH;
     if (isLeftAnimating && leftAnimateTransform) {
       if (leftSlideDirection === 'left') {
@@ -246,9 +246,9 @@ export const useIndependentCarousel = ({
       }
     }
     return `translateX(${offset}px)`;
-  }, [isLeftAnimating, leftAnimateTransform, leftSlideDirection]);
+  };
 
-  const getRightTransform = useCallback(() => {
+  const getRightTransform = () => {
     let offset = -SINGLE_MONTH_WIDTH;
     if (isRightAnimating && rightAnimateTransform) {
       if (rightSlideDirection === 'left') {
@@ -258,7 +258,7 @@ export const useIndependentCarousel = ({
       }
     }
     return `translateX(${offset}px)`;
-  }, [isRightAnimating, rightAnimateTransform, rightSlideDirection]);
+  };
 
   // Months for carousels
   const leftPrevMonth = getPrevMonth(leftInternalMonth);

--- a/lib/components/DateRangePicker/components/CalendarPanel/hooks/useTogetherCarousel.ts
+++ b/lib/components/DateRangePicker/components/CalendarPanel/hooks/useTogetherCarousel.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 
 import { SlideDirection } from '../CalendarPanel.types';
 import { SINGLE_MONTH_WIDTH, GAP_WIDTH, MS_PER_MONTH } from '../constants';
@@ -160,7 +160,7 @@ export const useTogetherCarousel = ({
   }, [isAnimating, animateTransform, animationDuration, slideDirection]);
 
   // Handle navigation
-  const handlePrevMonth = useCallback(() => {
+  const handlePrevMonth = () => {
     if (isAnimating || disabled || !canNavigatePrev) {
       return;
     }
@@ -169,9 +169,9 @@ export const useTogetherCarousel = ({
     setIsAnimating(true);
     setAnimateTransform(false);
     navigatePrevMonth();
-  }, [isAnimating, disabled, canNavigatePrev, navigatePrevMonth]);
+  };
 
-  const handleNextMonth = useCallback(() => {
+  const handleNextMonth = () => {
     if (isAnimating || disabled || !canNavigateNext) {
       return;
     }
@@ -180,10 +180,10 @@ export const useTogetherCarousel = ({
     setIsAnimating(true);
     setAnimateTransform(false);
     navigateNextMonth();
-  }, [isAnimating, disabled, canNavigateNext, navigateNextMonth]);
+  };
 
   // Calculate transform
-  const getTransform = useCallback(() => {
+  const getTransform = () => {
     let offset = baseOffset;
 
     if (isAnimating && animateTransform) {
@@ -195,7 +195,7 @@ export const useTogetherCarousel = ({
     }
 
     return `translateX(${offset}px)`;
-  }, [baseOffset, isAnimating, animateTransform, slideDirection, slideWidth]);
+  };
 
   // Months to render
   const monthsToRender = [

--- a/lib/components/DateRangePicker/components/DateTimeInputs/hooks/useDateTimeInputs.ts
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/hooks/useDateTimeInputs.ts
@@ -47,10 +47,7 @@ export const useDateTimeInputs = ({
     setTime,
   } = useDateRangePicker();
 
-  const restrictions = useMemo(
-    () => ({ blockedDays, blockedMonths, minDate, maxDate }),
-    [blockedDays, blockedMonths, minDate, maxDate],
-  );
+  const restrictions = { blockedDays, blockedMonths, minDate, maxDate };
 
   // Track if inputs are focused (typing mode)
   const isStartTypingRef = useRef(false);
@@ -80,7 +77,7 @@ export const useDateTimeInputs = ({
   }, [range.to]);
 
   // Start date handlers
-  const handleStartDateFocus = useCallback(() => {
+  const handleStartDateFocus = () => {
     isStartTypingRef.current = true;
     setStartDateError(undefined);
     if (range.from) {
@@ -93,82 +90,68 @@ export const useDateTimeInputs = ({
         setStartDateValue(formatDateToString(parsed));
       }
     }
-  }, [range.from, startDateValue]);
+  };
 
-  const handleStartDateChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const rawValue = e.target.value;
-      const formattedValue = autoFormatDateInput(rawValue, startDateValue);
-      setStartDateValue(formattedValue);
-      setStartDateError(undefined);
+  const handleStartDateChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const rawValue = e.target.value;
+    const formattedValue = autoFormatDateInput(rawValue, startDateValue);
+    setStartDateValue(formattedValue);
+    setStartDateError(undefined);
 
-      const parsed = parseDateString(formattedValue);
-      if (parsed) {
-        if (isDateSelectable(parsed, restrictions)) {
-          const endParsed =
-            range.to ||
-            parseDateString(endDateValue) ||
-            parseDisplayDateString(endDateValue);
-          if (endParsed && parsed > endParsed) {
-            return;
-          }
-          setRange({ ...range, from: parsed });
+    const parsed = parseDateString(formattedValue);
+    if (parsed) {
+      if (isDateSelectable(parsed, restrictions)) {
+        const endParsed =
+          range.to ||
+          parseDateString(endDateValue) ||
+          parseDisplayDateString(endDateValue);
+        if (endParsed && parsed > endParsed) {
+          return;
         }
+        setRange({ ...range, from: parsed });
       }
-    },
-    [startDateValue, endDateValue, range, setRange, restrictions],
-  );
+    }
+  };
 
-  const handleStartDateBlur = useCallback(
-    (e: FocusEvent<HTMLInputElement>) => {
-      const value = e.currentTarget.value.trim();
+  const handleStartDateBlur = (e: FocusEvent<HTMLInputElement>) => {
+    const value = e.currentTarget.value.trim();
 
-      if (value === '') {
-        isStartTypingRef.current = false;
-        setStartDateError(undefined);
-        setStartDateValue('');
-        setRange({ ...range, from: undefined });
-        return;
-      }
-
-      const parsed = parseDateString(value);
-      if (!parsed) {
-        setStartDateError(errorInvalidDate);
-        return;
-      }
-
-      if (!isDateSelectable(parsed, restrictions)) {
-        setStartDateError(errorDateNotAvailable);
-        return;
-      }
-
-      const endParsed =
-        parseDateString(endDateValue) || parseDisplayDateString(endDateValue);
-      if (endParsed && parsed > endParsed) {
-        setStartDateError(errorStartAfterEnd);
-        isEndTypingRef.current = true;
-        setRange({ from: undefined, to: undefined });
-        return;
-      }
-
+    if (value === '') {
       isStartTypingRef.current = false;
       setStartDateError(undefined);
-      setRange({ ...range, from: parsed });
-      setStartDateValue(formatDateToDisplayString(parsed));
-    },
-    [
-      range,
-      setRange,
-      restrictions,
-      errorInvalidDate,
-      errorDateNotAvailable,
-      errorStartAfterEnd,
-      endDateValue,
-    ],
-  );
+      setStartDateValue('');
+      setRange({ ...range, from: undefined });
+      return;
+    }
+
+    const parsed = parseDateString(value);
+    if (!parsed) {
+      setStartDateError(errorInvalidDate);
+      return;
+    }
+
+    if (!isDateSelectable(parsed, restrictions)) {
+      setStartDateError(errorDateNotAvailable);
+      return;
+    }
+
+    const endParsed =
+      parseDateString(endDateValue) || parseDisplayDateString(endDateValue);
+    if (endParsed && parsed > endParsed) {
+      setStartDateError(errorStartAfterEnd);
+      isEndTypingRef.current = true;
+      setRange({ from: undefined, to: undefined });
+      return;
+    }
+
+    isStartTypingRef.current = false;
+    setStartDateError(undefined);
+    setRange({ ...range, from: parsed });
+    setStartDateValue(formatDateToDisplayString(parsed));
+  };
 
   // End date handlers
-  const handleEndDateFocus = useCallback(() => {
+  const handleEndDateFocus = () => {
     isEndTypingRef.current = true;
     setEndDateError(undefined);
     if (range.to) {
@@ -180,80 +163,65 @@ export const useDateTimeInputs = ({
         setEndDateValue(formatDateToString(parsed));
       }
     }
-  }, [range.to, endDateValue]);
+  };
 
-  const handleEndDateChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const rawValue = e.target.value;
-      const formattedValue = autoFormatDateInput(rawValue, endDateValue);
-      setEndDateValue(formattedValue);
-      setEndDateError(undefined);
+  const handleEndDateChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const rawValue = e.target.value;
+    const formattedValue = autoFormatDateInput(rawValue, endDateValue);
+    setEndDateValue(formattedValue);
+    setEndDateError(undefined);
 
-      const parsed = parseDateString(formattedValue);
-      if (parsed) {
-        if (isDateSelectable(parsed, restrictions)) {
-          const startParsed =
-            range.from ||
-            parseDateString(startDateValue) ||
-            parseDisplayDateString(startDateValue);
-          if (startParsed && parsed < startParsed) {
-            return;
-          }
-          setRange({ ...range, to: parsed });
+    const parsed = parseDateString(formattedValue);
+    if (parsed) {
+      if (isDateSelectable(parsed, restrictions)) {
+        const startParsed =
+          range.from ||
+          parseDateString(startDateValue) ||
+          parseDisplayDateString(startDateValue);
+        if (startParsed && parsed < startParsed) {
+          return;
         }
+        setRange({ ...range, to: parsed });
       }
-    },
-    [endDateValue, startDateValue, range, setRange, restrictions],
-  );
+    }
+  };
 
-  const handleEndDateBlur = useCallback(
-    (e: FocusEvent<HTMLInputElement>) => {
-      const value = e.currentTarget.value.trim();
+  const handleEndDateBlur = (e: FocusEvent<HTMLInputElement>) => {
+    const value = e.currentTarget.value.trim();
 
-      if (value === '') {
-        isEndTypingRef.current = false;
-        setEndDateError(undefined);
-        setEndDateValue('');
-        setRange({ ...range, to: undefined });
-        return;
-      }
-
-      const parsed = parseDateString(value);
-      if (!parsed) {
-        setEndDateError(errorInvalidDate);
-        return;
-      }
-
-      if (!isDateSelectable(parsed, restrictions)) {
-        setEndDateError(errorDateNotAvailable);
-        return;
-      }
-
-      const startParsed =
-        parseDateString(startDateValue) ||
-        parseDisplayDateString(startDateValue);
-      if (startParsed && parsed < startParsed) {
-        setEndDateError(errorEndBeforeStart);
-        isStartTypingRef.current = true;
-        setRange({ from: undefined, to: undefined });
-        return;
-      }
-
+    if (value === '') {
       isEndTypingRef.current = false;
       setEndDateError(undefined);
-      setRange({ ...range, to: parsed });
-      setEndDateValue(formatDateToDisplayString(parsed));
-    },
-    [
-      range,
-      setRange,
-      restrictions,
-      errorInvalidDate,
-      errorDateNotAvailable,
-      errorEndBeforeStart,
-      startDateValue,
-    ],
-  );
+      setEndDateValue('');
+      setRange({ ...range, to: undefined });
+      return;
+    }
+
+    const parsed = parseDateString(value);
+    if (!parsed) {
+      setEndDateError(errorInvalidDate);
+      return;
+    }
+
+    if (!isDateSelectable(parsed, restrictions)) {
+      setEndDateError(errorDateNotAvailable);
+      return;
+    }
+
+    const startParsed =
+      parseDateString(startDateValue) || parseDisplayDateString(startDateValue);
+    if (startParsed && parsed < startParsed) {
+      setEndDateError(errorEndBeforeStart);
+      isStartTypingRef.current = true;
+      setRange({ from: undefined, to: undefined });
+      return;
+    }
+
+    isEndTypingRef.current = false;
+    setEndDateError(undefined);
+    setRange({ ...range, to: parsed });
+    setEndDateValue(formatDateToDisplayString(parsed));
+  };
 
   // Time handlers
   const handleStartTimeChange = useCallback(

--- a/lib/components/Datepicker/DatePicker.tsx
+++ b/lib/components/Datepicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useState } from 'react';
+import { FC, useState } from 'react';
 import { DayPicker as DatePickerPrimitive } from 'react-day-picker';
 
 import { cn } from '@/utils';
@@ -45,15 +45,12 @@ const DatePicker: FC<Props> = ({
     () => defaultSelected,
   );
 
-  const handleSelect = useCallback(
-    (date?: Date) => {
-      if (date) {
-        setSelected(date);
-        onSelect?.(date);
-      }
-    },
-    [onSelect],
-  );
+  const handleSelect = (date?: Date) => {
+    if (date) {
+      setSelected(date);
+      onSelect?.(date);
+    }
+  };
 
   return (
     <DatePickerPrimitive

--- a/lib/components/Drawer/hooks/useDrawer.ts
+++ b/lib/components/Drawer/hooks/useDrawer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   ANIMATION_DELAY_MS,
@@ -99,49 +99,44 @@ export const useDrawer = ({
   }, [position, minWidth, maxWidth, canResize, cleanupResizeListeners]);
 
   // Handle resize mouse down
-  const handleMouseDown = useCallback(() => {
+  const handleMouseDown = () => {
     isDraggingRef.current = true;
     document.addEventListener('mousemove', handleMouseMoveRef.current);
     document.addEventListener('mouseup', handleMouseUpRef.current);
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
-  }, []);
+  };
 
   // Handle keyboard resize for accessibility
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      if (!canResize) return;
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (!canResize) return;
 
-      const isIncreaseKey =
-        (position === 'right' && event.key === 'ArrowLeft') ||
-        (position === 'left' && event.key === 'ArrowRight');
-      const isDecreaseKey =
-        (position === 'right' && event.key === 'ArrowRight') ||
-        (position === 'left' && event.key === 'ArrowLeft');
+    const isIncreaseKey =
+      (position === 'right' && event.key === 'ArrowLeft') ||
+      (position === 'left' && event.key === 'ArrowRight');
+    const isDecreaseKey =
+      (position === 'right' && event.key === 'ArrowRight') ||
+      (position === 'left' && event.key === 'ArrowLeft');
 
-      if (isIncreaseKey) {
-        event.preventDefault();
-        setWidth((prev) => Math.min(maxWidth, prev + KEYBOARD_RESIZE_STEP));
-      } else if (isDecreaseKey) {
-        event.preventDefault();
-        setWidth((prev) => Math.max(minWidth, prev - KEYBOARD_RESIZE_STEP));
-      }
-    },
-    [canResize, position, maxWidth, minWidth],
-  );
+    if (isIncreaseKey) {
+      event.preventDefault();
+      setWidth((prev) => Math.min(maxWidth, prev + KEYBOARD_RESIZE_STEP));
+    } else if (isDecreaseKey) {
+      event.preventDefault();
+      setWidth((prev) => Math.max(minWidth, prev - KEYBOARD_RESIZE_STEP));
+    }
+  };
 
   // Cleanup resize listeners on unmount
   useEffect(() => {
     return cleanupResizeListeners;
   }, [cleanupResizeListeners]);
 
-  // Compute translate class based on animation state
-  const translateClass = useMemo(() => {
-    if (isAnimating) {
-      return 'translate-x-0';
-    }
-    return position === 'left' ? '-translate-x-full' : 'translate-x-full';
-  }, [isAnimating, position]);
+  const translateClass = isAnimating
+    ? 'translate-x-0'
+    : position === 'left'
+      ? '-translate-x-full'
+      : 'translate-x-full';
 
   return {
     isAnimating,

--- a/lib/components/Filter/components/BadgeDropdown/BadgeMultiSelect.hook.ts
+++ b/lib/components/Filter/components/BadgeDropdown/BadgeMultiSelect.hook.ts
@@ -28,51 +28,42 @@ export const useBadgeMultiSelect = ({
 
   useFilterDropdownSync({ id, onClose: handleClose, onReset: clearSelection });
 
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        sendOpenFilterEvent(id);
-        setSelectedOptions((prevOptions) =>
-          prevOptions.filter((option) => option.isApplied),
-        );
-      }
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      sendOpenFilterEvent(id);
+      setSelectedOptions((prevOptions) =>
+        prevOptions.filter((option) => option.isApplied),
+      );
+    }
 
-      setIsOpen(open);
-    },
-    [id],
-  );
+    setIsOpen(open);
+  };
 
-  const handleSelectOption = useCallback(
-    (option: Option, checked: boolean) => {
-      if (checked) {
-        setSelectedOptions([
-          ...selectedOptions,
-          { ...option, isApplied: false },
-        ]);
-      } else {
-        setSelectedOptions(
-          selectedOptions.map((o) => {
-            if (o.id === option.id) {
-              return { ...o, isRemoved: true };
-            }
+  const handleSelectOption = (option: Option, checked: boolean) => {
+    if (checked) {
+      setSelectedOptions([...selectedOptions, { ...option, isApplied: false }]);
+    } else {
+      setSelectedOptions(
+        selectedOptions.map((o) => {
+          if (o.id === option.id) {
+            return { ...o, isRemoved: true };
+          }
 
-            return o;
-          }),
-        );
-      }
-    },
-    [setSelectedOptions, selectedOptions],
-  );
+          return o;
+        }),
+      );
+    }
+  };
 
-  const handleResetOptions = useCallback(() => {
+  const handleResetOptions = () => {
     clearSelection();
 
     if (closeOnApply) {
       setIsOpen(false);
     }
-  }, [clearSelection, closeOnApply]);
+  };
 
-  const handleApplyOptions = useCallback(() => {
+  const handleApplyOptions = () => {
     const newOptions = selectedOptions
       ?.filter((option) => !option.isRemoved)
       .map((option) => ({ ...option, isApplied: true }));
@@ -87,7 +78,7 @@ export const useBadgeMultiSelect = ({
     if (closeOnApply) {
       setIsOpen(false);
     }
-  }, [closeOnApply, onApply, selectedOptions, setSelectedOptions]);
+  };
 
   const selectedCount = useMemo(
     () => selectedOptions.filter((option) => option.isApplied),
@@ -103,16 +94,13 @@ export const useBadgeMultiSelect = ({
     [options, selectedOptions],
   );
 
-  const handleSelectAll = useCallback(
-    (allOptions: Option[], checked: boolean) => {
-      if (checked) {
-        setSelectedOptions(
-          allOptions.map((opt) => ({ ...opt, isApplied: false })),
-        );
-      }
-    },
-    [],
-  );
+  const handleSelectAll = (allOptions: Option[], checked: boolean) => {
+    if (checked) {
+      setSelectedOptions(
+        allOptions.map((opt) => ({ ...opt, isApplied: false })),
+      );
+    }
+  };
 
   return {
     isOpen,

--- a/lib/components/Filter/components/DateFilterDropdown/DateFilterDropdown.hook.ts
+++ b/lib/components/Filter/components/DateFilterDropdown/DateFilterDropdown.hook.ts
@@ -28,25 +28,22 @@ export const useDateFilterDropdown = ({
     [appliedDay, countryCode],
   );
 
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        sendOpenFilterEvent(id);
-      }
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      sendOpenFilterEvent(id);
+    }
 
-      setIsOpen(open);
-    },
-    [id],
-  );
+    setIsOpen(open);
+  };
 
-  const handleApply = useCallback(() => {
+  const handleApply = () => {
     setAppliedDay(selectedDay);
     onApply?.(selectedDay);
 
     if (closeOnApply) {
       setIsOpen(false);
     }
-  }, [closeOnApply, onApply, selectedDay]);
+  };
 
   const handleSelect = useCallback((date: Date) => setSelectedDay(date), []);
   const handleClose = useCallback(() => setIsOpen(false), []);
@@ -57,13 +54,13 @@ export const useDateFilterDropdown = ({
     onApply?.();
   }, [onApply]);
 
-  const handleReset = useCallback(() => {
+  const handleReset = () => {
     clearSelection();
 
     if (closeOnApply) {
       setIsOpen(false);
     }
-  }, [clearSelection, closeOnApply]);
+  };
 
   useFilterDropdownSync({ id, onClose: handleClose, onReset: clearSelection });
 

--- a/lib/components/Filter/components/DateRangeFilterDropdown/DateRangeFilterDropdown.hook.ts
+++ b/lib/components/Filter/components/DateRangeFilterDropdown/DateRangeFilterDropdown.hook.ts
@@ -47,18 +47,15 @@ export const useDateRangeFilterDropdown = ({
     return formatDate(appliedRange.from);
   }, [appliedRange]);
 
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        sendOpenFilterEvent(id);
-      }
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      sendOpenFilterEvent(id);
+    }
 
-      setIsOpen(open);
-    },
-    [id],
-  );
+    setIsOpen(open);
+  };
 
-  const handleApply = useCallback(() => {
+  const handleApply = () => {
     const rangeWithTime: DateRangeWithTime = {
       from: selectedRange?.from,
       to: selectedRange?.to,
@@ -69,7 +66,7 @@ export const useDateRangeFilterDropdown = ({
     if (closeOnApply) {
       setIsOpen(false);
     }
-  }, [closeOnApply, onApply, selectedRange]);
+  };
 
   const handleRangeChange = useCallback((range: DateRangeWithTime) => {
     setSelectedRange({ from: range.from, to: range.to });
@@ -83,13 +80,13 @@ export const useDateRangeFilterDropdown = ({
     onApply?.();
   }, [onApply]);
 
-  const handleReset = useCallback(() => {
+  const handleReset = () => {
     clearSelection();
 
     if (closeOnApply) {
       setIsOpen(false);
     }
-  }, [clearSelection, closeOnApply]);
+  };
 
   useFilterDropdownSync({ id, onClose: handleClose, onReset: clearSelection });
 

--- a/lib/components/Filter/components/ResetButton/ResetButton.tsx
+++ b/lib/components/Filter/components/ResetButton/ResetButton.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import { FC } from 'react';
 
 import { Button } from '@/components/Button/Button';
 import { cn } from '@/utils';
@@ -16,10 +16,10 @@ export const ResetButton: FC<ResetButtonProps> = ({
 }) => {
   const { resetScope } = useFilterContext();
 
-  const handleClick = useCallback(() => {
+  const handleClick = () => {
     resetEvent(resetScope);
     onClick?.();
-  }, [onClick, resetScope]);
+  };
 
   return (
     <Button

--- a/lib/components/Filter/components/TimeFilterDropdown/TimeFilterDropdown.hook.ts
+++ b/lib/components/Filter/components/TimeFilterDropdown/TimeFilterDropdown.hook.ts
@@ -28,28 +28,25 @@ export const useTimeFilterDropdown = ({
     appliedPresetLabel ??
     (appliedTime ? getFormattedTime(appliedTime, format) : undefined);
 
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        sendOpenFilterEvent(id);
-      }
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      sendOpenFilterEvent(id);
+    }
 
-      setIsOpen(open);
-    },
-    [id],
-  );
+    setIsOpen(open);
+  };
 
-  const handleSelectPreset = useCallback((preset: TimePreset) => {
+  const handleSelectPreset = (preset: TimePreset) => {
     setSelectedTime(preset.value);
     setSelectedPresetLabel(preset.label);
-  }, []);
+  };
 
   const handleSelectCustom = useCallback((time: Date) => {
     setSelectedTime(time);
     setSelectedPresetLabel(undefined);
   }, []);
 
-  const handleApply = useCallback(() => {
+  const handleApply = () => {
     setAppliedTime(selectedTime);
     setAppliedPresetLabel(selectedPresetLabel);
     onApply?.(selectedTime);
@@ -57,7 +54,7 @@ export const useTimeFilterDropdown = ({
     if (closeOnApply) {
       setIsOpen(false);
     }
-  }, [closeOnApply, onApply, selectedTime, selectedPresetLabel]);
+  };
 
   const handleClose = useCallback(() => setIsOpen(false), []);
 
@@ -69,13 +66,13 @@ export const useTimeFilterDropdown = ({
     onApply?.();
   }, [onApply]);
 
-  const handleReset = useCallback(() => {
+  const handleReset = () => {
     clearSelection();
 
     if (closeOnApply) {
       setIsOpen(false);
     }
-  }, [clearSelection, closeOnApply]);
+  };
 
   useFilterDropdownSync({ id, onClose: handleClose, onReset: clearSelection });
 

--- a/lib/components/MultiSelectDropdown/hooks/useMultiSelectDropdown.ts
+++ b/lib/components/MultiSelectDropdown/hooks/useMultiSelectDropdown.ts
@@ -32,17 +32,14 @@ export const useMultiSelectDropdown = () => {
     };
   }, [onOpen]);
 
-  const handleOpen = useCallback(
-    (event: React.MouseEvent<HTMLElement>) => {
-      const target = event.target as HTMLElement | null;
-      const parentWithDataValue = target?.closest('[data-value]');
+  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement | null;
+    const parentWithDataValue = target?.closest('[data-value]');
 
-      if (!parentWithDataValue) {
-        onOpen(true);
-      }
-    },
-    [onOpen],
-  );
+    if (!parentWithDataValue) {
+      onOpen(true);
+    }
+  };
 
   return {
     wrapperRef,

--- a/lib/components/PhoneNumberInput/components/FlagSelectorWrapper/FlagSelectorWrapper.tsx
+++ b/lib/components/PhoneNumberInput/components/FlagSelectorWrapper/FlagSelectorWrapper.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, useCallback } from 'react';
+import { ChangeEvent, FC } from 'react';
 
 import { Input } from '@/components/Input/Input';
 
@@ -17,9 +17,9 @@ export const FlagSelectorWrapper: FC<Props> = ({
 }) => {
   const { onChangeTermOfSearch } = usePhoneNumberContext();
 
-  const onChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
     onChangeTermOfSearch(event.target.value);
-  }, []);
+  };
 
   return (
     <div

--- a/lib/components/PhoneNumberInput/components/Wrapper.tsx
+++ b/lib/components/PhoneNumberInput/components/Wrapper.tsx
@@ -75,18 +75,15 @@ export const Wrapper: ForwardRefExoticComponent<
 
     useImperativeHandle(ref, () => inputRef.current!, [inputRef]);
 
-    const onChange = useCallback(
-      (event: ChangeEvent<HTMLInputElement>) => {
-        const value = event.target.value;
+    const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
 
-        if (value.startsWith(selectedCountry.prefix)) {
-          onChangeValue(event.target.value);
-        } else {
-          onChangeValue(`${selectedCountry.prefix} `);
-        }
-      },
-      [selectedCountry.prefix, onChangeValue],
-    );
+      if (value.startsWith(selectedCountry.prefix)) {
+        onChangeValue(event.target.value);
+      } else {
+        onChangeValue(`${selectedCountry.prefix} `);
+      }
+    };
 
     const handleClickOutside = useCallback(() => {
       handleOpenSelector(false);

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -1,4 +1,4 @@
-import { FC, forwardRef, useCallback, useId } from 'react';
+import { FC, forwardRef, useId } from 'react';
 
 import { Typography } from '@/components/Typography/Typography';
 import { cn } from '@/utils';
@@ -50,13 +50,6 @@ const Radio: FC<Props> = forwardRef<HTMLInputElement, Props>(
     const id = useId();
     const defaultFor = `${id}-${name}`;
 
-    const handleChange = useCallback(
-      (value: string) => {
-        onChange?.(value);
-      },
-      [onChange],
-    );
-
     return (
       <label
         htmlFor={defaultFor}
@@ -77,7 +70,7 @@ const Radio: FC<Props> = forwardRef<HTMLInputElement, Props>(
           checked={checked}
           defaultChecked={defaultChecked}
           className="hidden peer"
-          onChange={() => handleChange(value)}
+          onChange={() => onChange?.(value)}
           disabled={disabled}
         />
 

--- a/lib/components/RadioCardGroup/RadioCardGroup.tsx
+++ b/lib/components/RadioCardGroup/RadioCardGroup.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useState } from 'react';
+import { FC, useState } from 'react';
 
 import { cn } from '@/utils';
 
@@ -39,13 +39,10 @@ export const RadioCardGroup: FC<Props> = ({
 }) => {
   const [selected, setSelected] = useState<string | undefined>(defaultChecked);
 
-  const handleSelected = useCallback(
-    (value: string) => {
-      setSelected(value);
-      onValueChange?.(value);
-    },
-    [onValueChange],
-  );
+  const handleSelected = (value: string) => {
+    setSelected(value);
+    onValueChange?.(value);
+  };
 
   return (
     <div

--- a/lib/components/RadioGroup/RadioGroup.tsx
+++ b/lib/components/RadioGroup/RadioGroup.tsx
@@ -1,5 +1,5 @@
 import { Slot } from '@radix-ui/react-slot';
-import { FC, useCallback, useState } from 'react';
+import { FC, useState } from 'react';
 
 import { cn } from '@/utils';
 
@@ -58,15 +58,12 @@ export const RadioGroup: FC<Props> = ({
   );
   const selected = isControlled ? value : internalSelected;
 
-  const handleSelected = useCallback(
-    (newValue: string) => {
-      if (!isControlled) {
-        setInternalSelected(newValue);
-      }
-      onValueChange?.(newValue);
-    },
-    [isControlled, onValueChange],
-  );
+  const handleSelected = (newValue: string) => {
+    if (!isControlled) {
+      setInternalSelected(newValue);
+    }
+    onValueChange?.(newValue);
+  };
 
   return (
     <Component

--- a/lib/components/Range/Range.tsx
+++ b/lib/components/Range/Range.tsx
@@ -8,7 +8,6 @@ import {
   ComponentRef,
   FC,
   forwardRef,
-  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -68,10 +67,9 @@ export const Range: FC<Props> = forwardRef<ComponentRef<'input'>, Props>(
       }
     }, [value]);
 
-    const handleValueChange = useCallback(
-      (newValue: number[]) => setValue(newValue),
-      [],
-    );
+    const handleValueChange = (newValue: number[]) => {
+      setValue(newValue);
+    };
 
     return (
       <div className="w-full relative flex flex-col gap-3" data-theme={theme}>

--- a/lib/components/Select/components/ListItem/ListItem.tsx
+++ b/lib/components/Select/components/ListItem/ListItem.tsx
@@ -1,4 +1,4 @@
-import { ComponentRef, FC, KeyboardEvent, useCallback, useRef } from 'react';
+import { ComponentRef, FC, KeyboardEvent, useRef } from 'react';
 
 import { cn } from '@/utils';
 
@@ -41,76 +41,75 @@ export const ListItem: FC<ListItemProps> = ({
     useSelectContext();
   const liRef = useRef<ComponentRef<'li'>>(null);
 
-  const handleClick = useCallback(
-    (option: Option) => {
-      setValue(option.value, inputRef);
-      toggleOpen(false);
-    },
-    [setValue, toggleOpen],
-  );
+  const handleClick = (option: Option) => {
+    setValue(option.value, inputRef);
+    toggleOpen(false);
+  };
 
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLLIElement>, option: Option) => {
-      if (event.key === 'Enter') {
-        event.stopPropagation();
-        handleClick(option);
-      }
-    },
-    [handleClick],
-  );
+  const handleKeyDown = (
+    event: KeyboardEvent<HTMLLIElement>,
+    option: Option,
+  ) => {
+    if (event.key === 'Enter') {
+      event.stopPropagation();
+      handleClick(option);
+    }
+  };
 
-  const getLabelValue = useCallback(
-    ({ label, rightComponent, subLabel, rightComponentClassName }: Option) => {
-      if (isEmpty) {
-        return (
-          <Typography
-            variant="body2"
-            className="text-zinc-800 dark:text-metal-50 italic"
-          >
-            {label}
-          </Typography>
-        );
-      }
-
-      if (typeof label !== 'string') {
-        return label;
-      }
-
-      const newValue =
-        highlightSearchEnabled && searchTerm.length > 0
-          ? highlightText(label, searchTerm)
-          : [label];
-
+  const getLabelValue = ({
+    label,
+    rightComponent,
+    subLabel,
+    rightComponentClassName,
+  }: Option) => {
+    if (isEmpty) {
       return (
         <Typography
           variant="body2"
-          className="text-zinc-700 dark:text-metal-50 font-medium"
+          className="text-zinc-800 dark:text-metal-50 italic"
         >
-          {rightComponent ? (
-            <span
-              className={cn('flex gap-2 items-center', rightComponentClassName)}
-            >
-              {newValue} {rightComponent}
-            </span>
-          ) : (
-            newValue
-          )}
-
-          {subLabel ? (
-            <span
-              className={cn(
-                'block font-normal text-sm text-metal-800 dark:text-metal-50',
-                listItemSecondRowClassName,
-              )}
-            >
-              {subLabel}
-            </span>
-          ) : null}
+          {label}
         </Typography>
       );
-    },
-    [highlightSearchEnabled, searchTerm],
-  );
+    }
+
+    if (typeof label !== 'string') {
+      return label;
+    }
+
+    const newValue =
+      highlightSearchEnabled && searchTerm.length > 0
+        ? highlightText(label, searchTerm)
+        : [label];
+
+    return (
+      <Typography
+        variant="body2"
+        className="text-zinc-700 dark:text-metal-50 font-medium"
+      >
+        {rightComponent ? (
+          <span
+            className={cn('flex gap-2 items-center', rightComponentClassName)}
+          >
+            {newValue} {rightComponent}
+          </span>
+        ) : (
+          newValue
+        )}
+
+        {subLabel ? (
+          <span
+            className={cn(
+              'block font-normal text-sm text-metal-800 dark:text-metal-50',
+              listItemSecondRowClassName,
+            )}
+          >
+            {subLabel}
+          </span>
+        ) : null}
+      </Typography>
+    );
+  };
 
   return (
     <li

--- a/lib/components/Select/hooks/useSelect.ts
+++ b/lib/components/Select/hooks/useSelect.ts
@@ -163,10 +163,10 @@ export const useSelect = ({
     };
   }, [toggleOpen, wrapperRef, setSearchTerm, onBlur, value]);
 
-  const handleOpen = useCallback(() => {
+  const handleOpen = () => {
     toggleOpen(true);
     requestAnimationFrame(() => searchInputRef?.current?.focus());
-  }, [searchInputRef, toggleOpen]);
+  };
 
   return {
     wrapperRef,

--- a/lib/components/Sidebar/components/Wrapper/Wrapper.tsx
+++ b/lib/components/Sidebar/components/Wrapper/Wrapper.tsx
@@ -116,25 +116,22 @@ const Wrapper: FC<Props> = ({
     document.removeEventListener('mouseup', handleMouseUp);
   }, [handleMouseMove]);
 
-  const handleMouseDown = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      event.stopPropagation();
+  const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
 
-      isResizingRef.current = true;
+    isResizingRef.current = true;
 
-      if (asideRef.current) {
-        asideRef.current.classList.add('transition-none');
-      }
+    if (asideRef.current) {
+      asideRef.current.classList.add('transition-none');
+    }
 
-      document.body.style.userSelect = 'none';
-      document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
 
-      document.addEventListener('mousemove', handleMouseMove);
-      document.addEventListener('mouseup', handleMouseUp);
-    },
-    [handleMouseMove, handleMouseUp],
-  );
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  };
 
   useEffect(() => {
     if (resolvedMode !== 'expanded' && asideRef.current) {
@@ -162,9 +159,9 @@ const Wrapper: FC<Props> = ({
     hasAppliedInitialWidthRef.current = true;
   }, [initialWidth, maxWith, minWith, resolvedMode]);
 
-  const handleOpenDrawer = useCallback(() => {
+  const handleOpenDrawer = () => {
     setIsDrawerOpen(true);
-  }, []);
+  };
 
   const handleCloseDrawer = useCallback(() => {
     setIsDrawerOpen(false);

--- a/lib/components/Slider/Slider.tsx
+++ b/lib/components/Slider/Slider.tsx
@@ -3,7 +3,6 @@ import {
   ComponentRef,
   FC,
   forwardRef,
-  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -62,10 +61,9 @@ export const Slider: FC<Props> = forwardRef<ComponentRef<'input'>, Props>(
       }
     }, [value]);
 
-    const handleValueChange = useCallback(
-      (newValue: number[]) => setValue(newValue),
-      [],
-    );
+    const handleValueChange = (newValue: number[]) => {
+      setValue(newValue);
+    };
 
     return (
       <div className="w-full relative flex flex-col gap-3" data-theme={theme}>

--- a/lib/components/Stepper/hooks/useStepItemLogic.ts
+++ b/lib/components/Stepper/hooks/useStepItemLogic.ts
@@ -1,5 +1,5 @@
 import { Slot } from '@radix-ui/react-slot';
-import { useCallback, type KeyboardEvent } from 'react';
+import { type KeyboardEvent } from 'react';
 
 import type {
   UseStepItemLogicProps,
@@ -17,25 +17,26 @@ export function useStepItemLogic({
   const isClickable = clickable && !isDisabled && hasCallback;
   const LabelComponent = typeof step.label === 'string' ? 'span' : Slot;
 
-  const handleClick = useCallback(() => {
-    if (!isClickable) return;
+  const handleClick = () => {
+    if (!isClickable) {
+      return;
+    }
     if (step.onClick) {
       step.onClick();
     } else if (onClick) {
       onClick();
     }
-  }, [isClickable, step.onClick, onClick]);
+  };
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLDivElement>) => {
-      if (!isClickable) return;
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        handleClick();
-      }
-    },
-    [isClickable, handleClick],
-  );
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!isClickable) {
+      return;
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  };
 
   return {
     isClickable,

--- a/lib/components/TagSelect/hooks/useTagSelect.ts
+++ b/lib/components/TagSelect/hooks/useTagSelect.ts
@@ -32,17 +32,14 @@ export const useTagSelect = () => {
     };
   }, [onOpen]);
 
-  const handleOpen = useCallback(
-    (event: React.MouseEvent<HTMLElement>) => {
-      const target = event.target as HTMLElement | null;
-      const parentWithDataValue = target?.closest('[data-value]');
+  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement | null;
+    const parentWithDataValue = target?.closest('[data-value]');
 
-      if (!parentWithDataValue) {
-        onOpen(true);
-      }
-    },
-    [onOpen],
-  );
+    if (!parentWithDataValue) {
+      onOpen(true);
+    }
+  };
 
   return {
     wrapperRef,

--- a/lib/components/TimePicker/components/HoursList/HoursList.tsx
+++ b/lib/components/TimePicker/components/HoursList/HoursList.tsx
@@ -1,11 +1,4 @@
-import {
-  FC,
-  MouseEvent,
-  KeyboardEvent,
-  useCallback,
-  useEffect,
-  useRef,
-} from 'react';
+import { FC, MouseEvent, KeyboardEvent, useEffect, useRef } from 'react';
 
 import { cn } from '@/utils';
 
@@ -25,54 +18,51 @@ const HoursList: FC<HourListProps> = ({ hours, scrollBehavior }) => {
   const newHours = format === '12' ? (hours >= 12 ? hours - 12 : hours) : hours;
   const maxHours = format === '12' ? 12 : 24;
 
-  const handleSelectHour = useCallback(
-    (event: MouseEvent<HTMLButtonElement>, hour: number) => {
-      event.currentTarget?.blur();
+  const handleSelectHour = (
+    event: MouseEvent<HTMLButtonElement>,
+    hour: number,
+  ) => {
+    event.currentTarget?.blur();
+    onSelectHour(hour);
+  };
+
+  const handleKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    currentIndex: number,
+  ) => {
+    const buttons = wrapperRef.current?.querySelectorAll('button');
+    if (!buttons) return;
+
+    let nextIndex = currentIndex;
+
+    if (event.key === 'ArrowDown' || (event.key === 'Tab' && !event.shiftKey)) {
+      event.preventDefault();
+      nextIndex = (currentIndex + 1) % maxHours;
+    } else if (
+      event.key === 'ArrowUp' ||
+      (event.key === 'Tab' && event.shiftKey)
+    ) {
+      event.preventDefault();
+      nextIndex = (currentIndex - 1 + maxHours) % maxHours;
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      // Select the hour
+      const hour = format === '12' ? currentIndex + 1 : currentIndex;
       onSelectHour(hour);
-    },
-    [onSelectHour],
-  );
+      // Move focus to minutes list
+      const minutesList = document.querySelector('[aria-label="minutes"]');
+      const activeMinuteButton = minutesList?.querySelector(
+        'li[data-active="true"] button',
+      ) as HTMLButtonElement;
+      activeMinuteButton?.focus();
+      return;
+    }
 
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
-      const buttons = wrapperRef.current?.querySelectorAll('button');
-      if (!buttons) return;
-
-      let nextIndex = currentIndex;
-
-      if (
-        event.key === 'ArrowDown' ||
-        (event.key === 'Tab' && !event.shiftKey)
-      ) {
-        event.preventDefault();
-        nextIndex = (currentIndex + 1) % maxHours;
-      } else if (
-        event.key === 'ArrowUp' ||
-        (event.key === 'Tab' && event.shiftKey)
-      ) {
-        event.preventDefault();
-        nextIndex = (currentIndex - 1 + maxHours) % maxHours;
-      } else if (event.key === 'Enter') {
-        event.preventDefault();
-        // Select the hour
-        const hour = format === '12' ? currentIndex + 1 : currentIndex;
-        onSelectHour(hour);
-        // Move focus to minutes list
-        const minutesList = document.querySelector('[aria-label="minutes"]');
-        const activeMinuteButton = minutesList?.querySelector(
-          'li[data-active="true"] button',
-        ) as HTMLButtonElement;
-        activeMinuteButton?.focus();
-        return;
-      }
-
-      if (nextIndex !== currentIndex) {
-        const nextButton = buttons[nextIndex] as HTMLButtonElement;
-        nextButton?.focus();
-      }
-    },
-    [format, maxHours, onSelectHour],
-  );
+    if (nextIndex !== currentIndex) {
+      const nextButton = buttons[nextIndex] as HTMLButtonElement;
+      nextButton?.focus();
+    }
+  };
 
   // Scroll on initial mount
   useEffect(() => {

--- a/lib/components/TimePicker/components/MeridianList/MeridianList.tsx
+++ b/lib/components/TimePicker/components/MeridianList/MeridianList.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEvent, KeyboardEvent, useCallback, useRef } from 'react';
+import { FC, MouseEvent, KeyboardEvent, useRef } from 'react';
 
 import { cn } from '@/utils';
 
@@ -16,45 +16,45 @@ const MeridianList: FC<MeridianListProps> = ({
   const wrapperRef = useRef<HTMLUListElement>(null);
   const { format, isAM, onSelectAM, onSelectPM } = useTimePickerContext();
 
-  const handleClick = useCallback(
-    (event: MouseEvent<HTMLButtonElement>, callback: () => void) => {
-      event.currentTarget?.blur();
-      callback();
-    },
-    [],
-  );
+  const handleClick = (
+    event: MouseEvent<HTMLButtonElement>,
+    callback: () => void,
+  ) => {
+    event.currentTarget?.blur();
+    callback();
+  };
 
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLButtonElement>, isCurrentlyAM: boolean) => {
-      const buttons = wrapperRef.current?.querySelectorAll('button');
-      if (!buttons) return;
+  const handleKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    isCurrentlyAM: boolean,
+  ) => {
+    const buttons = wrapperRef.current?.querySelectorAll('button');
+    if (!buttons) return;
 
-      const isTabForward = event.key === 'Tab' && !event.shiftKey;
-      const isTabBackward = event.key === 'Tab' && event.shiftKey;
-      const isArrow = event.key === 'ArrowDown' || event.key === 'ArrowUp';
+    const isTabForward = event.key === 'Tab' && !event.shiftKey;
+    const isTabBackward = event.key === 'Tab' && event.shiftKey;
+    const isArrow = event.key === 'ArrowDown' || event.key === 'ArrowUp';
 
-      if (isArrow || isTabForward || isTabBackward) {
-        event.preventDefault();
-        // Navigate between AM and PM without selecting
-        if (isCurrentlyAM) {
-          (buttons[1] as HTMLButtonElement)?.focus();
-        } else {
-          (buttons[0] as HTMLButtonElement)?.focus();
-        }
-      } else if (event.key === 'Enter') {
-        event.preventDefault();
-        // Select the current option
-        if (isCurrentlyAM) {
-          onSelectAM();
-        } else {
-          onSelectPM();
-        }
-        // Close the list
-        onClose?.();
+    if (isArrow || isTabForward || isTabBackward) {
+      event.preventDefault();
+      // Navigate between AM and PM without selecting
+      if (isCurrentlyAM) {
+        (buttons[1] as HTMLButtonElement)?.focus();
+      } else {
+        (buttons[0] as HTMLButtonElement)?.focus();
       }
-    },
-    [onSelectAM, onSelectPM, onClose],
-  );
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      // Select the current option
+      if (isCurrentlyAM) {
+        onSelectAM();
+      } else {
+        onSelectPM();
+      }
+      // Close the list
+      onClose?.();
+    }
+  };
 
   if (format === '24') {
     return null;

--- a/lib/components/TimePicker/components/MinutesList/MinutesList.tsx
+++ b/lib/components/TimePicker/components/MinutesList/MinutesList.tsx
@@ -1,11 +1,4 @@
-import {
-  useEffect,
-  useRef,
-  FC,
-  MouseEvent,
-  KeyboardEvent,
-  useCallback,
-} from 'react';
+import { useEffect, useRef, FC, MouseEvent, KeyboardEvent } from 'react';
 
 import { cn } from '@/utils';
 
@@ -63,58 +56,55 @@ const MinutesList: FC<MinutesLitProps> = ({
     }
   }, [minutes, isTyping]);
 
-  const handleSelectMinute = useCallback(
-    (index: number, event: MouseEvent<HTMLButtonElement>) => {
-      onSelectMinute(index);
-      event.currentTarget?.blur();
-    },
-    [onSelectMinute],
-  );
+  const handleSelectMinute = (
+    index: number,
+    event: MouseEvent<HTMLButtonElement>,
+  ) => {
+    onSelectMinute(index);
+    event.currentTarget?.blur();
+  };
 
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
-      const buttons = wrapperRef.current?.querySelectorAll('button');
-      if (!buttons) return;
+  const handleKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    currentIndex: number,
+  ) => {
+    const buttons = wrapperRef.current?.querySelectorAll('button');
+    if (!buttons) return;
 
-      let nextIndex = currentIndex;
+    let nextIndex = currentIndex;
 
-      if (
-        event.key === 'ArrowDown' ||
-        (event.key === 'Tab' && !event.shiftKey)
-      ) {
-        event.preventDefault();
-        nextIndex = (currentIndex + 1) % 60;
-      } else if (
-        event.key === 'ArrowUp' ||
-        (event.key === 'Tab' && event.shiftKey)
-      ) {
-        event.preventDefault();
-        nextIndex = (currentIndex - 1 + 60) % 60;
-      } else if (event.key === 'Enter') {
-        event.preventDefault();
-        // Select the minute
-        onSelectMinute(currentIndex);
-        // If onClose is provided (24h format), close the list
-        if (onClose) {
-          onClose();
-          return;
-        }
-        // Otherwise move focus to meridian list (AM/PM)
-        const meridianList = document.querySelector('[aria-label="meridian"]');
-        const activeMeridianButton = meridianList?.querySelector(
-          'li[data-active="true"] button',
-        ) as HTMLButtonElement;
-        activeMeridianButton?.focus();
+    if (event.key === 'ArrowDown' || (event.key === 'Tab' && !event.shiftKey)) {
+      event.preventDefault();
+      nextIndex = (currentIndex + 1) % 60;
+    } else if (
+      event.key === 'ArrowUp' ||
+      (event.key === 'Tab' && event.shiftKey)
+    ) {
+      event.preventDefault();
+      nextIndex = (currentIndex - 1 + 60) % 60;
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      // Select the minute
+      onSelectMinute(currentIndex);
+      // If onClose is provided (24h format), close the list
+      if (onClose) {
+        onClose();
         return;
       }
+      // Otherwise move focus to meridian list (AM/PM)
+      const meridianList = document.querySelector('[aria-label="meridian"]');
+      const activeMeridianButton = meridianList?.querySelector(
+        'li[data-active="true"] button',
+      ) as HTMLButtonElement;
+      activeMeridianButton?.focus();
+      return;
+    }
 
-      if (nextIndex !== currentIndex) {
-        const nextButton = buttons[nextIndex] as HTMLButtonElement;
-        nextButton?.focus();
-      }
-    },
-    [onSelectMinute, onClose],
-  );
+    if (nextIndex !== currentIndex) {
+      const nextButton = buttons[nextIndex] as HTMLButtonElement;
+      nextButton?.focus();
+    }
+  };
 
   return (
     <ul

--- a/lib/components/TimePicker/components/Wrapper/Wrapper.tsx
+++ b/lib/components/TimePicker/components/Wrapper/Wrapper.tsx
@@ -59,131 +59,122 @@ export const Wrapper: FC<WrapperProps> = ({
     }
   }, [formattedTime]);
 
-  const handleOpen = useCallback(() => {
+  const handleOpen = () => {
     if (!disabled) {
       setIsOpen((status) => !status);
     }
-  }, [disabled]);
+  };
 
-  const handleInputFocus = useCallback(() => {
+  const handleInputFocus = () => {
     if (!disabled && showList) {
       setIsOpen(true);
     }
     // Clear error when focusing
     setInternalError(undefined);
-  }, [disabled, showList]);
+  };
 
   // Reset typing flag when clicking on the list (before blur fires)
-  const handleWrapperMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      // If clicking inside wrapper but not on the input, it's a list click
-      if (e.target !== inputRef.current) {
-        isTypingRef.current = false;
-        setIsTyping(false);
-      }
-    },
-    [setIsTyping],
-  );
-
-  const handleInputBlur = useCallback(
-    (e: FocusEvent<HTMLInputElement>) => {
-      // Don't close if clicking inside the wrapper (e.g., on the list)
-      if (wrapperRef.current?.contains(e.relatedTarget as Node)) {
-        return;
-      }
+  const handleWrapperMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    // If clicking inside wrapper but not on the input, it's a list click
+    if (e.target !== inputRef.current) {
       isTypingRef.current = false;
       setIsTyping(false);
-      setIsOpen(false);
+    }
+  };
 
-      // Validate and update time on blur - read directly from event target
-      const value = e.currentTarget.value.trim();
-      if (value === '') {
-        setInternalError(undefined);
-        return;
-      }
+  const handleInputBlur = (e: FocusEvent<HTMLInputElement>) => {
+    // Don't close if clicking inside the wrapper (e.g., on the list)
+    if (wrapperRef.current?.contains(e.relatedTarget as Node)) {
+      return;
+    }
+    isTypingRef.current = false;
+    setIsTyping(false);
+    setIsOpen(false);
 
-      const parsed = parseTimeString(value, format);
-      if (parsed) {
-        setInternalError(undefined);
-        setTimeDirectly(parsed);
+    // Validate and update time on blur - read directly from event target
+    const value = e.currentTarget.value.trim();
+    if (value === '') {
+      setInternalError(undefined);
+      return;
+    }
 
-        // Auto-format the input value
-        const hours = parsed.getHours();
-        const minutes = parsed.getMinutes().toString().padStart(2, '0');
+    const parsed = parseTimeString(value, format);
+    if (parsed) {
+      setInternalError(undefined);
+      setTimeDirectly(parsed);
 
-        if (format === '24') {
-          setInputValue(`${hours.toString().padStart(2, '0')}:${minutes}`);
-        } else {
-          // 12-hour format
-          const displayHours = hours % 12 || 12;
-          const meridian = hours >= 12 ? 'PM' : 'AM';
-          setInputValue(`${displayHours}:${minutes} ${meridian}`);
-        }
+      // Auto-format the input value
+      const hours = parsed.getHours();
+      const minutes = parsed.getMinutes().toString().padStart(2, '0');
+
+      if (format === '24') {
+        setInputValue(`${hours.toString().padStart(2, '0')}:${minutes}`);
       } else {
-        setInternalError('Invalid time');
+        // 12-hour format
+        const displayHours = hours % 12 || 12;
+        const meridian = hours >= 12 ? 'PM' : 'AM';
+        setInputValue(`${displayHours}:${minutes} ${meridian}`);
       }
-    },
-    [format, setTimeDirectly, setIsTyping],
-  );
+    } else {
+      setInternalError('Invalid time');
+    }
+  };
 
-  const handleInputChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const rawValue = e.target.value;
-      let value = '';
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const rawValue = e.target.value;
+    let value = '';
 
-      // Mark as typing to prevent sync from overwriting and enable list scroll
-      isTypingRef.current = true;
-      setIsTyping(true);
+    // Mark as typing to prevent sync from overwriting and enable list scroll
+    isTypingRef.current = true;
+    setIsTyping(true);
 
-      // Detect if user is deleting (new value is shorter)
-      const isDeleting = rawValue.length < inputValue.length;
+    // Detect if user is deleting (new value is shorter)
+    const isDeleting = rawValue.length < inputValue.length;
 
-      if (format === '12') {
-        // 12-hour format: allow typing patterns like "1:30 PM", "12:00 AM"
-        // Max length: 8 characters (e.g., "12:00 PM")
-        const filtered = rawValue
-          .replace(/[^0-9:apmAPM\s]/g, '')
-          .replace(/[apm]/gi, (char) => char.toUpperCase());
+    if (format === '12') {
+      // 12-hour format: allow typing patterns like "1:30 PM", "12:00 AM"
+      // Max length: 8 characters (e.g., "12:00 PM")
+      const filtered = rawValue
+        .replace(/[^0-9:apmAPM\s]/g, '')
+        .replace(/[apm]/gi, (char) => char.toUpperCase());
 
-        // Validate structure as user types
-        const match = filtered.match(/^(\d{0,2}):?(\d{0,2})\s?(A|AM|P|PM)?$/i);
-        if (match || filtered === '') {
-          value = filtered.slice(0, 8);
-
-          // Auto-insert colon after 2 digits if no colon exists (only when not deleting)
-          if (!isDeleting && /^\d{2}$/.test(value)) {
-            value = value + ':';
-          }
-        } else {
-          // Keep previous valid value
-          value = inputValue;
-        }
-      } else {
-        // 24-hour format: only digits and colon, max 5 chars (e.g., "23:59")
-        // Remove invalid chars and ensure only one colon
-        value = rawValue
-          .replace(/[^0-9:]/g, '')
-          .replace(/:+/g, ':') // Replace multiple colons with single colon
-          .slice(0, 5);
+      // Validate structure as user types
+      const match = filtered.match(/^(\d{0,2}):?(\d{0,2})\s?(A|AM|P|PM)?$/i);
+      if (match || filtered === '') {
+        value = filtered.slice(0, 8);
 
         // Auto-insert colon after 2 digits if no colon exists (only when not deleting)
         if (!isDeleting && /^\d{2}$/.test(value)) {
           value = value + ':';
         }
+      } else {
+        // Keep previous valid value
+        value = inputValue;
       }
+    } else {
+      // 24-hour format: only digits and colon, max 5 chars (e.g., "23:59")
+      // Remove invalid chars and ensure only one colon
+      value = rawValue
+        .replace(/[^0-9:]/g, '')
+        .replace(/:+/g, ':') // Replace multiple colons with single colon
+        .slice(0, 5);
 
-      setInputValue(value);
-      // Clear error while typing
-      setInternalError(undefined);
-
-      // Try to parse and update time as user types (for list sync)
-      const parsed = parseTimeString(value, format);
-      if (parsed) {
-        setTimeDirectly(parsed);
+      // Auto-insert colon after 2 digits if no colon exists (only when not deleting)
+      if (!isDeleting && /^\d{2}$/.test(value)) {
+        value = value + ':';
       }
-    },
-    [format, inputValue, setTimeDirectly, setIsTyping],
-  );
+    }
+
+    setInputValue(value);
+    // Clear error while typing
+    setInternalError(undefined);
+
+    // Try to parse and update time as user types (for list sync)
+    const parsed = parseTimeString(value, format);
+    if (parsed) {
+      setTimeDirectly(parsed);
+    }
+  };
 
   const handleClickOutside = useCallback(() => {
     setIsOpen(false);

--- a/lib/components/TimePicker/components/WrapperList/WrapperList.tsx
+++ b/lib/components/TimePicker/components/WrapperList/WrapperList.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react';
+import { FC } from 'react';
 
 import { cn } from '@/utils';
 
@@ -19,8 +19,8 @@ export const WrapperList: FC<WrapperListProps> = ({
   onClose,
 }) => {
   const { time, format } = useTimePickerContext();
-  const selectedHours = useMemo(() => getHours(time), [time]);
-  const selectedMinutes = useMemo(() => getMinutes(time), [time]);
+  const selectedHours = getHours(time);
+  const selectedMinutes = getMinutes(time);
 
   if (!isOpen) {
     return null;

--- a/lib/components/TimePicker/contexts/time-picker.provider.tsx
+++ b/lib/components/TimePicker/contexts/time-picker.provider.tsx
@@ -1,11 +1,4 @@
-import {
-  FC,
-  PropsWithChildren,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { FC, PropsWithChildren, useCallback, useEffect, useState } from 'react';
 
 import { TimePickerProps } from '../TimePicker.types';
 import { getFormattedTime } from '../utils';
@@ -22,7 +15,7 @@ export const TimePickerProvider: FC<
   const [format, setFormat] = useState(defaultFormat);
   const [time, setTime] = useState<Date | undefined>(() => defaultTime);
   const [isTyping, setIsTyping] = useState(false);
-  const isAM = useMemo(() => (time ? time.getHours() < 12 : true), [time]);
+  const isAM = time ? time.getHours() < 12 : true;
 
   const updateTime = useCallback(
     (newTime: Date) => {

--- a/lib/components/Toast/Toast.tsx
+++ b/lib/components/Toast/Toast.tsx
@@ -9,14 +9,7 @@ import {
   Viewport,
 } from '@radix-ui/react-toast';
 import { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
-import {
-  FC,
-  isValidElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import { FC, isValidElement, useEffect, useRef } from 'react';
 import { X } from 'react-feather';
 
 import {
@@ -77,26 +70,22 @@ export const Toast: FC<Props> = ({
     return () => clearTimeout(timerRef.current);
   }, []);
 
-  const titleResult = useMemo(() => {
-    if (isValidElement(title)) {
-      return <Slot className={titleClassName}>{title}</Slot>;
-    }
+  const titleResult = isValidElement(title) ? (
+    <Slot className={titleClassName}>{title}</Slot>
+  ) : (
+    title
+  );
 
-    return title;
-  }, [title, titleClassName]);
+  const descriptionResult = isValidElement(description) ? (
+    <Slot className={descriptionClassName}>{description}</Slot>
+  ) : (
+    description
+  );
 
-  const descriptionResult = useMemo(() => {
-    if (isValidElement(description)) {
-      return <Slot className={descriptionClassName}>{description}</Slot>;
-    }
-
-    return description;
-  }, [description, descriptionClassName]);
-
-  const handleClick = useCallback(() => {
+  const handleClick = () => {
     setOpen(false);
     timerRef.current = window.setTimeout(() => setOpen(true), 100);
-  }, [setOpen]);
+  };
 
   return (
     <Provider swipeDirection="right" duration={duration}>


### PR DESCRIPTION
## Summary

Requested review of the memoization added over time (stacked on #677). All **200 `useCallback`/`useMemo` sites** in `lib/` were analyzed individually: **76 removed, 102 kept** with a concrete justification each (the rest were in files with no changes needed).

## Criteria

**Removed** — identity consumed by nothing:
- Handlers attached only to DOM elements or non-memoized components (Radio, Slider, Counter, Alert, Badge, Checkbox, TimePicker lists, Filter dropdown apply/reset handlers, Stepper, Autocomplete, AlertDialog…). Radix callback props are wrapped in `useCallbackRef` internally, so they aren't identity-sensitive either.
- `useMemo` over trivial expressions (ternaries, small literals, one-liner Date getters) with no identity consumers (`isAM`, `translateClass`, Toast's conditional JSX, DateRangePicker passthroughs).

**Kept** — a real reason exists:
- Context provider values and the callbacks that feed them (all providers).
- Dependencies of effects or identity-sensitive hooks: `useClickOutside`, `useFilterDropdownSync`, `TruncateText`'s resize handler, Drawer's resize listeners, cmdk's `onSelect` (verified in its dist: it re-attaches a listener when `onSelect` changes), DatePicker/TimePicker `onChange` chains that land in provider dep arrays.
- `memo()` children props (ButtonGroup items, Stepper items).
- Real computations: countries list, filtered options, calendar height math, chart.js `data`/`options`/`plugins` (identity drives `redraw`), TanStack Table column config.
- `useToggle`: public API stability contract.

Net: **−182 lines**, less noise, and every remaining memoization now has a purpose you can point to.

## Testing
Full suite green: 558 tests, lint (react-hooks rules clean), types, prettier.