### PR TITLE
✨ feat: add Sidebar collapse trigger and logo visibility options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ coverage
 /.fnpm
 bun.lockb
 bun.lock
+yarn.lock
+pnpm-lock.yaml
+deno.lock

--- a/lib/components/Sidebar/Sidebar.css
+++ b/lib/components/Sidebar/Sidebar.css
@@ -137,9 +137,10 @@ aside.konstruct-sidebar[data-mode='collapsed'] {
 }
 
 /*
- * Hidden logo in collapsed mode (`hideOnCollapse`, the default). The logo
- * content hides but a direct-child CollapseTrigger stays visible, and the
- * header keeps vertical padding so the trigger doesn't touch the top edge.
+ * Hidden logo in collapsed mode (the default, unless `showOnCollapse` is
+ * set). The logo content hides but a direct-child CollapseTrigger stays
+ * visible, and the header keeps vertical padding so the trigger doesn't
+ * touch the top edge.
  */
 .konstruct-sidebar[data-mode='collapsed']
   [data-konstruct-sidebar-logo][data-hide-on-collapse]

--- a/lib/components/Sidebar/Sidebar.css
+++ b/lib/components/Sidebar/Sidebar.css
@@ -137,6 +137,25 @@ aside.konstruct-sidebar[data-mode='collapsed'] {
 }
 
 /*
+ * Hidden logo in collapsed mode (`hideOnCollapse`, the default). The logo
+ * content hides but a direct-child CollapseTrigger stays visible, and the
+ * header keeps vertical padding so the trigger doesn't touch the top edge.
+ */
+.konstruct-sidebar[data-mode='collapsed']
+  [data-konstruct-sidebar-logo][data-hide-on-collapse]
+  > *:not([data-konstruct-sidebar-collapse-trigger]) {
+  display: none;
+}
+.konstruct-sidebar[data-mode='collapsed']
+  [data-konstruct-sidebar-logo][data-hide-on-collapse] {
+  margin-bottom: 0;
+  padding: var(
+    --konstruct-sidebar-logo-padding-collapsed,
+    var(--konstruct-sidebar-logo-padding, 1.25rem 0)
+  );
+}
+
+/*
  * Auto-inserted separator between consecutive NavigationGroups.
  * Mirrors the Tailwind variant (`h-px w-full bg-white/20 my-3`) as plain
  * CSS so it survives un-layered overrides from MFE bundles.

--- a/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/lib/components/Sidebar/Sidebar.stories.tsx
@@ -89,9 +89,10 @@ const meta = {
 const renderSidebarContent = (
   theme: Theme,
   onThemeChange: (next: Theme) => void,
+  hideLogoOnCollapse = true,
 ) => (
   <>
-    <Logo>
+    <Logo hideOnCollapse={hideLogoOnCollapse}>
       <a className="flex items-center w-full">
         <img
           className="hidden group-data-[mode=expanded]/sidebar:block w-auto h-auto max-w-full"
@@ -180,6 +181,18 @@ export const CollapsedMode = {
     return (
       <SidebarPrimitive theme={theme} mode="collapsed">
         {renderSidebarContent(theme, setTheme)}
+      </SidebarPrimitive>
+    );
+  },
+} satisfies Story;
+
+export const CollapsedModeWithVisibleLogo = {
+  render: function CollapsedVisibleLogoStory() {
+    const [theme, setTheme] = useState<Theme>('kubefirst');
+
+    return (
+      <SidebarPrimitive theme={theme} mode="collapsed">
+        {renderSidebarContent(theme, setTheme, false)}
       </SidebarPrimitive>
     );
   },

--- a/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/lib/components/Sidebar/Sidebar.stories.tsx
@@ -89,10 +89,10 @@ const meta = {
 const renderSidebarContent = (
   theme: Theme,
   onThemeChange: (next: Theme) => void,
-  hideLogoOnCollapse = true,
+  showLogoOnCollapse = false,
 ) => (
   <>
-    <Logo hideOnCollapse={hideLogoOnCollapse}>
+    <Logo showOnCollapse={showLogoOnCollapse}>
       <a className="flex items-center w-full">
         <img
           className="hidden group-data-[mode=expanded]/sidebar:block w-auto h-auto max-w-full"
@@ -192,7 +192,7 @@ export const CollapsedModeWithVisibleLogo = {
 
     return (
       <SidebarPrimitive theme={theme} mode="collapsed">
-        {renderSidebarContent(theme, setTheme, false)}
+        {renderSidebarContent(theme, setTheme, true)}
       </SidebarPrimitive>
     );
   },

--- a/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/lib/components/Sidebar/Sidebar.stories.tsx
@@ -13,6 +13,7 @@ import { Theme } from '@/domain/theme';
 
 import { Typography } from '../Typography/Typography';
 import {
+  CollapseTrigger,
   Footer,
   Label,
   Logo,
@@ -106,6 +107,7 @@ const renderSidebarContent = (
       <Typography variant="labelSmall" className="text-[#ABADC6] lowercase">
         v1.11.1
       </Typography>
+      <CollapseTrigger className="group-data-[mode=expanded]/sidebar:absolute group-data-[mode=expanded]/sidebar:right-4 group-data-[mode=expanded]/sidebar:top-5" />
     </Logo>
 
     <Navigation className="mt-4 group-data-[mode=expanded]/sidebar:mt-0">

--- a/lib/components/Sidebar/Sidebar.test.tsx
+++ b/lib/components/Sidebar/Sidebar.test.tsx
@@ -197,10 +197,10 @@ describe('Sidebar', () => {
       );
     });
 
-    it('keeps the logo content visible in collapsed mode when hideOnCollapse is false', () => {
+    it('keeps the logo content visible in collapsed mode when showOnCollapse is set', () => {
       const { container } = render(
         <Sidebar mode="collapsed">
-          <Logo hideOnCollapse={false}>
+          <Logo showOnCollapse>
             <span>Logo</span>
             <CollapseTrigger />
           </Logo>

--- a/lib/components/Sidebar/Sidebar.test.tsx
+++ b/lib/components/Sidebar/Sidebar.test.tsx
@@ -183,6 +183,42 @@ describe('Sidebar', () => {
       expect(screen.queryByText('Admin')).not.toBeInTheDocument();
     });
 
+    it('hides the logo content but keeps the collapse trigger in collapsed mode by default', () => {
+      const { container } = renderWithGroups('collapsed');
+
+      const logo = container.querySelector('[data-konstruct-sidebar-logo]');
+      const trigger = screen.getByRole('button', {
+        name: /expand navigation/i,
+      });
+
+      expect(logo).toHaveAttribute('data-hide-on-collapse');
+      expect(trigger).toHaveAttribute(
+        'data-konstruct-sidebar-collapse-trigger',
+      );
+    });
+
+    it('keeps the logo content visible in collapsed mode when hideOnCollapse is false', () => {
+      const { container } = render(
+        <Sidebar mode="collapsed">
+          <Logo hideOnCollapse={false}>
+            <span>Logo</span>
+            <CollapseTrigger />
+          </Logo>
+          <Navigation>
+            <NavigationGroup title="Main">
+              <NavigationOption>
+                <Label>Clusters</Label>
+              </NavigationOption>
+            </NavigationGroup>
+          </Navigation>
+        </Sidebar>,
+      );
+
+      const logo = container.querySelector('[data-konstruct-sidebar-logo]');
+
+      expect(logo).not.toHaveAttribute('data-hide-on-collapse');
+    });
+
     it('auto-inserts a separator between groups in collapsed mode', () => {
       const { container } = renderWithGroups('collapsed');
 

--- a/lib/components/Sidebar/Sidebar.test.tsx
+++ b/lib/components/Sidebar/Sidebar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { ReactNode } from 'react';
 
 import {
+  CollapseTrigger,
   Footer,
   Label,
   Logo,
@@ -126,7 +127,10 @@ describe('Sidebar', () => {
     ) =>
       render(
         <Sidebar mode={mode} {...extraProps}>
-          <Logo>Logo</Logo>
+          <Logo>
+            Logo
+            <CollapseTrigger />
+          </Logo>
           <Navigation>
             <NavigationGroup title="Main">
               <NavigationOption>
@@ -197,6 +201,70 @@ describe('Sidebar', () => {
       const separators = nav?.querySelectorAll(':scope > div') ?? [];
 
       expect(separators.length).toBe(0);
+    });
+
+    it('expands the sidebar when the collapse trigger is clicked in collapsed mode', async () => {
+      renderWithGroups('collapsed');
+
+      const user = userEvent.setup();
+      const trigger = screen.getByRole('button', {
+        name: /expand navigation/i,
+      });
+
+      expect(document.querySelector('aside')).toHaveAttribute(
+        'data-mode',
+        'collapsed',
+      );
+
+      await user.click(trigger);
+
+      expect(document.querySelector('aside')).toHaveAttribute(
+        'data-mode',
+        'expanded',
+      );
+      expect(screen.getByText('Main')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /collapse navigation/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('collapses the sidebar when the collapse trigger is clicked in expanded mode', async () => {
+      renderWithGroups('expanded');
+
+      const user = userEvent.setup();
+      const trigger = screen.getByRole('button', {
+        name: /collapse navigation/i,
+      });
+
+      await user.click(trigger);
+
+      expect(document.querySelector('aside')).toHaveAttribute(
+        'data-mode',
+        'collapsed',
+      );
+      expect(screen.queryByText('Main')).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /expand navigation/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not render the collapse trigger in drawer mode', async () => {
+      renderWithGroups('drawer');
+
+      const user = userEvent.setup();
+      const trigger = screen.getByRole('button', {
+        name: /open navigation/i,
+      });
+
+      await user.click(trigger);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', { name: /collapse navigation/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /expand navigation/i }),
+      ).not.toBeInTheDocument();
     });
 
     it('renders a hamburger trigger and hides the aside in drawer mode', async () => {

--- a/lib/components/Sidebar/Sidebar.tsx
+++ b/lib/components/Sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@
 import { FC } from 'react';
 
 import {
+  CollapseTrigger,
   Footer,
   Label,
   Logo,
@@ -44,6 +45,7 @@ const Sidebar: FC<SidebarProps> & SidebarChildrenProps = (props) => (
 
 Sidebar.displayName = 'KonstructSidebar';
 
+Sidebar.CollapseTrigger = CollapseTrigger;
 Sidebar.Footer = Footer;
 Sidebar.Label = Label;
 Sidebar.Logo = Logo;
@@ -53,6 +55,7 @@ Sidebar.NavigationOption = NavigationOption;
 Sidebar.NavigationSeparator = NavigationSeparator;
 
 export {
+  CollapseTrigger,
   Footer,
   Label,
   Logo,

--- a/lib/components/Sidebar/Sidebar.types.ts
+++ b/lib/components/Sidebar/Sidebar.types.ts
@@ -7,6 +7,7 @@ import { Theme } from '@/domain/theme';
 import { SidebarModeProp } from './hooks/useSidebarMode';
 import { wrapperSiderbarVariants } from './Sidebar.variants';
 import {
+  CollapseTriggerProps,
   FooterProps,
   LabelProps,
   LogoProps,
@@ -135,6 +136,7 @@ export type SidebarProps = Props;
  * Sidebar compound component type with sub-components.
  */
 export type SidebarChildrenProps = {
+  CollapseTrigger: FC<CollapseTriggerProps>;
   Footer: FC<FooterProps>;
   Label: FC<LabelProps>;
   Logo: FC<LogoProps>;

--- a/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.tsx
+++ b/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.tsx
@@ -20,6 +20,7 @@ const CollapseTrigger: FC<Props> = ({ className }) => {
   return (
     <button
       type="button"
+      data-konstruct-sidebar-collapse-trigger=""
       aria-label={label}
       aria-expanded={!isCollapsed}
       className={cn(collapseTriggerVariants({ className }))}

--- a/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.tsx
+++ b/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.tsx
@@ -1,0 +1,42 @@
+import { FC } from 'react';
+
+import { ArrowLeftIcon, ArrowRightIcon } from '@/assets/icons/components';
+import { cn } from '@/utils';
+
+import { useSidebarContext } from '../../contexts';
+
+import { Props } from './CollapseTrigger.types';
+import { collapseTriggerVariants } from './CollapseTrigger.variants';
+
+const CollapseTrigger: FC<Props> = ({ className }) => {
+  const { isCollapsed, canToggle, toggleMode } = useSidebarContext();
+
+  if (!canToggle) {
+    return null;
+  }
+
+  const label = isCollapsed ? 'Expand navigation' : 'Collapse navigation';
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-expanded={!isCollapsed}
+      className={cn(collapseTriggerVariants({ className }))}
+      onClick={(event) => {
+        event.stopPropagation();
+        toggleMode();
+      }}
+    >
+      {isCollapsed ? (
+        <ArrowRightIcon size={24} aria-hidden="true" />
+      ) : (
+        <ArrowLeftIcon size={24} aria-hidden="true" />
+      )}
+    </button>
+  );
+};
+
+CollapseTrigger.displayName = 'KonstructSidebarCollapseTrigger';
+
+export { CollapseTrigger };

--- a/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.types.ts
+++ b/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.types.ts
@@ -1,0 +1,5 @@
+export interface Props {
+  className?: string;
+}
+
+export type CollapseTriggerProps = Props;

--- a/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.variants.ts
+++ b/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.variants.ts
@@ -1,0 +1,18 @@
+import { cva } from 'class-variance-authority';
+
+export const collapseTriggerVariants = cva([
+  'inline-flex',
+  'items-center',
+  'justify-center',
+  'shrink-0',
+  'p-1',
+  'rounded',
+  'border',
+  'border-metal-700',
+  'text-metal-50',
+  'cursor-pointer',
+  'hover:bg-metal-800',
+  'focus:outline-none',
+  'focus-visible:ring-2',
+  'focus-visible:ring-white/40',
+]);

--- a/lib/components/Sidebar/components/Logo/Logo.tsx
+++ b/lib/components/Sidebar/components/Logo/Logo.tsx
@@ -7,14 +7,14 @@ import { useSidebarContext } from '../../contexts';
 import { Props } from './Logo.types';
 import { logoVariants } from './Logo.variants';
 
-const Logo: FC<Props> = ({ children, className, hideOnCollapse = true }) => {
+const Logo: FC<Props> = ({ children, className, showOnCollapse = false }) => {
   const { closeDrawer } = useSidebarContext();
 
   return (
     <header
       data-konstruct-sidebar-logo=""
-      data-hide-on-collapse={hideOnCollapse ? '' : undefined}
-      className={cn(logoVariants({ hideOnCollapse, className }))}
+      data-hide-on-collapse={showOnCollapse ? undefined : ''}
+      className={cn(logoVariants({ showOnCollapse, className }))}
       onClick={() => closeDrawer()}
     >
       {children}

--- a/lib/components/Sidebar/components/Logo/Logo.tsx
+++ b/lib/components/Sidebar/components/Logo/Logo.tsx
@@ -7,13 +7,14 @@ import { useSidebarContext } from '../../contexts';
 import { Props } from './Logo.types';
 import { logoVariants } from './Logo.variants';
 
-const Logo: FC<Props> = ({ children, className }) => {
+const Logo: FC<Props> = ({ children, className, hideOnCollapse = true }) => {
   const { closeDrawer } = useSidebarContext();
 
   return (
     <header
       data-konstruct-sidebar-logo=""
-      className={cn(logoVariants({ className }))}
+      data-hide-on-collapse={hideOnCollapse ? '' : undefined}
+      className={cn(logoVariants({ hideOnCollapse, className }))}
       onClick={() => closeDrawer()}
     >
       {children}

--- a/lib/components/Sidebar/components/Logo/Logo.types.ts
+++ b/lib/components/Sidebar/components/Logo/Logo.types.ts
@@ -7,13 +7,13 @@ export interface Props
   extends PropsWithChildren, VariantProps<typeof logoVariants> {
   className?: string;
   /**
-   * When true, hides the logo content while the sidebar is in `collapsed`
-   * mode. A `Sidebar.CollapseTrigger` placed as a direct child of
+   * When true, keeps the logo content visible while the sidebar is in
+   * `collapsed` mode. By default the logo content hides in collapsed mode,
+   * while a `Sidebar.CollapseTrigger` placed as a direct child of
    * `Sidebar.Logo` stays visible so the user can still expand the sidebar.
-   * Pass `false` to keep the logo content visible in collapsed mode.
-   * Defaults to `true`.
+   * Defaults to `false`.
    */
-  hideOnCollapse?: boolean;
+  showOnCollapse?: boolean;
 }
 
 /** @deprecated Use Props instead */

--- a/lib/components/Sidebar/components/Logo/Logo.types.ts
+++ b/lib/components/Sidebar/components/Logo/Logo.types.ts
@@ -6,6 +6,14 @@ import { logoVariants } from './Logo.variants';
 export interface Props
   extends PropsWithChildren, VariantProps<typeof logoVariants> {
   className?: string;
+  /**
+   * When true, hides the logo content while the sidebar is in `collapsed`
+   * mode. A `Sidebar.CollapseTrigger` placed as a direct child of
+   * `Sidebar.Logo` stays visible so the user can still expand the sidebar.
+   * Pass `false` to keep the logo content visible in collapsed mode.
+   * Defaults to `true`.
+   */
+  hideOnCollapse?: boolean;
 }
 
 /** @deprecated Use Props instead */

--- a/lib/components/Sidebar/components/Logo/Logo.variants.ts
+++ b/lib/components/Sidebar/components/Logo/Logo.variants.ts
@@ -26,17 +26,17 @@ export const logoVariants = cva(
   ],
   {
     variants: {
-      hideOnCollapse: {
-        true: [
+      showOnCollapse: {
+        true: null,
+        false: [
           'group-data-[mode=collapsed]/sidebar:[&>*:not([data-konstruct-sidebar-collapse-trigger])]:hidden',
           'group-data-[mode=collapsed]/sidebar:py-5',
           'group-data-[mode=collapsed]/sidebar:mb-0',
         ],
-        false: null,
       },
     },
     defaultVariants: {
-      hideOnCollapse: true,
+      showOnCollapse: false,
     },
   },
 );

--- a/lib/components/Sidebar/components/Logo/Logo.variants.ts
+++ b/lib/components/Sidebar/components/Logo/Logo.variants.ts
@@ -1,25 +1,42 @@
 import { cva } from 'class-variance-authority';
 
-export const logoVariants = cva([
-  'group-data-[mode=expanded]/sidebar:px-4',
-  'group-data-[mode=expanded]/sidebar:py-5',
-  'flex',
-  'flex-col',
-  'justify-center',
-  'group-data-[mode=collapsed]/sidebar:items-center',
-  'group-data-[mode=collapsed]/sidebar:[&>a]:justify-center',
-  'group-data-[mode=collapsed]/sidebar:[&>p]:text-center',
-  'group-data-[mode=collapsed]/sidebar:[&>p]:pt-1',
-  'gap-1',
-  'group',
-  'relative',
-  'mb-8',
-  'group-data-[mode=expanded]/sidebar:[&>p]:pl-14',
-  '[&>p]:-mt-2',
-  '[&>img]:pt-3',
-  '[&>*>p]:absolute',
-  '[&>*>p]:bottom-0',
-  '[&>*>p]:-mt-2',
-  '[&>*>img]:pt-3',
-  'cursor-pointer',
-]);
+export const logoVariants = cva(
+  [
+    'group-data-[mode=expanded]/sidebar:px-4',
+    'group-data-[mode=expanded]/sidebar:py-5',
+    'flex',
+    'flex-col',
+    'justify-center',
+    'group-data-[mode=collapsed]/sidebar:items-center',
+    'group-data-[mode=collapsed]/sidebar:[&>a]:justify-center',
+    'group-data-[mode=collapsed]/sidebar:[&>p]:text-center',
+    'group-data-[mode=collapsed]/sidebar:[&>p]:pt-1',
+    'gap-1',
+    'group',
+    'relative',
+    'mb-8',
+    'group-data-[mode=expanded]/sidebar:[&>p]:pl-14',
+    '[&>p]:-mt-2',
+    '[&>img]:pt-3',
+    '[&>*>p]:absolute',
+    '[&>*>p]:bottom-0',
+    '[&>*>p]:-mt-2',
+    '[&>*>img]:pt-3',
+    'cursor-pointer',
+  ],
+  {
+    variants: {
+      hideOnCollapse: {
+        true: [
+          'group-data-[mode=collapsed]/sidebar:[&>*:not([data-konstruct-sidebar-collapse-trigger])]:hidden',
+          'group-data-[mode=collapsed]/sidebar:py-5',
+          'group-data-[mode=collapsed]/sidebar:mb-0',
+        ],
+        false: null,
+      },
+    },
+    defaultVariants: {
+      hideOnCollapse: true,
+    },
+  },
+);

--- a/lib/components/Sidebar/components/Wrapper/Wrapper.tsx
+++ b/lib/components/Sidebar/components/Wrapper/Wrapper.tsx
@@ -47,6 +47,15 @@ const Wrapper: FC<Props> = ({
   );
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [viewportWidth, setViewportWidth] = useState<number | null>(null);
+  // User-driven expand/collapse override (set via `toggleMode`, e.g. the
+  // CollapseTrigger). Wins over the viewport-derived mode until the
+  // viewport crosses a breakpoint, then resets so `auto` stays in charge.
+  const [modeOverride, setModeOverride] = useState<Exclude<
+    SidebarMode,
+    'drawer'
+  > | null>(null);
+  const effectiveMode: SidebarMode =
+    resolvedMode === 'drawer' ? 'drawer' : (modeOverride ?? resolvedMode);
 
   const dragRef = useRef<ComponentRef<'div'>>(null);
   const asideRef = useRef<ComponentRef<'aside'>>(null);
@@ -137,21 +146,23 @@ const Wrapper: FC<Props> = ({
   );
 
   useEffect(() => {
-    if (resolvedMode !== 'expanded' && asideRef.current) {
+    if (effectiveMode !== 'expanded' && asideRef.current) {
       asideRef.current.style.width = '';
     }
-  }, [resolvedMode]);
+  }, [effectiveMode]);
 
   useEffect(() => {
     if (resolvedMode !== 'drawer') {
       setIsDrawerOpen(false);
     }
+
+    setModeOverride(null);
   }, [resolvedMode]);
 
   useEffect(() => {
     if (
       hasAppliedInitialWidthRef.current ||
-      resolvedMode !== 'expanded' ||
+      effectiveMode !== 'expanded' ||
       !asideRef.current
     ) {
       return;
@@ -160,7 +171,7 @@ const Wrapper: FC<Props> = ({
     const clamped = Math.min(Math.max(initialWidth, minWith), maxWith);
     asideRef.current.style.width = `${clamped}px`;
     hasAppliedInitialWidthRef.current = true;
-  }, [initialWidth, maxWith, minWith, resolvedMode]);
+  }, [initialWidth, maxWith, minWith, effectiveMode]);
 
   const handleOpenDrawer = useCallback(() => {
     setIsDrawerOpen(true);
@@ -169,6 +180,14 @@ const Wrapper: FC<Props> = ({
   const handleCloseDrawer = useCallback(() => {
     setIsDrawerOpen(false);
   }, []);
+
+  const handleToggleMode = useCallback(() => {
+    setModeOverride((current) => {
+      const base = current ?? resolvedMode;
+
+      return base === 'collapsed' ? 'expanded' : 'collapsed';
+    });
+  }, [resolvedMode]);
 
   if (resolvedMode === 'drawer') {
     const drawerWidth =
@@ -209,6 +228,8 @@ const Wrapper: FC<Props> = ({
               animateOnHover: false,
               separatorClassName,
               closeDrawer: handleCloseDrawer,
+              canToggle: false,
+              toggleMode: () => {},
             }}
           >
             <div
@@ -224,7 +245,8 @@ const Wrapper: FC<Props> = ({
     );
   }
 
-  const asideMode: Exclude<SidebarMode, 'drawer'> = resolvedMode;
+  const asideMode: Exclude<SidebarMode, 'drawer'> =
+    modeOverride ?? resolvedMode;
   const showResizeHandle = canResize && asideMode === 'expanded';
   const contextValue = {
     mode: asideMode,
@@ -233,6 +255,8 @@ const Wrapper: FC<Props> = ({
     animateOnHover,
     separatorClassName,
     closeDrawer: handleCloseDrawer,
+    canToggle: true,
+    toggleMode: handleToggleMode,
   };
 
   return (

--- a/lib/components/Sidebar/components/index.ts
+++ b/lib/components/Sidebar/components/index.ts
@@ -1,3 +1,5 @@
+export * from './CollapseTrigger/CollapseTrigger';
+export type { CollapseTriggerProps } from './CollapseTrigger/CollapseTrigger.types';
 export * from './Footer/Footer';
 export type { FooterProps } from './Footer/Footer.types';
 export * from './HamburgerTrigger/HamburgerTrigger';

--- a/lib/components/Sidebar/contexts/SidebarContext.tsx
+++ b/lib/components/Sidebar/contexts/SidebarContext.tsx
@@ -14,6 +14,18 @@ export interface SidebarContextValue {
    * navigation events (e.g. when the user clicks a link).
    */
   closeDrawer: () => void;
+  /**
+   * Whether the sidebar can be toggled between `expanded` and `collapsed`.
+   * `false` in `drawer` mode, where the drawer's own open/close controls
+   * apply instead.
+   */
+  canToggle: boolean;
+  /**
+   * Toggles the sidebar between `expanded` and `collapsed`, overriding the
+   * viewport-derived mode until the viewport crosses a breakpoint. No-op in
+   * `drawer` mode.
+   */
+  toggleMode: () => void;
 }
 
 export const SidebarContext = createContext<SidebarContextValue>({
@@ -22,6 +34,8 @@ export const SidebarContext = createContext<SidebarContextValue>({
   expandOnHover: false,
   animateOnHover: true,
   closeDrawer: () => {},
+  canToggle: false,
+  toggleMode: () => {},
 });
 
 export const useSidebarContext = (): SidebarContextValue => {


### PR DESCRIPTION
## Summary

- Adds `Sidebar.CollapseTrigger`, a compound sub-component that toggles the sidebar between `expanded` and `collapsed`, letting users expand an auto-collapsed sidebar (viewport-derived mode). The user override wins until the viewport crosses a breakpoint, then `auto` takes over again. Hidden in `drawer` mode, where the drawer's own controls apply.
- Exposes `canToggle` / `toggleMode` through the Sidebar context.
- Hides the logo content in `collapsed` mode by default, while a direct-child `CollapseTrigger` stays visible so the sidebar can still be expanded. The header keeps vertical padding and drops its bottom margin so the trigger stays evenly spaced. Pass `showOnCollapse` to `Sidebar.Logo` to keep the logo content visible when collapsed.
- Hiding/padding rules are mirrored in the un-layered protection stylesheet (`sidebar.css`) so they survive CSS resets from federated micro-frontends, honoring the existing `--konstruct-sidebar-logo-padding-*` custom properties.
- Adds Storybook stories for the collapsed mode variations and ignores `yarn.lock` / `pnpm-lock.yaml` / `deno.lock`.

## Test plan

- [x] Unit tests for expand/collapse via the trigger, drawer-mode behavior, and logo visibility defaults (19 tests passing)
- [x] `npm run check:types` and `npm run lint` clean
- [x] Verified spacing in Storybook (`CollapsedMode` story): 20px top padding, no extra bottom margin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
