### PR TITLE
🐛 fix: stop the Select reopening when a Drawer or Modal returns focus

### DIFF
--- a/lib/components/Select/Select.test.tsx
+++ b/lib/components/Select/Select.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import userEvent, { UserEvent } from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { FC, FormEvent, PropsWithChildren, useState } from 'react';
 
 import { Button } from '@/components/Button/Button';
+import { Drawer } from '@/components/Drawer/Drawer';
 import { Modal } from '@/components/Modal/Modal';
 
 import { Select } from './Select';
@@ -218,6 +219,73 @@ describe('Select', () => {
       expect(screen.getByRole('textbox')).toHaveAttribute('tabindex', '-1');
     });
 
+    it('should not expand the combobox just by focusing it', async () => {
+      const { user, findComboBox } = setup();
+
+      const comboBox = await findComboBox();
+
+      await user.tab();
+
+      expect(comboBox).toHaveFocus();
+      expect(comboBox).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it.each(['{ArrowDown}', '{Enter}', ' '])(
+      'should open the list when pressing %s on the focused combobox',
+      async (key) => {
+        const { user, findComboBox } = setup();
+
+        const comboBox = await findComboBox();
+
+        await user.tab();
+        await user.keyboard(key);
+
+        expect(comboBox).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
+      },
+    );
+
+    it('should move the focus to the first option on the second ArrowDown', async () => {
+      const { user, findComboBox } = setup();
+
+      const comboBox = await findComboBox();
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+
+      expect(comboBox).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getAllByRole('option').at(0)).toHaveFocus();
+    });
+
+    it('should close the list when pressing Enter again on the combobox', async () => {
+      const { user, findComboBox } = setup();
+
+      const comboBox = await findComboBox();
+
+      await user.tab();
+      await user.keyboard('{Enter}');
+      await user.keyboard('{Enter}');
+
+      expect(comboBox).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('should allow typing spaces in the search input of a searchable select', async () => {
+      const { user, findComboBox } = setup({ searchable: true });
+
+      const comboBox = await findComboBox();
+
+      await user.click(comboBox);
+      await waitFor(() => {
+        expect(screen.getByRole('textbox')).toHaveFocus();
+      });
+      await user.keyboard('a b');
+
+      expect(screen.getByRole('textbox')).toHaveValue('a b');
+    });
+
     it('should render the labelAction next to the label', () => {
       setup({
         labelAction: <button type="button">Action</button>,
@@ -371,6 +439,44 @@ describe('Select', () => {
           name: defaultProps.name,
         },
       });
+    });
+  });
+
+  describe('select inside a drawer', () => {
+    const DrawerWrapper: FC<PropsWithChildren> = ({ children }) => {
+      const [isOpen, setIsOpen] = useState(false);
+
+      return (
+        <>
+          <Button onClick={() => setIsOpen(true)}>Open Drawer</Button>
+          <Drawer isOpen={isOpen} onClose={() => setIsOpen(false)}>
+            <Drawer.Body>{children}</Drawer.Body>
+          </Drawer>
+        </>
+      );
+    };
+
+    const openDrawer = async (user: UserEvent) => {
+      await user.click(
+        await screen.findByRole('button', { name: /open drawer/i }),
+      );
+    };
+
+    it('should stay closed after selecting an option when the drawer returns focus to the combobox', async () => {
+      const { user, findComboBox } = setup({}, DrawerWrapper);
+
+      await openDrawer(user);
+
+      const comboBox = await findComboBox();
+      await user.click(comboBox);
+
+      await user.click(screen.getByText(defaultProps.options[0].label));
+
+      await waitFor(() => {
+        expect(comboBox).toHaveFocus();
+      });
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(comboBox).toHaveAttribute('aria-expanded', 'false');
     });
   });
 });

--- a/lib/components/Select/components/Wrapper.tsx
+++ b/lib/components/Select/components/Wrapper.tsx
@@ -4,6 +4,7 @@ import {
   ComponentRef,
   forwardRef,
   ForwardRefExoticComponent,
+  KeyboardEvent,
   RefAttributes,
   useEffect,
   useId,
@@ -93,10 +94,8 @@ export const Wrapper: ForwardRefExoticComponent<
     }, [options, value]);
 
     const { wrapperRef, wrapperInputRef, handleOpen } = useSelect({
-      ulRef,
       inputRef,
       searchInputRef,
-      disabled,
       internalValue,
       onBlur,
     });
@@ -113,6 +112,34 @@ export const Wrapper: ForwardRefExoticComponent<
       }
 
       handleOpen();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<ComponentRef<'div'>>) => {
+      if (disabled) {
+        return;
+      }
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+
+        if (!isOpen) {
+          handleOpen();
+
+          return;
+        }
+
+        ulRef.current?.querySelector('li')?.focus();
+
+        return;
+      }
+
+      if (
+        event.target === event.currentTarget &&
+        (event.key === 'Enter' || event.key === ' ')
+      ) {
+        event.preventDefault();
+        handleToggleOpen();
+      }
     };
 
     const htmlFor = name ? `${id}-${name}` : id;
@@ -187,6 +214,7 @@ export const Wrapper: ForwardRefExoticComponent<
           )}
           role="combobox"
           onClick={handleToggleOpen}
+          onKeyDown={handleKeyDown}
           aria-expanded={isOpen}
           tabIndex={isWrapperInputFocusable.current}
           aria-labelledby={htmlFor}

--- a/lib/components/Select/hooks/useSelect.ts
+++ b/lib/components/Select/hooks/useSelect.ts
@@ -6,19 +6,15 @@ import { useSelectContext } from '../contexts';
 import { SelectProps, Option } from '../Select.types';
 
 type UseSelectParams = {
-  ulRef: RefObject<ComponentRef<'ul'> | null>;
   inputRef?: RefObject<ComponentRef<'input'> | null>;
   searchInputRef?: RefObject<ComponentRef<'input'> | null>;
-  disabled: boolean;
   internalValue?: Option;
   onBlur?: SelectProps['onBlur'];
 };
 
 export const useSelect = ({
-  ulRef,
   inputRef,
   searchInputRef,
-  disabled,
   internalValue,
   onBlur,
 }: UseSelectParams) => {
@@ -57,42 +53,10 @@ export const useSelect = ({
       },
     );
 
-    wrapperInputRef.current?.addEventListener(
-      'focusin',
-      (event: FocusEvent) => {
-        if (!disabled && (event.target as Element)?.matches(':focus-visible')) {
-          toggleOpen(true);
-        }
-      },
-      { signal: controller.signal },
-    );
-
     return () => {
       controller.abort();
     };
   }, [toggleOpen, wrapperRef]);
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    wrapperInputRef.current?.addEventListener(
-      'keydown',
-      (event: KeyboardEvent) => {
-        if (event.key === 'ArrowDown') {
-          const firstItem = ulRef.current?.querySelector('li');
-
-          if (firstItem) {
-            firstItem.focus();
-          }
-        }
-      },
-      { signal: controller.signal },
-    );
-
-    return () => {
-      controller.abort();
-    };
-  }, [wrapperInputRef, ulRef]);
 
   useEffect(() => {
     const controller = new AbortController();


### PR DESCRIPTION
## What

Stops the `Select` from reopening its listbox when a `Drawer` or `Modal` returns focus to the combobox, and moves opening to explicit keyboard intent.

- `useSelect` no longer opens the list from a `focusin` whose target matches `:focus-visible`.
- The combobox gets an `onKeyDown`: `ArrowDown` opens and, once open, moves focus to the first option; `Enter`/`Space` toggle it, but only while the combobox itself holds focus.
- Both imperative `addEventListener` calls in `useSelect` are consolidated into that React handler, where `isOpen` can never be stale.

## Why

`0.1.2-alpha.104` wrapped the `Modal` and `Drawer` panels in `react-focus-lock` (#672). That made every `Select` inside them unusable:

1. Clicking an option focuses the `<li>`.
2. `toggleOpen(false)` unmounts the list, so the focused element disappears.
3. The focus lock returns focus into the panel — the `div[role="combobox"]`.
4. That fired the `focusin` listener which opened the list whenever the target matched `:focus-visible`.

The list reopened immediately and covered every field below it, so the form could not be filled in at all. Verified in a real browser (see below).

Opening on focus was wrong regardless of the focus lock: per the ARIA [select-only combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/), focus alone must not expand the listbox — `ArrowDown`, `Enter` and `Space` are the open keys. Keeping `Enter`/`Space` scoped to `event.target === event.currentTarget` means both keys still reach the search input of a searchable `Select`.

## Testing

- `vitest run` — 574/574 pass.
- `npm run check:types`, `npm run lint`, `prettier --check` — clean.
- 6 new tests in `Select.test.tsx`. The 4 keyboard-open ones fail on `main` and pass here (confirmed by stashing only the source changes), plus one asserting focus alone does not expand and one for a `Select` inside a `Drawer`.
- Real-browser check with this branch built and dropped into `civo/dashboard/dns-micro-frontend` (whose `add-record` Cypress spec is what surfaced the bug): e2e **13/13** (was 12/13) and visual regression **8/8**, including the `domain-records-after-create` snapshot.

Worth noting: **jsdom returns `false` for `matches(':focus-visible')` on every element**, so the `focusin` branch was dead code under unit tests. That is why the existing *"should close select list after selecting an option in modal"* test stayed green while the behaviour was broken in real browsers.
