### PR TITLE
🐛 fix: select all re-selects items after deselection in Filter multiselects

### DIFF
--- a/lib/components/Checkbox/Checkbox.test.tsx
+++ b/lib/components/Checkbox/Checkbox.test.tsx
@@ -78,6 +78,53 @@ describe('Checkbox', () => {
     expect(checkbox).toBeDisabled();
   });
 
+  describe('Controlled', () => {
+    it('should render checked when the checked prop is true', async () => {
+      const { getCheckbox } = setup({ checked: true });
+
+      const checkbox = await getCheckbox();
+
+      expect(checkbox).toBeChecked();
+    });
+
+    it('should render unchecked when the checked prop is false', async () => {
+      const { getCheckbox } = setup({ checked: false });
+
+      const checkbox = await getCheckbox();
+
+      expect(checkbox).not.toBeChecked();
+    });
+
+    it('should call onChange without changing the visual state until the prop changes', async () => {
+      const onChange = vi.fn();
+      const { rerender } = render(
+        <Checkbox {...defaultProps} checked={false} onChange={onChange} />,
+      );
+      const user = userEvent.setup();
+
+      const checkbox = await screen.findByRole('checkbox');
+      await user.click(checkbox);
+
+      expect(onChange).toHaveBeenCalledWith(true);
+      expect(checkbox).not.toBeChecked();
+
+      rerender(
+        <Checkbox {...defaultProps} checked={true} onChange={onChange} />,
+      );
+
+      expect(checkbox).toBeChecked();
+    });
+
+    it('should keep the uncontrolled behavior when the checked prop is omitted', async () => {
+      const { user, getCheckbox } = setup();
+
+      const checkbox = await getCheckbox();
+      await user.click(checkbox);
+
+      expect(checkbox).toBeChecked();
+    });
+  });
+
   describe('Form', () => {
     const mockSubmit = vi.fn();
 

--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -20,7 +20,7 @@ import { checkboxVariants, labelVariants } from './Checkbox.variants';
  * // Controlled checkbox
  * <Checkbox
  *   label="Subscribe to newsletter"
- *   defaultChecked={subscribed}
+ *   checked={subscribed}
  *   onChange={(checked) => setSubscribed(checked)}
  * />
  *
@@ -34,6 +34,7 @@ const Checkbox: FC<Props> = forwardRef<HTMLButtonElement, Props>(
   (
     {
       ariaLabelledBy,
+      checked: checkedProp,
       className,
       defaultChecked,
       disabled,
@@ -50,12 +51,19 @@ const Checkbox: FC<Props> = forwardRef<HTMLButtonElement, Props>(
     },
     ref,
   ) => {
-    const [checked, setChecked] = useToggle(defaultChecked ?? false);
+    const [internalChecked, setInternalChecked] = useToggle(
+      defaultChecked ?? false,
+    );
+    const isControlled = checkedProp !== undefined;
+    const checked = isControlled ? checkedProp : internalChecked;
     const defaultId = useId();
 
-    const handleChange = (checked: boolean) => {
-      setChecked(checked);
-      onChange?.(checked);
+    const handleChange = (newChecked: boolean) => {
+      if (!isControlled) {
+        setInternalChecked(newChecked);
+      }
+
+      onChange?.(newChecked);
     };
 
     return (

--- a/lib/components/Checkbox/Checkbox.types.ts
+++ b/lib/components/Checkbox/Checkbox.types.ts
@@ -16,10 +16,11 @@ import { checkboxVariants } from './Checkbox.variants';
  */
 export interface Props
   extends
-    Omit<CheckboxPropsPrimitive, 'onChange'>,
+    Omit<CheckboxPropsPrimitive, 'onChange' | 'checked'>,
     Omit<VariantProps<typeof checkboxVariants>, 'checked'> {
   /** ID of element that labels the checkbox for accessibility */
   ariaLabelledBy?: string;
+  checked?: boolean;
   /** Additional CSS classes */
   className?: string;
   /** Initial checked state */

--- a/lib/components/Filter/Filter.test.tsx
+++ b/lib/components/Filter/Filter.test.tsx
@@ -405,6 +405,147 @@ describe('FilterComponent', () => {
     expect(onApplyB).not.toHaveBeenCalled();
   });
 
+  describe('Select All', () => {
+    const getCheckbox = async (name: string) => {
+      return screen.findByRole('checkbox', { name });
+    };
+
+    it('should check every option when checking the select all checkbox', async () => {
+      const { user, getBadgeButton } = setup();
+
+      await user.click(await getBadgeButton('Badge'));
+      await user.click(await getCheckbox('All'));
+
+      expect(await getCheckbox('Creating')).toBeChecked();
+      expect(await getCheckbox('Ready')).toBeChecked();
+    });
+
+    it('should re-check every option when checking select all after unchecking an option', async () => {
+      const { user, getBadgeButton } = setup();
+
+      await user.click(await getBadgeButton('Badge'));
+      await user.click(await getCheckbox('All'));
+      await user.click(await getCheckbox('Creating'));
+
+      expect(await getCheckbox('Creating')).not.toBeChecked();
+      expect(await getCheckbox('All')).not.toBeChecked();
+
+      await user.click(await getCheckbox('All'));
+
+      expect(await getCheckbox('Creating')).toBeChecked();
+      expect(await getCheckbox('Ready')).toBeChecked();
+    });
+
+    it('should uncheck every option when unchecking the select all checkbox', async () => {
+      const { user, getBadgeButton } = setup();
+
+      await user.click(await getBadgeButton('Badge'));
+      await user.click(await getCheckbox('All'));
+      await user.click(await getCheckbox('All'));
+
+      expect(await getCheckbox('Creating')).not.toBeChecked();
+      expect(await getCheckbox('Ready')).not.toBeChecked();
+    });
+
+    it('should uncheck the select all checkbox when unchecking an option', async () => {
+      const { user, getBadgeButton } = setup();
+
+      await user.click(await getBadgeButton('Badge'));
+      await user.click(await getCheckbox('All'));
+
+      expect(await getCheckbox('All')).toBeChecked();
+
+      await user.click(await getCheckbox('Ready'));
+
+      expect(await getCheckbox('All')).not.toBeChecked();
+    });
+
+    it('should apply every option after select all and none after unchecking it', async () => {
+      const mockOnApply = vi.fn();
+      const { user, getBadgeButton, getApplyButton } = setup({
+        onApplyBadge: mockOnApply,
+      });
+
+      await user.click(await getBadgeButton('Badge'));
+      await user.click(await getCheckbox('All'));
+      await user.click(await getApplyButton());
+
+      expect(mockOnApply).toHaveBeenCalledWith([
+        { id: 'creating', label: 'Creating', variant: 'warning' },
+        { id: 'ready', label: 'Ready', variant: 'success' },
+      ]);
+
+      await user.click(await getBadgeButton('Badge'));
+      await user.click(await getCheckbox('All'));
+      await user.click(await getApplyButton());
+
+      expect(mockOnApply).toHaveBeenLastCalledWith([]);
+    });
+
+    it('should keep the applied count while editing until apply', async () => {
+      const mockOnApply = vi.fn();
+      const { user, getBadgeButton, getApplyButton } = setup({
+        onApplyBadge: mockOnApply,
+      });
+
+      await user.click(await getBadgeButton('Badge'));
+      await user.click(await getCheckbox('All'));
+      await user.click(await getApplyButton());
+
+      const badgeButton = await getBadgeButton('Badge');
+
+      expect(badgeButton).toHaveTextContent('2');
+
+      await user.click(badgeButton);
+      await user.click(await getCheckbox('All'));
+
+      expect(badgeButton).toHaveTextContent('2');
+
+      await user.click(await getApplyButton());
+
+      expect(badgeButton).not.toHaveTextContent('2');
+    });
+
+    it('should not apply duplicated options after re-checking an unchecked option', async () => {
+      const mockOnApply = vi.fn();
+      const { user, getBadgeButton, getApplyButton } = setup({
+        onApplyBadge: mockOnApply,
+      });
+
+      await user.click(await getBadgeButton('Badge'));
+      await user.click(await getCheckbox('All'));
+      await user.click(await getCheckbox('Creating'));
+      await user.click(await getCheckbox('Creating'));
+      await user.click(await getApplyButton());
+
+      expect(mockOnApply).toHaveBeenCalledWith([
+        { id: 'creating', label: 'Creating', variant: 'warning' },
+        { id: 'ready', label: 'Ready', variant: 'success' },
+      ]);
+    });
+
+    it('should show applied options as checked after abandoning staged changes', async () => {
+      const mockOnApply = vi.fn();
+      const { user, getBadgeButton, getApplyButton } = setup({
+        onApplyBadge: mockOnApply,
+      });
+
+      await user.click(await getBadgeButton('Badge'));
+      await user.click(await getCheckbox('Creating'));
+      await user.click(await getApplyButton());
+
+      await user.click(await getBadgeButton('Badge'));
+      await user.click(await getCheckbox('Creating'));
+
+      expect(await getCheckbox('Creating')).not.toBeChecked();
+
+      await user.click(document.body);
+      await user.click(await getBadgeButton('Badge'));
+
+      expect(await getCheckbox('Creating')).toBeChecked();
+    });
+  });
+
   it('should select a date and reset the values', async () => {
     const mockOnApply = vi.fn();
 

--- a/lib/components/Filter/components/BadgeDropdown/BadgeMultiSelect.hook.ts
+++ b/lib/components/Filter/components/BadgeDropdown/BadgeMultiSelect.hook.ts
@@ -32,7 +32,9 @@ export const useBadgeMultiSelect = ({
     if (open) {
       sendOpenFilterEvent(id);
       setSelectedOptions((prevOptions) =>
-        prevOptions.filter((option) => option.isApplied),
+        prevOptions
+          .filter((option) => option.isApplied)
+          .map((option) => ({ ...option, isRemoved: false })),
       );
     }
 
@@ -41,10 +43,24 @@ export const useBadgeMultiSelect = ({
 
   const handleSelectOption = (option: Option, checked: boolean) => {
     if (checked) {
-      setSelectedOptions([...selectedOptions, { ...option, isApplied: false }]);
+      setSelectedOptions((prevOptions) => {
+        const exists = prevOptions.some((o) => o.id === option.id);
+
+        if (exists) {
+          return prevOptions.map((o) => {
+            if (o.id === option.id) {
+              return { ...o, isRemoved: false };
+            }
+
+            return o;
+          });
+        }
+
+        return [...prevOptions, { ...option, isApplied: false }];
+      });
     } else {
-      setSelectedOptions(
-        selectedOptions.map((o) => {
+      setSelectedOptions((prevOptions) =>
+        prevOptions.map((o) => {
           if (o.id === option.id) {
             return { ...o, isRemoved: true };
           }
@@ -65,7 +81,7 @@ export const useBadgeMultiSelect = ({
 
   const handleApplyOptions = () => {
     const newOptions = selectedOptions
-      ?.filter((option) => !option.isRemoved)
+      .filter((option) => !option.isRemoved)
       .map((option) => ({ ...option, isApplied: true }));
 
     setSelectedOptions(newOptions);
@@ -96,8 +112,20 @@ export const useBadgeMultiSelect = ({
 
   const handleSelectAll = (allOptions: Option[], checked: boolean) => {
     if (checked) {
-      setSelectedOptions(
-        allOptions.map((opt) => ({ ...opt, isApplied: false })),
+      setSelectedOptions((prevOptions) =>
+        allOptions.map((opt) => {
+          const existing = prevOptions.find((o) => o.id === opt.id);
+
+          if (existing) {
+            return { ...existing, isRemoved: false };
+          }
+
+          return { ...opt, isApplied: false };
+        }),
+      );
+    } else {
+      setSelectedOptions((prevOptions) =>
+        prevOptions.map((o) => ({ ...o, isRemoved: true })),
       );
     }
   };

--- a/lib/components/Filter/components/BadgeDropdown/BadgeMultiSelect.tsx
+++ b/lib/components/Filter/components/BadgeDropdown/BadgeMultiSelect.tsx
@@ -67,23 +67,23 @@ export const BadgeMultiSelect: FC<BadgeMultiSelectProps> = ({
           {showSelectAll && (
             <div className="flex gap-4">
               <Checkbox
-                key={`select-all-${isAllSelected}`}
-                defaultChecked={isAllSelected}
+                checked={isAllSelected}
+                aria-label={selectAllLabel}
                 onChange={(checked) => handleSelectAll(options, checked)}
               />
               <Badge label={selectAllLabel} />
             </div>
           )}
           {options.map((option) => {
-            const isSelected = !!selectedOptions.find(
-              (status) => status.id === option.id,
+            const isSelected = selectedOptions.some(
+              (selected) => selected.id === option.id && !selected.isRemoved,
             );
 
             return (
               <div key={option.id} className="flex gap-4">
                 <Checkbox
-                  key={`${option.id}-${isSelected}`}
-                  defaultChecked={isSelected}
+                  checked={isSelected}
+                  aria-label={option.label}
                   data-label={option.id}
                   onChange={(checked) => handleSelectOption(option, checked)}
                 />

--- a/lib/components/Filter/components/TextMultiSelect/TextMultiSelect.test.tsx
+++ b/lib/components/Filter/components/TextMultiSelect/TextMultiSelect.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { Filter } from '../../Filter';
+import { Option } from '../../Filter.types';
+
+import { TextMultiSelectProps } from './TextMultiSelect.types';
+
+const options: Option[] = [
+  {
+    id: 'ubuntu',
+    label: 'Ubuntu',
+  },
+  {
+    id: 'debian',
+    label: 'Debian',
+  },
+];
+
+describe('TextMultiSelect', () => {
+  const setup = (props?: Partial<TextMultiSelectProps>) => {
+    const { container: component } = render(
+      <Filter>
+        <Filter.TextMultiSelect label="OS" options={options} {...props} />
+      </Filter>,
+    );
+
+    const user = userEvent.setup();
+
+    const getTriggerButton = async () => {
+      return screen.findByRole('button', { name: /os/i });
+    };
+
+    const getCheckbox = async (name: string) => {
+      return screen.findByRole('checkbox', { name });
+    };
+
+    const getApplyButton = async () => {
+      return screen.findByRole('button', { name: /apply/i });
+    };
+
+    return {
+      component,
+      user,
+      getApplyButton,
+      getCheckbox,
+      getTriggerButton,
+    };
+  };
+
+  it('should render the component', async () => {
+    const { component } = setup();
+
+    expect(component).toBeInTheDocument();
+  });
+
+  it("should doesn't have violations", async () => {
+    const { component } = setup();
+
+    const results = await axe(component);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should re-check every option when checking select all after unchecking an option', async () => {
+    const { user, getTriggerButton, getCheckbox } = setup();
+
+    await user.click(await getTriggerButton());
+    await user.click(await getCheckbox('All'));
+    await user.click(await getCheckbox('Ubuntu'));
+
+    expect(await getCheckbox('Ubuntu')).not.toBeChecked();
+    expect(await getCheckbox('All')).not.toBeChecked();
+
+    await user.click(await getCheckbox('All'));
+
+    expect(await getCheckbox('Ubuntu')).toBeChecked();
+    expect(await getCheckbox('Debian')).toBeChecked();
+  });
+
+  it('should uncheck every option when unchecking the select all checkbox', async () => {
+    const { user, getTriggerButton, getCheckbox } = setup();
+
+    await user.click(await getTriggerButton());
+    await user.click(await getCheckbox('All'));
+    await user.click(await getCheckbox('All'));
+
+    expect(await getCheckbox('Ubuntu')).not.toBeChecked();
+    expect(await getCheckbox('Debian')).not.toBeChecked();
+  });
+
+  it('should apply every option after select all and none after unchecking it', async () => {
+    const mockOnApply = vi.fn();
+    const { user, getTriggerButton, getCheckbox, getApplyButton } = setup({
+      onApply: mockOnApply,
+    });
+
+    await user.click(await getTriggerButton());
+    await user.click(await getCheckbox('All'));
+    await user.click(await getApplyButton());
+
+    expect(mockOnApply).toHaveBeenCalledWith([
+      { id: 'ubuntu', label: 'Ubuntu' },
+      { id: 'debian', label: 'Debian' },
+    ]);
+
+    await user.click(await getTriggerButton());
+    await user.click(await getCheckbox('All'));
+    await user.click(await getApplyButton());
+
+    expect(mockOnApply).toHaveBeenLastCalledWith([]);
+  });
+
+  it('should hide the select all checkbox when showSelectAll is false', async () => {
+    const { user, getTriggerButton } = setup({ showSelectAll: false });
+
+    await user.click(await getTriggerButton());
+
+    expect(
+      screen.queryByRole('checkbox', { name: 'All' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/lib/components/Filter/components/TextMultiSelect/TextMultiSelect.tsx
+++ b/lib/components/Filter/components/TextMultiSelect/TextMultiSelect.tsx
@@ -67,8 +67,8 @@ export const TextMultiSelect: FC<TextMultiSelectProps> = ({
           {showSelectAll && (
             <div className="flex gap-4">
               <Checkbox
-                key={`select-all-${isAllSelected}`}
-                defaultChecked={isAllSelected}
+                checked={isAllSelected}
+                aria-label={selectAllLabel}
                 onChange={(checked) => handleSelectAll(options, checked)}
               />
               <span className="text-sm text-slate-700 dark:text-metal-200 whitespace-nowrap">
@@ -77,15 +77,15 @@ export const TextMultiSelect: FC<TextMultiSelectProps> = ({
             </div>
           )}
           {options.map((option) => {
-            const isSelected = !!selectedOptions.find(
-              (status) => status.id === option.id,
+            const isSelected = selectedOptions.some(
+              (selected) => selected.id === option.id && !selected.isRemoved,
             );
 
             return (
               <div key={option.id} className="flex gap-4">
                 <Checkbox
-                  key={`${option.id}-${isSelected}`}
-                  defaultChecked={isSelected}
+                  checked={isSelected}
+                  aria-label={option.label}
                   data-label={option.id}
                   onChange={(checked) => handleSelectOption(option, checked)}
                 />


### PR DESCRIPTION
## Problem

In `Filter.BadgeMultiSelect` and `Filter.TextMultiSelect`, checking **Select All** works the first time, but after unchecking some items and checking **All** again, the item checkboxes stay visually unchecked — while the internal state considers them all selected, so **Apply** emits options the user cannot see as checked.

## Root cause

`Checkbox` was uncontrolled-only (`useToggle(defaultChecked)`), so both multiselects forced visual sync by remounting via `key={`${option.id}-${isSelected}`}`. The per-item `isSelected` predicate ignored the `isRemoved` tombstone flag while `isAllSelected` respected it: unchecking an item didn't change its key (no remount), and re-checking All didn't either — leaving the DOM state permanently out of sync with the model.

## Changes

- **`Checkbox`**: supports a real controlled `checked` prop (backwards compatible — uncontrolled behavior unchanged when the prop is omitted). The prop was already advertised via the Radix prop passthrough but broken in practice.
- **`BadgeMultiSelect` / `TextMultiSelect`**: drop the key/`defaultChecked` remount hack, pass `checked` directly, fix the `isSelected` predicate to respect `isRemoved`, and add accessible names (`aria-label`) to the checkboxes.
- **`useBadgeMultiSelect` hook**:
  - Unchecking **Select All** now tombstones every option (previously a no-op).
  - Checking **Select All** preserves `isApplied` flags, so the trigger badge count no longer resets mid-edit.
  - Re-checking a tombstoned option clears the flag instead of appending a duplicate entry.
  - Reopening the dropdown resets stale tombstones on applied entries.
  - All state updates are functional (`setState(prev => ...)`).

## Tests

- `Checkbox`: controlled-mode suite (renders from prop, `onChange` without visual change until prop changes, uncontrolled behavior intact).
- `Filter`: new **Select All** regression suite covering the reported flow (All → uncheck one → All → all checked), uncheck-All, badge count stability, duplicate prevention, and abandoned staged edits — all via `getByRole('checkbox', { name })`.
- New `TextMultiSelect.test.tsx` (had no coverage) with jest-axe.

`npm run lint`, `npm run check:types`, and the full suite (592 tests) pass; production build succeeds.