### PR TITLE
✨ feat: add black variant to Switch and align thumb with Figma

### DIFF
--- a/lib/components/Switch/Switch.test.tsx
+++ b/lib/components/Switch/Switch.test.tsx
@@ -43,6 +43,30 @@ describe('Switch', () => {
     expect(results).toHaveNoViolations();
   });
 
+  it('should render the aurora track by default', async () => {
+    const { getSwitch } = setup();
+
+    const switchComponent = await getSwitch();
+
+    expect(switchComponent).toHaveClass('bg-aurora-500');
+  });
+
+  it('should render the black track when the black variant is used', async () => {
+    const { getSwitch } = setup({ variant: 'black' });
+
+    const switchComponent = await getSwitch();
+
+    expect(switchComponent).toHaveClass('bg-black');
+  });
+
+  it("should doesn't have violations with the black variant", async () => {
+    const { component } = setup({ variant: 'black' });
+
+    const results = await axe(component);
+
+    expect(results).toHaveNoViolations();
+  });
+
   it('should activate the switch when the user has been clicked on it', async () => {
     const handleSubmit = vitest.fn();
 

--- a/lib/components/Switch/Switch.tsx
+++ b/lib/components/Switch/Switch.tsx
@@ -56,6 +56,7 @@ export const Switch: FC<Props> = forwardRef<HTMLInputElement, Props>(
       theme,
       thumbClassName,
       value,
+      variant,
       onChange,
     },
     ref,
@@ -88,7 +89,7 @@ export const Switch: FC<Props> = forwardRef<HTMLInputElement, Props>(
           defaultChecked={defaultChecked}
           checked={value}
           onCheckedChange={(e) => onChange?.(e)}
-          className={cn(switchVariants({ className }))}
+          className={cn(switchVariants({ variant, className }))}
           aria-label={label}
           disabled={disabled}
         >

--- a/lib/components/Switch/Switch.variants.ts
+++ b/lib/components/Switch/Switch.variants.ts
@@ -1,31 +1,46 @@
 import { cva } from 'class-variance-authority';
 
-export const switchVariants = cva([
-  'w-10',
-  'h-5',
-  'flex',
-  'items-center',
-  'rounded-full',
-  'shadow',
-  'focus:shadow-md',
-  'data-[state=unchecked]:bg-gray-300',
-  'dark:data-[state=unchecked]:bg-metal-600',
-  'transition-all',
-  'delay-10',
-  'duration-250',
-  'cursor-pointer',
-  'bg-aurora-500',
-  'kubefirst:bg-kubefirst-primary',
-  '[&+label,&+span]:cursor-pointer',
-  'disabled:[&+label,&+span,&]:cursor-not-allowed',
-  'disabled:bg-gray-200',
-  'disabled:data-[state=unchecked]:[&>span]:bg-white',
-  'disabled:data-[state=unchecked]:bg-gray-200',
-  'dark:disabled:bg-metal-700',
-  'dark:disabled:data-[state=unchecked]:[&>span]:bg-metal-600',
-  'dark:disabled:data-[state=unchecked]:bg-metal-700',
-  'dark:disabled:[&>span]:bg-metal-600',
-]);
+export const switchVariants = cva(
+  [
+    'w-10',
+    'h-5',
+    'flex',
+    'items-center',
+    'rounded-full',
+    'shadow',
+    'focus:shadow-md',
+    'data-[state=unchecked]:bg-gray-300',
+    'dark:data-[state=unchecked]:bg-metal-600',
+    'transition-all',
+    'delay-10',
+    'duration-250',
+    'cursor-pointer',
+    '[&+label,&+span]:cursor-pointer',
+    'disabled:[&+label,&+span,&]:cursor-not-allowed',
+    'disabled:bg-gray-200',
+    'disabled:data-[state=unchecked]:[&>span]:bg-white',
+    'disabled:data-[state=unchecked]:bg-gray-200',
+    'dark:disabled:bg-metal-700',
+    'dark:disabled:data-[state=unchecked]:[&>span]:bg-metal-600',
+    'dark:disabled:data-[state=unchecked]:bg-metal-700',
+    'dark:disabled:[&>span]:bg-metal-600',
+  ],
+  {
+    variants: {
+      variant: {
+        default: ['bg-aurora-500', 'kubefirst:bg-kubefirst-primary'],
+        black: [
+          'bg-black',
+          'dark:bg-aurora-500',
+          'kubefirst:bg-kubefirst-primary',
+        ],
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
 
 export const thumbVariants = cva([
   'block',
@@ -37,8 +52,8 @@ export const thumbVariants = cva([
   'rounded-full',
   'shadow-md',
   'transition-all',
-  'translate-x-1',
-  'data-[state=checked]:translate-x-5',
+  'translate-x-0.5',
+  'data-[state=checked]:translate-x-5.5',
   'delay-10',
   'duration-300',
 ]);

--- a/lib/components/Switch/stories/Dark.stories.tsx
+++ b/lib/components/Switch/stories/Dark.stories.tsx
@@ -40,6 +40,14 @@ export const Dark = {
         />
 
         <SwitchComponent
+          label="Civo theme (black)"
+          {...args}
+          value={value.switch3}
+          onChange={(event) => handleChange('switch3', event)}
+          variant="black"
+        />
+
+        <SwitchComponent
           label="Civo theme"
           {...args}
           value={true}

--- a/lib/components/Switch/stories/Light.stories.tsx
+++ b/lib/components/Switch/stories/Light.stories.tsx
@@ -37,6 +37,14 @@ export const Light = {
         />
 
         <SwitchComponent
+          label="Civo theme (black)"
+          {...args}
+          value={value.switch3}
+          onChange={(event) => handleChange('switch3', event)}
+          variant="black"
+        />
+
+        <SwitchComponent
           label="Civo theme"
           {...args}
           value={true}


### PR DESCRIPTION
## Context

Design updated the toggle in [Figma (node 4241:23105)](https://www.figma.com/design/Vc1acpmWdXOcuwaQwHA4kr/Konstruct?node-id=4241-23105&m=dev): in light mode the checked track is now **black** (`#000000`) with a white thumb, instead of the aurora green.

It ships as an **opt-in variant** rather than a new default, so anyone already using the green switch is untouched.

## Changes

### `variant="black"`

`switchVariants` moves from a flat class array to `cva(base, { variants, defaultVariants })`, following the pattern already used by `Checkbox`:

```ts
variant: {
  default: ['bg-aurora-500', 'kubefirst:bg-kubefirst-primary'],
  black: ['bg-black', 'dark:bg-aurora-500', 'kubefirst:bg-kubefirst-primary'],
}
```

- `default` is byte-for-byte the previous behaviour.
- In **dark** mode the black variant falls back to `aurora-500`, matching the current civo dark look — a black track on a dark surface has no contrast.
- **kubefirst** stays purple in both variants.
- `bg-black` resolves the `--color-black` token from `civo-theme.css`, not a hardcoded hex.

No changes were needed in `Switch.types.ts`: `Props` already extends `VariantProps<typeof switchVariants>`, so `variant?: 'default' | 'black' | null` appears on the public API automatically.

### Thumb geometry

Figma specs the 16px thumb at **2px** from each edge of the 40×20 track; the code used 4px. Aligned in the base, so it applies to every switch — `translate-x-0.5` → `data-[state=checked]:translate-x-5.5`. This is a position-only change; no colour change for the default variant.

## Cascade

Verified against the built `dist/styles.css` rather than assumed:

- `.bg-black` (line 449) is emitted **before** `.dark:bg-aurora-500` (1055) and `.kubefirst:bg-kubefirst-primary` (1237), so both themes still override it — they tie on specificity (`:where()` contributes 0), so source order decides.
- Unchecked (`data-[state=unchecked]`) and `disabled:` rules carry an attribute / pseudo-class selector (0,2,0) against the base colour's 0,1,0, so they keep winning in both variants.
- Confirmed Tailwind v4 actually emits the fractional utilities: `.translate-x-0\.5` and `.data-\[state\=checked\]\:translate-x-5\.5` → `calc(var(--spacing) * 5.5)`.

## Testing

- Full suite: **595 tests / 48 files passing**. Three new cases on `Switch`: aurora track by default, `bg-black` with the variant, and a `jest-axe` check for the variant.
- `npm run check:types`, `npm run lint`, prettier and `npm run build`: clean.
- Stories: added a `Civo theme (black)` switch to both Light and Dark, with its own state so on/off is interactive. The dark story is what shows the variant collapsing to aurora.
- **Not covered:** no browser-based visual diff — the repo has no playwright/puppeteer, so the confirmation is at the generated-CSS and cascade level, not pixels. `npm run storybook` → `In Review/Switch/Light` to eyeball it against Figma.

## Out of scope

`kubefirst-dark` has no classes at all in `Switch`, so it renders the light palette (green, not purple). Pre-existing gap, unrelated to this change, left as-is.