### PR TITLE
🐛 fix: accessible names, error state and listbox semantics for composite controls

### DIFF
--- a/lib/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/lib/components/ButtonGroup/ButtonGroup.test.tsx
@@ -71,6 +71,48 @@ describe('ButtonGroup', () => {
     expect(label).toBeInTheDocument();
   });
 
+  it('should expose the label as the accessible name of the group', async () => {
+    setup({ label: 'Instance type' });
+
+    expect(
+      await screen.findByRole('radiogroup', { name: 'Instance type' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should describe the group with its error message', async () => {
+    const { findRadioGroup } = setup({
+      label: 'Instance type',
+      error: 'Pick one',
+      isRequired: true,
+    });
+
+    const group = await findRadioGroup();
+
+    expect(group).toHaveAttribute('aria-invalid', 'true');
+    expect(group).toHaveAttribute('aria-required', 'true');
+    expect(group).toHaveAccessibleDescription('Pick one');
+  });
+
+  it('should describe the group with its helper text', async () => {
+    const { findRadioGroup } = setup({
+      label: 'Instance type',
+      helperText: 'Balanced compute',
+    });
+
+    const group = await findRadioGroup();
+
+    expect(group).not.toHaveAttribute('aria-invalid');
+    expect(group).toHaveAccessibleDescription('Balanced compute');
+  });
+
+  it('should keep the required marker out of the accessible name', async () => {
+    setup({ label: 'Instance type', isRequired: true });
+
+    expect(
+      await screen.findByRole('radiogroup', { name: 'Instance type' }),
+    ).toBeInTheDocument();
+  });
+
   it('should render required indicator when isRequired is true', async () => {
     const { findByText } = setup({ label: 'Required field', isRequired: true });
 

--- a/lib/components/ButtonGroup/ButtonGroup.tsx
+++ b/lib/components/ButtonGroup/ButtonGroup.tsx
@@ -1,7 +1,7 @@
 import { motion } from 'motion/react';
 import { FC, useMemo } from 'react';
 
-import { cn } from '@/utils';
+import { cn, composeIds } from '@/utils';
 
 import { Props } from './ButtonGroup.types';
 import {
@@ -89,6 +89,16 @@ export const ButtonGroup: FC<Props> = ({
     onValueChange,
   });
 
+  const labelId = `${id}-label`;
+  const errorId = `${id}-error`;
+  const helperTextId = `${id}-helper-text`;
+  const hasError = typeof error === 'string' && error.length > 0;
+  const hasHelperText = !hasError && !!helperText;
+  const describedBy = composeIds(
+    hasError && errorId,
+    hasHelperText && helperTextId,
+  );
+
   const numOptions = options.length;
   const selectedIndex = useMemo(
     () => options.findIndex((o) => o.value === selected),
@@ -103,7 +113,7 @@ export const ButtonGroup: FC<Props> = ({
       {label && (
         <ButtonGroupLabel
           className={labelClassName}
-          htmlFor={id}
+          id={labelId}
           isRequired={isRequired}
           label={label}
           requiredClassName={requiredClassName}
@@ -113,7 +123,10 @@ export const ButtonGroup: FC<Props> = ({
       <div
         ref={groupRef}
         role="radiogroup"
-        aria-labelledby={label ? id : undefined}
+        aria-labelledby={label ? labelId : undefined}
+        aria-invalid={hasError || undefined}
+        aria-describedby={describedBy}
+        aria-required={isRequired || undefined}
         className={cn(buttonGroupVariants({ disabled }), className)}
       >
         {selectedIndex >= 0 && (
@@ -169,8 +182,10 @@ export const ButtonGroup: FC<Props> = ({
       <ButtonGroupMessage
         error={error}
         errorClassName={errorClassName}
+        errorId={errorId}
         helperText={helperText}
         helperTextClassName={helperTextClassName}
+        helperTextId={helperTextId}
       />
     </div>
   );

--- a/lib/components/ButtonGroup/components/ButtonGroupLabel/ButtonGroupLabel.tsx
+++ b/lib/components/ButtonGroup/components/ButtonGroupLabel/ButtonGroupLabel.tsx
@@ -7,11 +7,11 @@ import { Typography } from '../../../Typography/Typography';
 import { Props } from './ButtonGroupLabel.types';
 
 export const ButtonGroupLabel: FC<Props> = memo(
-  ({ className, htmlFor, isRequired, label, requiredClassName }) => (
+  ({ className, id, isRequired, label, requiredClassName }) => (
     <Typography
-      component="label"
+      component="span"
       variant="labelLarge"
-      htmlFor={htmlFor}
+      id={id}
       className={cn(
         'cursor-pointer',
         'flex',
@@ -26,6 +26,7 @@ export const ButtonGroupLabel: FC<Props> = memo(
       {isRequired && (
         <Typography
           component="span"
+          aria-hidden="true"
           className={cn(
             'text-red-600',
             'dark:text-red-500',

--- a/lib/components/ButtonGroup/components/ButtonGroupLabel/ButtonGroupLabel.types.ts
+++ b/lib/components/ButtonGroup/components/ButtonGroupLabel/ButtonGroupLabel.types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 export type Props = {
   className?: string;
-  htmlFor: string;
+  id: string;
   isRequired?: boolean;
   label: ReactNode | string;
   requiredClassName?: string;

--- a/lib/components/ButtonGroup/components/ButtonGroupMessage/ButtonGroupMessage.tsx
+++ b/lib/components/ButtonGroup/components/ButtonGroupMessage/ButtonGroupMessage.tsx
@@ -7,13 +7,21 @@ import { Typography } from '../../../Typography/Typography';
 import { Props } from './ButtonGroupMessage.types';
 
 export const ButtonGroupMessage: FC<Props> = memo(
-  ({ error, errorClassName, helperText, helperTextClassName }) => {
+  ({
+    error,
+    errorClassName,
+    errorId,
+    helperText,
+    helperTextClassName,
+    helperTextId,
+  }) => {
     const hasError = typeof error === 'string' && error.length > 0;
 
     if (hasError) {
       return (
         <Typography
           component="span"
+          id={errorId}
           className={cn(
             'text-xs',
             'tracking-normal',
@@ -30,6 +38,7 @@ export const ButtonGroupMessage: FC<Props> = memo(
       return (
         <Typography
           component="span"
+          id={helperTextId}
           variant="body1"
           className={cn(
             'text-xs',

--- a/lib/components/ButtonGroup/components/ButtonGroupMessage/ButtonGroupMessage.types.ts
+++ b/lib/components/ButtonGroup/components/ButtonGroupMessage/ButtonGroupMessage.types.ts
@@ -1,6 +1,8 @@
 export type Props = {
   error?: string;
   errorClassName?: string;
+  errorId?: string;
   helperText?: string;
   helperTextClassName?: string;
+  helperTextId?: string;
 };

--- a/lib/components/DateRangePicker/components/DateTimeInputs/components/EndInputFields/EndInputFields.tsx
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/components/EndInputFields/EndInputFields.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useId } from 'react';
 
 import { cn } from '@/utils';
 
@@ -24,66 +24,77 @@ export const EndInputFields: FC<Props> = ({
   labelDate = 'End date',
   labelTime = 'Time',
   ariaLabelDate = 'End date',
+  ariaLabelTime = 'End time',
   onDateChange,
   onDateFocus,
   onDateBlur,
   onTimeChange,
   classNames,
-}) => (
-  <div
-    className={cn(
-      dateTimeGroupVariants(),
-      !showTime && 'w-auto flex-1',
-      classNames?.group,
-    )}
-  >
+}) => {
+  const id = useId();
+  const timeControlId = `${id}-time`;
+
+  return (
     <div
       className={cn(
-        dateInputWrapperVariants(),
-        !showTime && 'w-full flex-1',
-        classNames?.dateWrapper,
+        dateTimeGroupVariants(),
+        !showTime && 'w-auto flex-1',
+        classNames?.group,
       )}
     >
-      <Typography
-        component="label"
-        className={cn(inputLabelVariants(), classNames?.label)}
+      <div
+        className={cn(
+          dateInputWrapperVariants(),
+          !showTime && 'w-full flex-1',
+          classNames?.dateWrapper,
+        )}
       >
-        {labelDate}
-      </Typography>
-
-      <Input
-        value={dateValue}
-        onChange={onDateChange}
-        onFocus={onDateFocus}
-        onBlur={onDateBlur}
-        error={error}
-        disabled={disabled}
-        className={cn(classNames?.input)}
-        aria-label={ariaLabelDate}
-      />
-    </div>
-
-    {showTime && (
-      <div className={cn(timeInputWrapperVariants(), classNames?.timeWrapper)}>
         <Typography
           component="label"
           className={cn(inputLabelVariants(), classNames?.label)}
         >
-          {labelTime}
+          {labelDate}
         </Typography>
 
-        <TimePicker
-          mode="input"
-          showList
-          format={timeFormat}
-          time={timeValue}
-          onChange={onTimeChange}
+        <Input
+          value={dateValue}
+          onChange={onDateChange}
+          onFocus={onDateFocus}
+          onBlur={onDateBlur}
+          error={error}
           disabled={disabled}
-          name="end time"
+          className={cn(classNames?.input)}
+          aria-label={ariaLabelDate}
         />
       </div>
-    )}
-  </div>
-);
+
+      {showTime && (
+        <div
+          className={cn(timeInputWrapperVariants(), classNames?.timeWrapper)}
+        >
+          <Typography
+            component="label"
+            htmlFor={timeControlId}
+            className={cn(inputLabelVariants(), classNames?.label)}
+          >
+            {labelTime}
+          </Typography>
+
+          <TimePicker
+            mode="input"
+            showList
+            format={timeFormat}
+            time={timeValue}
+            onChange={onTimeChange}
+            disabled={disabled}
+            ariaLabel={ariaLabelTime}
+            id={timeControlId}
+            name="end time"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
 
 EndInputFields.displayName = 'EndInputFields';

--- a/lib/components/DateRangePicker/components/DateTimeInputs/components/EndInputFields/EndInputFields.types.ts
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/components/EndInputFields/EndInputFields.types.ts
@@ -10,6 +10,7 @@ export type Props = {
   labelDate?: string;
   labelTime?: string;
   ariaLabelDate?: string;
+  ariaLabelTime?: string;
   onDateChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onDateFocus: () => void;
   onDateBlur: (e: FocusEvent<HTMLInputElement>) => void;

--- a/lib/components/DateRangePicker/components/DateTimeInputs/components/StartInputFields/StartInputFields.tsx
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/components/StartInputFields/StartInputFields.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useId } from 'react';
 
 import { cn } from '@/utils';
 
@@ -24,66 +24,77 @@ export const StartInputFields: FC<Props> = ({
   labelDate = 'Start date',
   labelTime = 'Time',
   ariaLabelDate = 'Start date',
+  ariaLabelTime = 'Start time',
   onDateChange,
   onDateFocus,
   onDateBlur,
   onTimeChange,
   classNames,
-}) => (
-  <div
-    className={cn(
-      dateTimeGroupVariants(),
-      !showTime && 'w-auto flex-1',
-      classNames?.group,
-    )}
-  >
+}) => {
+  const id = useId();
+  const timeControlId = `${id}-time`;
+
+  return (
     <div
       className={cn(
-        dateInputWrapperVariants(),
-        !showTime && 'w-full flex-1',
-        classNames?.dateWrapper,
+        dateTimeGroupVariants(),
+        !showTime && 'w-auto flex-1',
+        classNames?.group,
       )}
     >
-      <Typography
-        component="label"
-        className={cn(inputLabelVariants(), classNames?.label)}
+      <div
+        className={cn(
+          dateInputWrapperVariants(),
+          !showTime && 'w-full flex-1',
+          classNames?.dateWrapper,
+        )}
       >
-        {labelDate}
-      </Typography>
-
-      <Input
-        value={dateValue}
-        onChange={onDateChange}
-        onFocus={onDateFocus}
-        onBlur={onDateBlur}
-        error={error}
-        disabled={disabled}
-        className={cn(classNames?.input)}
-        aria-label={ariaLabelDate}
-      />
-    </div>
-
-    {showTime && (
-      <div className={cn(timeInputWrapperVariants(), classNames?.timeWrapper)}>
         <Typography
           component="label"
           className={cn(inputLabelVariants(), classNames?.label)}
         >
-          {labelTime}
+          {labelDate}
         </Typography>
 
-        <TimePicker
-          mode="input"
-          showList
-          format={timeFormat}
-          time={timeValue}
-          onChange={onTimeChange}
+        <Input
+          value={dateValue}
+          onChange={onDateChange}
+          onFocus={onDateFocus}
+          onBlur={onDateBlur}
+          error={error}
           disabled={disabled}
-          name="start time"
+          className={cn(classNames?.input)}
+          aria-label={ariaLabelDate}
         />
       </div>
-    )}
-  </div>
-);
+
+      {showTime && (
+        <div
+          className={cn(timeInputWrapperVariants(), classNames?.timeWrapper)}
+        >
+          <Typography
+            component="label"
+            htmlFor={timeControlId}
+            className={cn(inputLabelVariants(), classNames?.label)}
+          >
+            {labelTime}
+          </Typography>
+
+          <TimePicker
+            mode="input"
+            showList
+            format={timeFormat}
+            time={timeValue}
+            onChange={onTimeChange}
+            disabled={disabled}
+            ariaLabel={ariaLabelTime}
+            id={timeControlId}
+            name="start time"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
 
 StartInputFields.displayName = 'StartInputFields';

--- a/lib/components/DateRangePicker/components/DateTimeInputs/components/StartInputFields/StartInputFields.types.ts
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/components/StartInputFields/StartInputFields.types.ts
@@ -10,6 +10,7 @@ export type Props = {
   labelDate?: string;
   labelTime?: string;
   ariaLabelDate?: string;
+  ariaLabelTime?: string;
   onDateChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onDateFocus: () => void;
   onDateBlur: (e: FocusEvent<HTMLInputElement>) => void;

--- a/lib/components/ImageUpload/ImageUpload.test.tsx
+++ b/lib/components/ImageUpload/ImageUpload.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { ImageUpload } from './ImageUpload';
+import { ImageUploadStatus } from './ImageUpload.types';
+
+describe('ImageUpload', () => {
+  it('should associate the label with the file input', () => {
+    render(<ImageUpload label="Profile picture" name="avatar" />);
+
+    expect(screen.getByLabelText('Profile picture')).toHaveAttribute(
+      'type',
+      'file',
+    );
+  });
+
+  it('should expose the label as the accessible name', () => {
+    render(<ImageUpload label="Profile picture" name="avatar" />);
+
+    const input = screen.getByLabelText('Profile picture');
+
+    expect(input).not.toHaveAttribute('aria-label');
+  });
+
+  it('should describe the input with its helper text', () => {
+    render(
+      <ImageUpload
+        label="Profile picture"
+        name="avatar"
+        helperText="PNG or SVG, max 5MB"
+      />,
+    );
+
+    const input = screen.getByLabelText('Profile picture');
+
+    expect(input).not.toHaveAttribute('aria-invalid');
+    expect(input).toHaveAccessibleDescription('PNG or SVG, max 5MB');
+  });
+
+  it('should describe the input with its error message', () => {
+    render(
+      <ImageUpload
+        label="Profile picture"
+        name="avatar"
+        error="File is too large"
+      />,
+    );
+
+    const input = screen.getByLabelText('Profile picture');
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAccessibleDescription('File is too large');
+  });
+
+  it('should flag the error status as invalid', () => {
+    render(
+      <ImageUpload
+        label="Profile picture"
+        name="avatar"
+        status={ImageUploadStatus.Error}
+      />,
+    );
+
+    expect(screen.getByLabelText('Profile picture')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('should expose the required state', () => {
+    render(<ImageUpload label="Profile picture" name="avatar" isRequired />);
+
+    expect(screen.getByLabelText(/Profile picture/)).toHaveAttribute(
+      'aria-required',
+      'true',
+    );
+  });
+
+  it('should keep the required marker out of the accessible name', () => {
+    render(<ImageUpload label="Profile picture" name="avatar" isRequired />);
+
+    expect(screen.getByLabelText(/Profile picture/)).toHaveAccessibleName(
+      'Profile picture',
+    );
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = render(
+      <ImageUpload label="Profile picture" name="avatar" />,
+    );
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/ImageUpload/ImageUpload.tsx
+++ b/lib/components/ImageUpload/ImageUpload.tsx
@@ -55,6 +55,7 @@ const ImageUpload = ({
   maxSize = 5 * 1024 * 1024,
 }: Props) => {
   const id = useId();
+  const messageId = `${id}-message`;
   const fileInputRef = useRef<HTMLInputElement>(null);
   const uploadTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [internalStatus, setInternalStatus] = useState(status);
@@ -178,7 +179,10 @@ const ImageUpload = ({
           >
             {label}
             {isRequired && (
-              <span className="text-red-600 dark:text-red-500 text-xs mt-0.5">
+              <span
+                aria-hidden="true"
+                className="text-red-600 dark:text-red-500 text-xs mt-0.5"
+              >
                 *
               </span>
             )}
@@ -308,6 +312,7 @@ const ImageUpload = ({
         <div className="flex w-full gap-2">
           <div className="flex-1 min-w-0">
             <p
+              id={messageId}
               className={cn(
                 helperTextVariants({
                   status: currentStatus,
@@ -335,7 +340,10 @@ const ImageUpload = ({
         accept={accept}
         onChange={handleFileChange}
         className="hidden"
-        aria-label={typeof label === 'string' ? label : 'File upload'}
+        aria-label={label ? undefined : 'File upload'}
+        aria-invalid={hasError || undefined}
+        aria-describedby={displayHelperText ? messageId : undefined}
+        aria-required={isRequired || undefined}
       />
     </div>
   );

--- a/lib/components/MultiSelectDropdown/MultiSelectDropdown.types.ts
+++ b/lib/components/MultiSelectDropdown/MultiSelectDropdown.types.ts
@@ -68,6 +68,8 @@ export interface Props
   name?: string;
   /** Text shown when no options match the search */
   noOptionsText?: string;
+  /** Text shown in the list while options are loading */
+  loadingText?: string;
   /** Available options to select from */
   options: MultiSelectDropdownOption[];
   /** Placeholder text when no selection */

--- a/lib/components/MultiSelectDropdown/components/List/List.tsx
+++ b/lib/components/MultiSelectDropdown/components/List/List.tsx
@@ -10,7 +10,7 @@ import { ListProps } from './List.types';
 import { listVariants } from './List.variants';
 
 export const List: FC<ListProps> = ({ theme }) => {
-  const { options, selectedOptions, isLoading, noOptionsText } =
+  const { options, selectedOptions, isLoading, noOptionsText, loadingText } =
     useMultiSelectDropdown();
 
   return (
@@ -18,7 +18,7 @@ export const List: FC<ListProps> = ({ theme }) => {
       {isLoading ? (
         <Item
           key="loading"
-          option={{ id: 'loading', label: 'Loading...' }}
+          option={{ id: 'loading', label: loadingText ?? 'Loading...' }}
           className="select-none pointer-events-none"
           isSelected={false}
         />

--- a/lib/components/MultiSelectDropdown/contexts/MultiSelectDropdown.context.ts
+++ b/lib/components/MultiSelectDropdown/contexts/MultiSelectDropdown.context.ts
@@ -18,6 +18,7 @@ const initialState: State = {
   },
   isLoading: false,
   noOptionsText: undefined,
+  loadingText: undefined,
 };
 
 export const MultiSelectDropdownContext = createContext<State>(initialState);

--- a/lib/components/MultiSelectDropdown/contexts/MultiSelectDropdown.provider.tsx
+++ b/lib/components/MultiSelectDropdown/contexts/MultiSelectDropdown.provider.tsx
@@ -25,6 +25,7 @@ export const MultiSelectDropdownProvider: FC<
   name,
   isLoading,
   noOptionsText,
+  loadingText,
 }) => {
   const inputRef = useRef<ComponentRef<'input'>>(null);
   const [isOpen, setIsOpen] = useToggle(false);
@@ -203,6 +204,7 @@ export const MultiSelectDropdownProvider: FC<
         onOpen: handleOpen,
         isLoading,
         noOptionsText,
+        loadingText,
       }}
     >
       {children}

--- a/lib/components/MultiSelectDropdown/contexts/MultiSelectDropdown.types.ts
+++ b/lib/components/MultiSelectDropdown/contexts/MultiSelectDropdown.types.ts
@@ -7,6 +7,7 @@ export type State = {
   isLoading?: boolean;
   isOpen: boolean;
   noOptionsText?: string;
+  loadingText?: string;
   options: MultiSelectDropdownOption[];
   selectedOptions: MultiSelectDropdownOption[];
   onSelectOption: (option: MultiSelectDropdownOption) => void;
@@ -20,6 +21,7 @@ export type MultiSelectDropdownProviderProps = PropsWithChildren & {
   multiselect?: boolean;
   name?: string;
   noOptionsText?: string;
+  loadingText?: string;
   value?: MultiSelectDropdownOption[];
   onChange?: (params: {
     target: { value: MultiSelectDropdownOption[]; name: string };

--- a/lib/components/PhoneNumberInput/PhoneNumberInput.test.tsx
+++ b/lib/components/PhoneNumberInput/PhoneNumberInput.test.tsx
@@ -80,6 +80,34 @@ describe('PhoneNumberInput', () => {
     expect(onChange).toHaveBeenCalled();
   });
 
+  it('should expose the required state without polluting the accessible name', () => {
+    setup({ isRequired: true });
+
+    const input = screen.getByRole('textbox', { name: 'Phone Number' });
+
+    expect(input).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('should describe the input with its error message', () => {
+    const { getInput } = setup({ error: 'Invalid number' });
+
+    expect(getInput()).toHaveAttribute('aria-invalid', 'true');
+    expect(getInput()).toHaveAccessibleDescription('Invalid number');
+  });
+
+  it('should describe the input with its helper text', () => {
+    const { getInput } = setup({ helperText: 'Include the area code' });
+
+    expect(getInput()).not.toHaveAttribute('aria-invalid');
+    expect(getInput()).toHaveAccessibleDescription('Include the area code');
+  });
+
+  it('should not treat an empty error string as an error', () => {
+    const { getInput } = setup({ error: '' });
+
+    expect(getInput()).not.toHaveAttribute('aria-invalid');
+  });
+
   it('should close the country selector when pressing Escape', async () => {
     const { user, getTrigger, getSearchInput, querySearchInput } = setup();
 

--- a/lib/components/PhoneNumberInput/components/Wrapper.tsx
+++ b/lib/components/PhoneNumberInput/components/Wrapper.tsx
@@ -17,7 +17,7 @@ import {
 
 import { Typography } from '@/components/Typography/Typography';
 import { useClickOutside } from '@/hooks';
-import { cn } from '@/utils';
+import { cn, composeIds } from '@/utils';
 
 import { Props } from '../PhoneNumberInput.types';
 import {
@@ -41,6 +41,7 @@ export const Wrapper: ForwardRefExoticComponent<
       error,
       helperText,
       helperTextClassName,
+      id,
       isRequired,
       label,
       labelClassName,
@@ -52,12 +53,15 @@ export const Wrapper: ForwardRefExoticComponent<
       showNameOnSearch = true,
       wrapperClassName,
       showPlaceHolder,
+      onChange: onChangeProp,
       ...delegated
     },
     ref,
   ) => {
     const generatedId = useId();
-    const id = name ?? generatedId;
+    const controlId = id ?? generatedId;
+    const errorId = `${controlId}-error`;
+    const helperTextId = `${controlId}-helper-text`;
     const wrapperRef = useRef<ComponentRef<'div'>>(null);
     const {
       isOpenSelector,
@@ -66,7 +70,12 @@ export const Wrapper: ForwardRefExoticComponent<
       onChangeValue,
       handleOpenSelector,
     } = usePhoneNumberContext();
-    const hasError = typeof error === 'string' && error.length >= 0;
+    const hasError = typeof error === 'string' && error.length > 0;
+    const hasHelperText = !hasError && !!helperText;
+    const describedBy = composeIds(
+      hasError && errorId,
+      hasHelperText && helperTextId,
+    );
 
     const inputRef: RefObject<ComponentRef<'input'> | null> = useMask({
       mask: getPhoneMask(selectedCountry),
@@ -83,6 +92,8 @@ export const Wrapper: ForwardRefExoticComponent<
       } else {
         onChangeValue(`${selectedCountry.prefix} `);
       }
+
+      onChangeProp?.(event);
     };
 
     const handleClickOutside = useCallback(() => {
@@ -143,7 +154,7 @@ export const Wrapper: ForwardRefExoticComponent<
         {label ? (
           <div className={cn(labelWrapperClassName)}>
             <label
-              htmlFor={id}
+              htmlFor={controlId}
               className={labelVariants({ className: labelClassName })}
               onClick={() => !disabled && inputRef.current?.focus()}
             >
@@ -151,6 +162,7 @@ export const Wrapper: ForwardRefExoticComponent<
               {isRequired && (
                 <Typography
                   component="span"
+                  aria-hidden="true"
                   className="text-red-600 dark:text-red-500 ml-1"
                 >
                   *
@@ -172,7 +184,8 @@ export const Wrapper: ForwardRefExoticComponent<
             <FlagContent />
 
             <input
-              id={label ? id : undefined}
+              {...delegated}
+              id={controlId}
               ref={setInputRef}
               name={name}
               autoComplete="off"
@@ -192,7 +205,9 @@ export const Wrapper: ForwardRefExoticComponent<
               value={value}
               onChange={onChange}
               disabled={disabled}
-              {...delegated}
+              aria-invalid={hasError || undefined}
+              aria-describedby={describedBy}
+              aria-required={isRequired || undefined}
             />
           </div>
 
@@ -207,18 +222,20 @@ export const Wrapper: ForwardRefExoticComponent<
           )}
         </div>
 
-        {error ? (
+        {hasError ? (
           <Typography
             component="span"
+            id={errorId}
             className="text-xs text-red-700 dark:text-red-500"
           >
             {error}
           </Typography>
         ) : null}
 
-        {!error && helperText ? (
+        {hasHelperText ? (
           <Typography
             component="span"
+            id={helperTextId}
             className={cn(
               'text-xs kubefirst-dark:text-slate-200',
               helperTextClassName,

--- a/lib/components/Select/Select.test.tsx
+++ b/lib/components/Select/Select.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { FC, FormEvent, PropsWithChildren, useState } from 'react';
@@ -80,6 +80,117 @@ describe('Select', () => {
       const results = await axe(component);
 
       expect(results).toHaveNoViolations();
+    });
+
+    it('should expose the label as the accessible name of the combobox', async () => {
+      setup();
+
+      expect(
+        await screen.findByRole('combobox', { name: 'Select' }),
+      ).toBeInTheDocument();
+    });
+
+    it('should not emit duplicated ids', async () => {
+      const { component } = setup({ isRequired: true, error: 'Required' });
+
+      const ids = [...component.querySelectorAll('[id]')].map(
+        (element) => element.id,
+      );
+
+      expect(ids).toHaveLength(new Set(ids).size);
+    });
+
+    it('should point the label at the combobox instead of itself', async () => {
+      const { component } = setup();
+
+      const label = component.querySelector('label');
+      const comboBox = await screen.findByRole('combobox');
+
+      expect(label?.getAttribute('for')).toBe(comboBox.id);
+      expect(label?.getAttribute('for')).not.toBe(label?.id);
+    });
+
+    it('should fall back to the placeholder when there is no label', async () => {
+      setup({ label: undefined, placeholder: 'Pick a region' });
+
+      expect(
+        await screen.findByRole('combobox', { name: 'Pick a region' }),
+      ).toBeInTheDocument();
+    });
+
+    it('should describe the combobox with its error message', async () => {
+      setup({ error: 'Required', isRequired: true });
+
+      const comboBox = await screen.findByRole('combobox');
+
+      expect(comboBox).toHaveAttribute('aria-invalid', 'true');
+      expect(comboBox).toHaveAttribute('aria-required', 'true');
+      expect(comboBox).toHaveAccessibleDescription('Required');
+    });
+
+    it('should describe the combobox with its helper text', async () => {
+      setup({ helperText: 'Pick the closest region' });
+
+      const comboBox = await screen.findByRole('combobox');
+
+      expect(comboBox).not.toHaveAttribute('aria-invalid');
+      expect(comboBox).toHaveAccessibleDescription('Pick the closest region');
+    });
+
+    it('should reference the listbox it controls while open', async () => {
+      const { user, findComboBox } = setup();
+
+      const comboBox = await findComboBox();
+
+      expect(comboBox).toHaveAttribute('aria-haspopup', 'listbox');
+      expect(comboBox).not.toHaveAttribute('aria-controls');
+
+      await user.click(comboBox);
+
+      const listbox = await screen.findByRole('listbox');
+
+      expect(comboBox).toHaveAttribute('aria-controls', listbox.id);
+    });
+
+    it('should expose grouped options as named groups', async () => {
+      const { user, findComboBox } = setup({
+        options: [
+          {
+            groupLabel: 'Europe',
+            options: [{ label: 'Ireland', value: 'ie' }],
+          },
+          {
+            groupLabel: 'Americas',
+            options: [{ label: 'Canada', value: 'ca' }],
+          },
+        ],
+      });
+
+      await user.click(await findComboBox());
+
+      expect(
+        await screen.findByRole('group', { name: 'Europe' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('group', { name: 'Americas' }),
+      ).toBeInTheDocument();
+
+      const europe = screen.getByRole('group', { name: 'Europe' });
+
+      expect(
+        within(europe).getByRole('option', { name: /Ireland/ }),
+      ).toBeInTheDocument();
+    });
+
+    it('should allow overriding the loading text', async () => {
+      const { user, findComboBox } = setup({
+        isLoading: true,
+        loadingText: 'Cargando...',
+      });
+
+      await user.click(await findComboBox());
+
+      expect(screen.getByText('Cargando...')).toBeInTheDocument();
     });
 
     it('should render the options correctly', async () => {

--- a/lib/components/Select/Select.tsx
+++ b/lib/components/Select/Select.tsx
@@ -1,6 +1,6 @@
-import { ComponentRef, FC, forwardRef, useMemo } from 'react';
+import { ComponentRef, FC, forwardRef, useId, useMemo } from 'react';
 
-import { cn } from '@/utils';
+import { cn, composeIds } from '@/utils';
 
 import { Wrapper } from './components';
 import { SelectProvider } from './contexts';
@@ -49,6 +49,7 @@ export const Select: FC<Props> = forwardRef<ComponentRef<'input'>, Props>(
       helperText,
       helperTextClassName,
       highlightSearch,
+      id,
       mainWrapperClassName,
       name,
       value,
@@ -59,6 +60,17 @@ export const Select: FC<Props> = forwardRef<ComponentRef<'input'>, Props>(
     },
     ref,
   ) => {
+    const generatedId = useId();
+    const fieldId = id ?? (name ? `${generatedId}-${name}` : generatedId);
+    const errorId = `${fieldId}-error`;
+    const helperTextId = `${fieldId}-helper-text`;
+    const hasError = typeof error === 'string' && error.length > 0;
+    const hasHelperText = !hasError && !!helperText;
+    const describedBy = composeIds(
+      hasError && errorId,
+      hasHelperText && helperTextId,
+    );
+
     const flatOptions = useMemo((): Option[] => {
       if (!options.length) {
         return [];
@@ -80,7 +92,9 @@ export const Select: FC<Props> = forwardRef<ComponentRef<'input'>, Props>(
       >
         <div className={cn('relative w-full', mainWrapperClassName)}>
           <Wrapper
+            describedBy={describedBy}
             error={error}
+            fieldId={fieldId}
             name={name}
             ref={ref}
             onBlur={onBlur}
@@ -88,8 +102,9 @@ export const Select: FC<Props> = forwardRef<ComponentRef<'input'>, Props>(
             {...delegated}
           />
 
-          {error ? (
+          {hasError ? (
             <span
+              id={errorId}
               className={cn(
                 'text-xs text-red-700 dark:text-red-400',
                 errorClassName,
@@ -99,8 +114,9 @@ export const Select: FC<Props> = forwardRef<ComponentRef<'input'>, Props>(
             </span>
           ) : null}
 
-          {!error && helperText ? (
+          {hasHelperText ? (
             <span
+              id={helperTextId}
               className={cn(
                 'text-xs text-slate-600 dark:text-slate-200',
                 helperTextClassName,

--- a/lib/components/Select/Select.types.ts
+++ b/lib/components/Select/Select.types.ts
@@ -124,6 +124,8 @@ export type Props = VariantProps<typeof selectVariants> &
     listItemSecondRowClassName?: string;
     mainWrapperClassName?: string;
     noOptionsText?: string;
+    /** Text shown in the list while options are loading */
+    loadingText?: string;
     visibleItems?: number;
     options: Option[] | OptionGroup[];
     searchable?: boolean;

--- a/lib/components/Select/components/List/List.tsx
+++ b/lib/components/Select/components/List/List.tsx
@@ -3,7 +3,6 @@ import {
   ComponentRef,
   forwardRef,
   ForwardRefExoticComponent,
-  Fragment,
   RefAttributes,
   useEffect,
   useImperativeHandle,
@@ -34,9 +33,12 @@ export const List: ForwardRefExoticComponent<
       additionalOptions,
       className,
       groupedOptions,
+      id,
       inputRef,
       isLoading,
       itemClassName,
+      labelledBy,
+      loadingText,
       name,
       searchable = false,
       listItemSecondRowClassName,
@@ -190,8 +192,10 @@ export const List: ForwardRefExoticComponent<
     return (
       <ul
         ref={ulRef}
+        id={id}
         title={name}
         role="listbox"
+        aria-labelledby={labelledBy}
         className={cn(listVariants({ className }))}
         style={listStyle}
         data-state={isOpen ? 'open' : 'closed'}
@@ -201,8 +205,8 @@ export const List: ForwardRefExoticComponent<
             className={cn('select-none', itemClassName)}
             isClickable={false}
             inputRef={inputRef}
-            value="Loading..."
-            label="Loading..."
+            value={loadingText ?? 'Loading...'}
+            label={loadingText ?? 'Loading...'}
             listItemSecondRowClassName={listItemSecondRowClassName}
           />
         ) : isEmpty ? (
@@ -217,27 +221,29 @@ export const List: ForwardRefExoticComponent<
           />
         ) : isGrouped ? (
           filteredGroups.map((group) => (
-            <Fragment key={group.groupLabel}>
-              <li
-                role="presentation"
-                aria-hidden="true"
-                data-action="true"
-                className={cn(listGroupLabelVariants())}
-              >
-                {group.groupLabel}
-              </li>
+            <li key={group.groupLabel} role="presentation" data-action="true">
+              <ul role="group" aria-label={group.groupLabel}>
+                <li
+                  role="presentation"
+                  aria-hidden="true"
+                  data-action="true"
+                  className={cn(listGroupLabelVariants())}
+                >
+                  {group.groupLabel}
+                </li>
 
-              {group.options.map((option) => (
-                <ListItem
-                  key={option.value}
-                  className={cn('select-none', itemClassName)}
-                  isClickable
-                  inputRef={inputRef}
-                  listItemSecondRowClassName={listItemSecondRowClassName}
-                  {...option}
-                />
-              ))}
-            </Fragment>
+                {group.options.map((option) => (
+                  <ListItem
+                    key={option.value}
+                    className={cn('select-none', itemClassName)}
+                    isClickable
+                    inputRef={inputRef}
+                    listItemSecondRowClassName={listItemSecondRowClassName}
+                    {...option}
+                  />
+                ))}
+              </ul>
+            </li>
           ))
         ) : (
           uniqueFilteredOptions.map((option) => (
@@ -255,7 +261,8 @@ export const List: ForwardRefExoticComponent<
         {isInfiniteScrollEnabled && canContinueFetching && (
           <li
             ref={loadingRef}
-            role="option"
+            role="presentation"
+            aria-hidden="true"
             data-action="true"
             className="flex items-center justify-center py-3"
             onClick={(e) => e.stopPropagation()}

--- a/lib/components/Select/components/List/List.types.ts
+++ b/lib/components/Select/components/List/List.types.ts
@@ -7,6 +7,8 @@ export type ListProps = Pick<
   'name' | 'options' | 'theme' | 'additionalOptions'
 > & {
   className?: string;
+  id?: string;
+  labelledBy?: string;
   groupedOptions: SelectProps['options'];
   inputRef?: RefObject<ComponentRef<'input'> | null>;
   isLoading: boolean;
@@ -17,5 +19,6 @@ export type ListProps = Pick<
   isInfiniteScrollEnabled: SelectProps['isInfiniteScrollEnabled'];
   onFetchMoreOptions?: SelectProps['onFetchMoreOptions'];
   noOptionsText?: SelectProps['noOptionsText'];
+  loadingText?: SelectProps['loadingText'];
   visibleItems?: number;
 };

--- a/lib/components/Select/components/Wrapper.tsx
+++ b/lib/components/Select/components/Wrapper.tsx
@@ -7,7 +7,6 @@ import {
   KeyboardEvent,
   RefAttributes,
   useEffect,
-  useId,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -31,11 +30,15 @@ import { List } from './List/List';
 export const Wrapper: ForwardRefExoticComponent<
   Omit<SelectProps, 'options'> & {
     groupedOptions: SelectProps['options'];
+    fieldId: string;
+    describedBy?: string;
   } & RefAttributes<ComponentRef<'input'>>
 > = forwardRef<
   ComponentRef<'input'>,
   Omit<SelectProps, 'helperText' | 'options'> & {
     groupedOptions: SelectProps['options'];
+    fieldId: string;
+    describedBy?: string;
   }
 >(
   (
@@ -43,6 +46,8 @@ export const Wrapper: ForwardRefExoticComponent<
       additionalOptions,
       className,
       defaultValue,
+      describedBy,
+      fieldId,
       disabled = false,
       error,
       groupedOptions,
@@ -51,6 +56,7 @@ export const Wrapper: ForwardRefExoticComponent<
       isInfiniteScrollEnabled = false,
       isLoading,
       isRequired,
+      loadingText,
       label,
       labelAction,
       labelClassName,
@@ -73,7 +79,9 @@ export const Wrapper: ForwardRefExoticComponent<
     },
     ref,
   ) => {
-    const id = useId();
+    const labelId = `${fieldId}-label`;
+    const controlId = `${fieldId}-control`;
+    const listboxId = `${fieldId}-listbox`;
     const inputRef = useRef<ComponentRef<'input'>>(null);
     const searchInputRef = useRef<ComponentRef<'input'>>(null);
     const ulRef = useRef<ComponentRef<'ul'>>(null);
@@ -128,7 +136,9 @@ export const Wrapper: ForwardRefExoticComponent<
           return;
         }
 
-        ulRef.current?.querySelector('li')?.focus();
+        ulRef.current
+          ?.querySelector<HTMLLIElement>('li:not([data-action="true"])')
+          ?.focus();
 
         return;
       }
@@ -141,8 +151,6 @@ export const Wrapper: ForwardRefExoticComponent<
         handleToggleOpen();
       }
     };
-
-    const htmlFor = name ? `${id}-${name}` : id;
 
     useImperativeHandle(ref, () => inputRef.current!, [inputRef]);
 
@@ -192,14 +200,19 @@ export const Wrapper: ForwardRefExoticComponent<
             )}
           >
             <label
-              id={htmlFor}
+              id={labelId}
               className={cn(labelVariants({ className: labelClassName }))}
-              htmlFor={htmlFor}
+              htmlFor={controlId}
               onClick={() => !disabled && handleOpen()}
             >
               {label}
               {isRequired && (
-                <span className="text-red-600 dark:text-red-500 ml-1">*</span>
+                <span
+                  aria-hidden="true"
+                  className="text-red-600 dark:text-red-500 ml-1"
+                >
+                  *
+                </span>
               )}
             </label>
             {labelAction}
@@ -208,7 +221,7 @@ export const Wrapper: ForwardRefExoticComponent<
 
         <div
           ref={wrapperInputRef}
-          id={htmlFor}
+          id={controlId}
           className={cn(
             selectVariants({ className, hasError: !!error, disabled }),
           )}
@@ -217,7 +230,14 @@ export const Wrapper: ForwardRefExoticComponent<
           onKeyDown={handleKeyDown}
           aria-expanded={isOpen}
           tabIndex={isWrapperInputFocusable.current}
-          aria-labelledby={htmlFor}
+          aria-labelledby={label ? labelId : undefined}
+          aria-label={label ? undefined : placeholder}
+          aria-haspopup="listbox"
+          aria-controls={isOpen ? listboxId : undefined}
+          aria-invalid={!!error || undefined}
+          aria-describedby={describedBy}
+          aria-required={isRequired || undefined}
+          aria-disabled={disabled || undefined}
         >
           <div className="flex gap-2.5 items-center flex-1">
             {internalValue?.leftIcon && !showSearchIcon && (
@@ -260,8 +280,10 @@ export const Wrapper: ForwardRefExoticComponent<
                     handleOpen();
                   }
                 }}
-                aria-label={label || placeholder}
-                aria-labelledby={htmlFor}
+                aria-labelledby={label ? labelId : undefined}
+                aria-label={label ? undefined : placeholder}
+                aria-invalid={!!error || undefined}
+                aria-describedby={describedBy}
                 required={isRequired}
                 autoComplete="off"
                 autoCapitalize="words"
@@ -329,6 +351,8 @@ export const Wrapper: ForwardRefExoticComponent<
         {isOpen && (
           <List
             ref={ulRef}
+            id={listboxId}
+            labelledBy={label ? labelId : undefined}
             additionalOptions={additionalOptions}
             className={listClassName}
             groupedOptions={groupedOptions}
@@ -343,6 +367,7 @@ export const Wrapper: ForwardRefExoticComponent<
             isInfiniteScrollEnabled={isInfiniteScrollEnabled}
             onFetchMoreOptions={onFetchMoreOptions}
             noOptionsText={noOptionsText}
+            loadingText={loadingText}
             visibleItems={visibleItems}
           />
         )}

--- a/lib/components/Sidebar/Sidebar.types.ts
+++ b/lib/components/Sidebar/Sidebar.types.ts
@@ -84,6 +84,8 @@ export interface Props
   separatorClassName?: string;
   /** Additional CSS classes for the hamburger trigger button rendered in drawer mode */
   triggerClassName?: string;
+  /** Accessible label for the mobile navigation trigger */
+  openNavigationLabel?: string;
   /**
    * Per-slot class overrides for the underlying `Drawer` rendered in
    * `drawer` mode. Mirrors `Drawer`'s `classNames` shape: `root`, `overlay`,

--- a/lib/components/Sidebar/components/HamburgerTrigger/HamburgerTrigger.tsx
+++ b/lib/components/Sidebar/components/HamburgerTrigger/HamburgerTrigger.tsx
@@ -7,17 +7,22 @@ import { cn } from '@/utils';
 import { Props } from './HamburgerTrigger.types';
 import { hamburgerTriggerVariants } from './HamburgerTrigger.variants';
 
-const HamburgerTrigger: FC<Props> = ({ isOpen, onClick, className }) => (
+const HamburgerTrigger: FC<Props> = ({
+  isOpen,
+  onClick,
+  className,
+  openNavigationLabel = 'Open navigation',
+}) => (
   <button
     type="button"
-    aria-label="Open navigation"
+    aria-label={openNavigationLabel}
     aria-expanded={isOpen}
     aria-haspopup="menu"
     className={cn(hamburgerTriggerVariants({ className }))}
     onClick={onClick}
   >
     <Menu size={20} aria-hidden="true" />
-    <VisuallyHidden>Open navigation</VisuallyHidden>
+    <VisuallyHidden>{openNavigationLabel}</VisuallyHidden>
   </button>
 );
 

--- a/lib/components/Sidebar/components/HamburgerTrigger/HamburgerTrigger.types.ts
+++ b/lib/components/Sidebar/components/HamburgerTrigger/HamburgerTrigger.types.ts
@@ -1,5 +1,7 @@
 export interface Props {
   isOpen: boolean;
+  /** Accessible label for the navigation trigger */
+  openNavigationLabel?: string;
   onClick: VoidFunction;
   className?: string;
 }

--- a/lib/components/Sidebar/components/Wrapper/Wrapper.tsx
+++ b/lib/components/Sidebar/components/Wrapper/Wrapper.tsx
@@ -37,6 +37,7 @@ const Wrapper: FC<Props> = ({
   style,
   theme,
   triggerClassName,
+  openNavigationLabel,
   wrapperClassName,
 }) => {
   const resolvedMode = useSidebarMode(
@@ -198,6 +199,7 @@ const Wrapper: FC<Props> = ({
           isOpen={isDrawerOpen}
           onClick={handleOpenDrawer}
           className={triggerClassName}
+          openNavigationLabel={openNavigationLabel}
         />
         <Drawer
           isOpen={isDrawerOpen}

--- a/lib/components/TimePicker/TimePicker.test.tsx
+++ b/lib/components/TimePicker/TimePicker.test.tsx
@@ -9,6 +9,7 @@ import { Props } from './TimePicker.types';
 describe('TimePicker', () => {
   const setup = (props?: Partial<Props>, wrapper?: FC<PropsWithChildren>) => {
     const defaultProps = {
+      label: 'Start time',
       name: 'time-picker-name',
     } satisfies Props;
 
@@ -21,13 +22,13 @@ describe('TimePicker', () => {
 
     const user = userEvent.setup();
 
+    const accessibleName = props?.label ?? defaultProps.label;
+
     const getButton = async () =>
-      screen.findByRole('button', { name: props?.name ?? defaultProps.name });
+      screen.findByRole('button', { name: accessibleName });
 
     const handleOpenTimePicker = async () => {
-      const button = screen.getByRole('button', {
-        name: props?.name ?? defaultProps.name,
-      });
+      const button = screen.getByRole('button', { name: accessibleName });
       await user.click(button);
     };
 
@@ -114,6 +115,42 @@ describe('TimePicker', () => {
     const results = await axe(component);
 
     expect(results).toHaveNoViolations();
+  });
+
+  it('should expose the label as the accessible name, not the form name', async () => {
+    const { getButton } = setup();
+
+    expect(await getButton()).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'time-picker-name' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should reflect the expanded state of the trigger', async () => {
+    const { getButton, handleOpenTimePicker } = setup();
+
+    expect(await getButton()).toHaveAttribute('aria-expanded', 'false');
+    expect(await getButton()).not.toHaveAttribute('aria-controls');
+
+    await handleOpenTimePicker();
+
+    expect(await getButton()).toHaveAttribute('aria-expanded', 'true');
+    expect(await getButton()).toHaveAttribute('aria-controls');
+  });
+
+  it('should describe the trigger with its error message', async () => {
+    const { getButton } = setup({ error: 'Pick a time' });
+
+    const button = await getButton();
+
+    expect(button).toHaveAttribute('aria-invalid', 'true');
+    expect(button).toHaveAccessibleDescription('Pick a time');
+  });
+
+  it('should expose the required state on the trigger', async () => {
+    const { getButton } = setup({ isRequired: true });
+
+    expect(await getButton()).toHaveAttribute('aria-required', 'true');
   });
 
   it('should open time picker when button is clicked', async () => {
@@ -330,6 +367,7 @@ describe('TimePicker', () => {
   describe('Input Mode with List', () => {
     const setup = (props?: Partial<Props>) => {
       const defaultProps = {
+        label: 'Start time',
         name: 'time-input',
         mode: 'input' as const,
         showList: true,
@@ -342,7 +380,9 @@ describe('TimePicker', () => {
       const user = userEvent.setup();
 
       const getInput = () =>
-        screen.getByRole('textbox', { name: props?.name ?? defaultProps.name });
+        screen.getByRole('textbox', {
+          name: props?.label ?? defaultProps.label,
+        });
 
       const getHoursList = () =>
         screen.queryByRole('listbox', { name: 'hours' });
@@ -561,6 +601,7 @@ describe('TimePicker', () => {
   describe('Input Mode without List', () => {
     const setup = (props?: Partial<Props>) => {
       const defaultProps = {
+        label: 'Start time',
         name: 'time-input-no-list',
         mode: 'input' as const,
         showList: false,
@@ -573,7 +614,9 @@ describe('TimePicker', () => {
       const user = userEvent.setup();
 
       const getInput = () =>
-        screen.getByRole('textbox', { name: props?.name ?? defaultProps.name });
+        screen.getByRole('textbox', {
+          name: props?.label ?? defaultProps.label,
+        });
 
       return {
         component,
@@ -688,6 +731,7 @@ describe('TimePicker', () => {
 
       const { container } = render(
         <TimePicker
+          label="Start time"
           name="time-form"
           mode="input"
           showList={false}
@@ -697,7 +741,7 @@ describe('TimePicker', () => {
       );
 
       const user = userEvent.setup();
-      const input = screen.getByRole('textbox', { name: 'time-form' });
+      const input = screen.getByRole('textbox', { name: 'Start time' });
 
       await user.clear(input);
       await user.type(input, '16:45');

--- a/lib/components/TimePicker/TimePicker.types.ts
+++ b/lib/components/TimePicker/TimePicker.types.ts
@@ -30,8 +30,12 @@ export type Props = VariantProps<typeof timePickerVariants> & {
   time?: Date;
   /** Form field name */
   name?: string;
+  /** Id of the rendered control, for consumer-owned labels */
+  id?: string;
   /** Label displayed above the picker */
   label?: string;
+  /** Accessible name, when the visible label is rendered by the consumer */
+  ariaLabel?: string;
   /** Whether the field is required */
   isRequired?: boolean;
   /** Additional CSS classes for the wrapper */

--- a/lib/components/TimePicker/components/Wrapper/Wrapper.tsx
+++ b/lib/components/TimePicker/components/Wrapper/Wrapper.tsx
@@ -22,6 +22,8 @@ import { WrapperList } from '../WrapperList/WrapperList';
 import { WrapperProps } from './Wrapper.types';
 
 export const Wrapper: FC<WrapperProps> = ({
+  ariaLabel,
+  id: idProp,
   name,
   label,
   isRequired,
@@ -43,7 +45,10 @@ export const Wrapper: FC<WrapperProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const { format, formattedTime, setTimeDirectly, setIsTyping } =
     useTimePickerContext();
-  const labelId = name ?? `time-${id}`;
+  const controlId = idProp ?? `time-${id}`;
+  const labelId = `${controlId}-label`;
+  const listboxId = `${controlId}-listbox`;
+  const errorId = `${controlId}-error`;
 
   const [inputValue, setInputValue] = useState(formattedTime);
   const [internalError, setInternalError] = useState<string | undefined>();
@@ -217,13 +222,15 @@ export const Wrapper: FC<WrapperProps> = ({
         <Typography
           component="label"
           variant="labelLarge"
-          htmlFor={labelId}
+          id={labelId}
+          htmlFor={controlId}
           className="font-medium"
         >
           {label}{' '}
           {isRequired && (
             <Typography
               component="span"
+              aria-hidden="true"
               className="text-red-600 dark:text-red-500 text-sm font-normal"
             >
               *
@@ -233,32 +240,43 @@ export const Wrapper: FC<WrapperProps> = ({
       ) : null}
 
       <div className="relative">
-        {mode === 'select' ? (
-          <button
-            aria-label={labelId}
-            aria-haspopup="listbox"
-            aria-expanded="true"
-            aria-controls="time-options"
-            className={cn(
-              timePickerVariants({ className }),
-              disabled && 'opacity-50 cursor-not-allowed',
-            )}
-            data-open={isOpen}
-            onClick={handleOpen}
-            disabled={disabled}
-          >
-            {formattedTime}
-            <ChevronDownIcon
-              className="w-4 h-4 transition-all text-gray-400 data-[open=true]:rotate-180"
+        <div className="flex flex-col gap-1">
+          {mode === 'select' ? (
+            <button
+              type="button"
+              id={controlId}
+              aria-label={ariaLabel}
+              aria-labelledby={!ariaLabel && label ? labelId : undefined}
+              aria-haspopup="listbox"
+              aria-expanded={isOpen}
+              aria-controls={isOpen && showList ? listboxId : undefined}
+              aria-invalid={!!displayError || undefined}
+              aria-describedby={displayError ? errorId : undefined}
+              aria-required={isRequired || undefined}
+              className={cn(
+                timePickerVariants({ className }),
+                disabled && 'opacity-50 cursor-not-allowed',
+              )}
               data-open={isOpen}
-            />
-          </button>
-        ) : (
-          <div className="flex flex-col gap-1">
+              onClick={handleOpen}
+              disabled={disabled}
+            >
+              {formattedTime}
+              <ChevronDownIcon
+                className="w-4 h-4 transition-all text-gray-400 data-[open=true]:rotate-180"
+                data-open={isOpen}
+              />
+            </button>
+          ) : (
             <input
               ref={inputRef}
               type="text"
-              aria-label={labelId}
+              id={controlId}
+              aria-label={ariaLabel}
+              aria-labelledby={!ariaLabel && label ? labelId : undefined}
+              aria-invalid={!!displayError || undefined}
+              aria-describedby={displayError ? errorId : undefined}
+              aria-required={isRequired || undefined}
               value={inputValue}
               onChange={handleInputChange}
               onFocus={handleInputFocus}
@@ -298,19 +316,22 @@ export const Wrapper: FC<WrapperProps> = ({
                 },
               )}
             />
-            {displayError && (
-              <Typography
-                component="span"
-                className="text-red-600 dark:text-red-500 text-xs"
-              >
-                {displayError}
-              </Typography>
-            )}
-          </div>
-        )}
+          )}
+
+          {displayError && (
+            <Typography
+              component="span"
+              id={errorId}
+              className="text-red-600 dark:text-red-500 text-xs"
+            >
+              {displayError}
+            </Typography>
+          )}
+        </div>
 
         {showList && (
           <WrapperList
+            id={listboxId}
             isOpen={isOpen}
             scrollBehavior={scrollBehavior}
             listClassName={listClassName}
@@ -323,7 +344,7 @@ export const Wrapper: FC<WrapperProps> = ({
 
       <input
         type="hidden"
-        name={labelId}
+        name={name}
         value={formattedTime}
         className="hidden"
       />

--- a/lib/components/TimePicker/components/WrapperList/WrapperList.tsx
+++ b/lib/components/TimePicker/components/WrapperList/WrapperList.tsx
@@ -11,6 +11,7 @@ import { MinutesList } from '../MinutesList/MinutesList';
 import { WrapperListProps } from './WrapperList.types';
 
 export const WrapperList: FC<WrapperListProps> = ({
+  id,
   isOpen,
   scrollBehavior,
   listClassName,
@@ -28,6 +29,7 @@ export const WrapperList: FC<WrapperListProps> = ({
 
   return (
     <div
+      id={id}
       role="group"
       className={cn(
         'flex',

--- a/lib/components/TimePicker/components/WrapperList/WrapperList.types.ts
+++ b/lib/components/TimePicker/components/WrapperList/WrapperList.types.ts
@@ -1,6 +1,7 @@
 import { Props as TimePickerProps } from '../../TimePicker.types';
 
 export type WrapperListProps = {
+  id?: string;
   isOpen: boolean;
   scrollBehavior?: TimePickerProps['scrollBehavior'];
   listClassName?: TimePickerProps['listClassName'];

--- a/tests/a11y/accessible-name.test.tsx
+++ b/tests/a11y/accessible-name.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import { ReactElement } from 'react';
+
+import { ButtonGroup } from '@/components/ButtonGroup/ButtonGroup';
+import { Checkbox } from '@/components/Checkbox/Checkbox';
+import { ImageUpload } from '@/components/ImageUpload/ImageUpload';
+import { Input } from '@/components/Input/Input';
+import { PhoneNumberInput } from '@/components/PhoneNumberInput/PhoneNumberInput';
+import { Select } from '@/components/Select/Select';
+import { Switch } from '@/components/Switch/Switch';
+import { TextArea } from '@/components/TextArea/TextArea';
+import { TimePicker } from '@/components/TimePicker/TimePicker';
+
+const LABEL = 'My label';
+
+type Case = {
+  name: string;
+  role: string;
+  render: (props: {
+    label: string;
+    name?: string;
+    id?: string;
+  }) => ReactElement;
+};
+
+const CASES: Case[] = [
+  {
+    name: 'Input',
+    role: 'textbox',
+    render: (props) => {
+      return <Input {...props} />;
+    },
+  },
+  {
+    name: 'TextArea',
+    role: 'textbox',
+    render: (props) => {
+      return <TextArea {...props} />;
+    },
+  },
+  {
+    name: 'Checkbox',
+    role: 'checkbox',
+    render: (props) => {
+      return <Checkbox {...props} />;
+    },
+  },
+  {
+    name: 'Switch',
+    role: 'switch',
+    render: (props) => {
+      return <Switch {...props} />;
+    },
+  },
+  {
+    name: 'Select',
+    role: 'combobox',
+    render: (props) => {
+      return (
+        <Select {...props} options={[{ label: 'Option 1', value: 'one' }]} />
+      );
+    },
+  },
+  {
+    name: 'PhoneNumberInput',
+    role: 'textbox',
+    render: (props) => {
+      return <PhoneNumberInput {...props} />;
+    },
+  },
+  {
+    name: 'TimePicker',
+    role: 'button',
+    render: (props) => {
+      return <TimePicker {...props} />;
+    },
+  },
+  {
+    name: 'ButtonGroup',
+    role: 'radiogroup',
+    render: (props) => {
+      return (
+        <ButtonGroup
+          {...props}
+          options={[{ value: 'one', label: 'Option 1' }]}
+        />
+      );
+    },
+  },
+];
+
+describe('accessible name', () => {
+  describe.each(CASES)('$name', ({ role, render: renderCase }) => {
+    it.each([
+      ['label only', {}],
+      ['label and name', { name: 'field-name' }],
+      ['label and id', { id: 'field-id' }],
+      ['label, name and id', { name: 'field-name', id: 'field-id' }],
+    ])('should expose its label as accessible name with %s', (_, extra) => {
+      render(renderCase({ label: LABEL, ...extra }));
+
+      expect(screen.getByRole(role, { name: LABEL })).toBeInTheDocument();
+    });
+  });
+
+  describe('ImageUpload', () => {
+    it.each([
+      ['label only', {}],
+      ['label and name', { name: 'field-name' }],
+    ])('should expose its label as accessible name with %s', (_, extra) => {
+      render(<ImageUpload label={LABEL} {...extra} />);
+
+      expect(screen.getByLabelText(LABEL)).toHaveAccessibleName(LABEL);
+    });
+  });
+});


### PR DESCRIPTION
Part 2 of 2 — **stacks on #701 and targets that branch, not `main`.** Review after it, or use the "Files changed" tab which already excludes its commits.

Same pass as the text-field PR, applied to the controls built out of wrappers and popups. Here the defects were mostly **dangling id references** rather than missing attributes, which is why they were invisible to both review and axe.

## Select gave its label and its combobox the same id

```jsx
<label id={m} htmlFor={m}>{label}</label>
<div id={m} role="combobox" aria-labelledby={m} />
```

Measured on a live render of a labelled, required Select with an error:

```json
{
  "duplicateIds":       ["_r_0_-region"],
  "labelFor":           "_r_0_-region",
  "labelForResolvesTo": "LABEL#_r_0_-region",   // the label points at itself
  "comboAriaInvalid":   null
}
```

So: a duplicate id in the document, a dead label→control association, and `aria-labelledby` landing on the label only by luck of document order (`getElementById` returns the first match). With `label` omitted the combobox had **no accessible name at all**, since the reference dangled with no fallback.

Split into `-label` / `-control` / `-listbox` ids derived from one base, with `aria-label={placeholder}` as the fallback.

## TimePicker's accessible name was the raw form name

One identifier did four unrelated jobs — the label's `htmlFor`, the control's `aria-label`, and the hidden input's `name` — while nothing carried it as an `id`. `<TimePicker name="startTime" />` announced as **"startTime"**. Alongside that:

- `aria-expanded="true"` was hardcoded, so the trigger always reported itself as expanded, including while closed.
- `aria-controls="time-options"` referenced an id nothing carried.
- The hidden input submitted under the label id rather than `name`.
- In **select mode the `error` prop rendered nothing at all** — the message lived inside the input-mode branch only.

## ButtonGroup's radiogroup had no accessible name

The label used `htmlFor` toward a `<div>`, which is not a labelable element, and the group's `aria-labelledby` referenced an id nothing in the tree carried. Both ends of the association were broken.

## Shared wiring

Across Select, PhoneNumberInput, TimePicker, ButtonGroup and ImageUpload: error and helper text carry ids referenced by `aria-describedby`, controls carry `aria-invalid`, and `isRequired` sets `aria-required` with the asterisk `aria-hidden` so it stays out of the accessible name (WCAG 3.3.1).

PhoneNumberInput carried its own copy of the Input `error.length >= 0` bug, treating `error=""` as an error state.

## Two behaviour fixes surfaced by the above

- **PhoneNumberInput dropped its own masking handler** whenever a caller passed `onChange`, because `{...delegated}` was spread after it — silently disabling country-prefix and mask logic for the common case. The two are now composed.
- **DateRangePicker cannot be split out of this PR.** It renders its own `<label>` with no `htmlFor` and passed `name="start time"` specifically so the buggy `aria-label` would name the field. With the name derived correctly it needs the new `id`/`ariaLabel` props to associate its label. Its two time fields also share the visible label "Time", so they became mutually ambiguous once the form name stopped disambiguating them — hence `ariaLabelTime` (default `"Start time"` / `"End time"`), mirroring the existing `ariaLabelDate` pattern. **Visible design is unchanged.**

## Select listbox structure

- **Grouped options were hidden from screen readers.** They rendered as a flat sibling list with the group name in an `aria-hidden` `<li>`: sighted users saw the grouping, screen-reader users got an undifferentiated list. Options are now wrapped in `<ul role="group" aria-label={groupLabel}>`, so the tree reads `listbox > group "Europe" > option`.

  Since this is a real DOM structure change, the layout was measured rather than eyeballed:

  ```
  LISTBOX L16 W350 | GROUP(Asia Pacific) L17 W348 pad=0px mt=0px
    LABEL L17 W348 H32 | OPT L17 W348 H40
  ```

  Every row keeps an identical left offset and width and the nested list inherits `padding-inline-start: 0`, so there is no indentation or spacing regression.
- The infinite-scroll spinner was `role="option"` — an unnamed, unselectable option inside the listbox. Now presentational.
- ArrowDown from the combobox targeted the first `<li>`, which in a grouped list was the group heading rather than an option. It now skips non-interactive rows.

**Deliberately not attempted here:** `aria-activedescendant` and the search input's `tabIndex={-1}`. Both force a choice between the APG combobox pattern, where focus stays on the combobox, and the current design, where focus moves into the options. They are mutually exclusive and the second is what the keyboard layer implements today, so this needs a decision rather than a patch.

## Overridable strings

Hardcoded English went straight into the accessible tree with no way for a localized application to intervene. Now `loadingText` (Select, MultiSelectDropdown) and `openNavigationLabel` (Sidebar), alongside `showPasswordLabel`/`hidePasswordLabel` in the previous PR.

These are per-component props rather than a root i18n provider, which keeps the change additive; if a provider is wanted later these become its fallback layer rather than dead API.

## Test gate

`jest-axe` is already a devDependency, but of the fourteen findings across both PRs it would have caught **one** — label and description wiring is invisible to automated scanning.

The gate asserts the accessible name for 9 components across the four `label`/`name`/`id` shapes a caller can pass, which is the axis these defects actually varied along. Most only misbehaved for specific combinations, which is exactly why they survived component tests that always passed the same fixture.

## Verification

`tsc`, ESLint, prettier, full suite (685 passing), build and coverage thresholds all pass.

⚠️ Run tests with Storybook **stopped** — a running dev server pushes TimePicker specs past their timeouts and produces ~20 phantom failures.
