### PR TITLE
✨ feat: add component prop to Card, Tag and Divider for semantic elements

### DIFF
--- a/lib/components/Card/Card.test.tsx
+++ b/lib/components/Card/Card.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { CardProps } from './Card.types';
@@ -33,6 +33,36 @@ describe('Test for Card component', () => {
     const { component } = setup();
 
     const results = await axe(component);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should render as a div by default', () => {
+    setup();
+
+    expect(screen.queryByRole('article')).not.toBeInTheDocument();
+  });
+
+  it('should render as the element passed in component', () => {
+    render(
+      <Card component="article" aria-labelledby="account-name">
+        <h3 id="account-name">Production</h3>
+      </Card>,
+    );
+
+    expect(
+      screen.getByRole('article', { name: 'Production' }),
+    ).toBeInTheDocument();
+  });
+
+  it("shouldn't have violations when rendered as a named article", async () => {
+    const { container } = render(
+      <Card component="article" aria-label="Production">
+        Body
+      </Card>,
+    );
+
+    const results = await axe(container);
 
     expect(results).toHaveNoViolations();
   });

--- a/lib/components/Card/Card.tsx
+++ b/lib/components/Card/Card.tsx
@@ -31,32 +31,44 @@ import { Props } from './Card.types';
  */
 const Card: FC<Props> = forwardRef<HTMLDivElement, Props>(
   (
-    { className, theme, isActive, canHover, wrapperClassName, ...props },
+    {
+      className,
+      component = 'div',
+      theme,
+      isActive,
+      canHover,
+      wrapperClassName,
+      ...props
+    },
     ref,
-  ) => (
-    <div
-      data-theme={theme}
-      className={cn(
-        cardBaseVariants({
-          canHover,
-          className: wrapperClassName,
-          isActive,
-        }),
-      )}
-    >
+  ) => {
+    const Component = component as 'div';
+
+    return (
       <div
-        ref={ref}
+        data-theme={theme}
         className={cn(
-          cardVariants({
-            className,
-            isActive,
+          cardBaseVariants({
             canHover,
+            className: wrapperClassName,
+            isActive,
           }),
         )}
-        {...props}
-      />
-    </div>
-  ),
+      >
+        <Component
+          ref={ref}
+          className={cn(
+            cardVariants({
+              className,
+              isActive,
+              canHover,
+            }),
+          )}
+          {...props}
+        />
+      </div>
+    );
+  },
 );
 
 Card.displayName = 'Card';

--- a/lib/components/Card/Card.types.ts
+++ b/lib/components/Card/Card.types.ts
@@ -22,6 +22,7 @@ export interface Props
     PropsWithChildren {
   /** Enable hover effect */
   canHover?: boolean;
+  component?: 'div' | 'article' | 'section' | 'aside' | 'li';
   /** Show active/selected state */
   isActive?: boolean;
   /** Theme override for this component */

--- a/lib/components/Divider/Divider.test.tsx
+++ b/lib/components/Divider/Divider.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { Divider } from './Divider';
+
+describe('Divider', () => {
+  it('should render as a div by default', () => {
+    render(<Divider />);
+
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+  });
+
+  it('should expose the separator role when rendered as a hr', () => {
+    render(<Divider component="hr" />);
+
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = render(<Divider component="hr" />);
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/Divider/Divider.tsx
+++ b/lib/components/Divider/Divider.tsx
@@ -1,7 +1,8 @@
-import { FC, HTMLAttributes } from 'react';
+import { FC } from 'react';
 
 import { cn } from '@/utils';
 
+import { Props } from './Divider.types';
 import { dividerVariants } from './Divider.variants';
 
 /**
@@ -18,10 +19,13 @@ import { dividerVariants } from './Divider.variants';
  *
  * @see {@link https://konstructio.github.io/konstruct-ui/?path=/docs/components-divider--docs Storybook}
  */
-const Divider: FC<HTMLAttributes<HTMLDivElement>> = ({
-  className,
-  ...delegated
-}) => <div className={cn(dividerVariants({ className }))} {...delegated} />;
+const Divider: FC<Props> = ({ className, component = 'div', ...delegated }) => {
+  const Component = component as 'div';
+
+  return (
+    <Component className={cn(dividerVariants({ className }))} {...delegated} />
+  );
+};
 
 Divider.displayName = 'Divider';
 

--- a/lib/components/Divider/Divider.types.ts
+++ b/lib/components/Divider/Divider.types.ts
@@ -1,0 +1,5 @@
+import { HTMLAttributes } from 'react';
+
+export type Props = HTMLAttributes<HTMLDivElement> & {
+  component?: 'div' | 'hr' | 'li';
+};

--- a/lib/components/Tag/Tag.test.tsx
+++ b/lib/components/Tag/Tag.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { Tag } from './Tag';
+
+describe('Tag', () => {
+  it('should render the label', () => {
+    render(<Tag id="1" label="Active" />);
+
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('should render as a div by default', () => {
+    render(<Tag id="1" label="Active" />);
+
+    expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+  });
+
+  it('should render as the element passed in component', () => {
+    render(
+      <ul>
+        <Tag id="1" label="Active" component="li" />
+      </ul>,
+    );
+
+    expect(screen.getByRole('listitem')).toBeInTheDocument();
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = render(<Tag id="1" label="Active" />);
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/Tag/Tag.tsx
+++ b/lib/components/Tag/Tag.tsx
@@ -22,14 +22,22 @@ import { tagVariants } from './Tag.variants';
 export const Tag: FC<Props> = ({
   label,
   color,
+  component = 'div',
   rightIcon,
   leftIcon,
   className,
   'data-value': dataValue,
-}) => (
-  <div className={cn(tagVariants({ color, className }))} data-value={dataValue}>
-    {leftIcon ? <Slot className="text-inherit">{leftIcon}</Slot> : null}
-    <span className="text-inherit">{label}</span>
-    {rightIcon ? <Slot className="text-inherit">{rightIcon}</Slot> : null}
-  </div>
-);
+}) => {
+  const Component = component as 'div';
+
+  return (
+    <Component
+      className={cn(tagVariants({ color, className }))}
+      data-value={dataValue}
+    >
+      {leftIcon ? <Slot className="text-inherit">{leftIcon}</Slot> : null}
+      <span className="text-inherit">{label}</span>
+      {rightIcon ? <Slot className="text-inherit">{rightIcon}</Slot> : null}
+    </Component>
+  );
+};

--- a/lib/components/Tag/Tag.types.ts
+++ b/lib/components/Tag/Tag.types.ts
@@ -42,6 +42,7 @@ export type Props = {
   leftIcon?: ReactNode;
   /** Additional CSS classes */
   className?: string;
+  component?: 'div' | 'li' | 'span';
   /** Data attribute for the tag value */
   'data-value'?: string;
   /** Whether the tag is in a selected state */


### PR DESCRIPTION
## Summary

Adds an opt-in `component` prop to the three components whose root/content element was a hardcoded, purely presentational tag, so consumers can pick a semantic element where the context calls for one. Follows the same pattern `Typography` already uses.

- **Card** — `'div' | 'article' | 'section' | 'aside' | 'li'`. The semantic element is the inner one (the node that receives `aria-*`, children and the forwarded ref), so `<Card component="article" aria-labelledby={id}>` yields a card reachable with `findByRole('article', { name })`.
- **Tag** — `'div' | 'li' | 'span'`, for real chip lists (`<ul>` of tags exposing `listitem`s).
- **Divider** — `'div' | 'hr' | 'li'`; as `hr` it exposes the native `separator` role. Gains the `Divider.types.ts` file it was missing.

Motivated by civo/dashboard/teams-micro-frontend#5, where account cards need an accessible name so Cypress specs can drop their `findByText(...).parents('article')` fallbacks.

## Backwards compatibility

Fully additive: `component` defaults to the element each component renders today, no prop was removed or renamed, and the forwarded ref stays typed `HTMLDivElement` so existing `useRef` usages keep compiling.

**Deliberately skipped** (already semantic or the element must not change): Alert (`role="alert"`), Badge (`span` + button role when clickable), Loading (`role="status"`), ProgressBar (`role="progressbar"`), Breadcrumb (`<nav>`), the Radix-based Modal/AlertDialog/Tabs/Toast, and Typography (already has `component`). Form-control wrapper divs are internal layout, not the component's element.

## Tests

- Card: renders `div` by default, renders as a named `article` (`getByRole('article', { name })`), axe check on the named-article shape.
- Tag and Divider had no test files — new suites cover the default element, the semantic override (`listitem` / `separator`), and the mandatory jest-axe check.

## Verification

`npm run lint`, `npm run check:types` and the full suite pass (pre-commit ran the whole CI pipeline: prettier + 605 tests + build).