### PR TITLE
✨ feat: add CopyButton component with tooltip feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ ComponentName/
 - **Button** - Primary, secondary, tertiary, danger, link variants
 - **Badge** - Status badges
 - **Card** - Container card
+- **CopyButton** - Copy-to-clipboard icon button with tooltip feedback
 - **Alert** - Alert messages
 - **AlertDialog** - Confirmation dialogs
 - **Modal** - Modal dialogs

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ Alternatively, set `data-theme` directly on the document root — useful when th
 
 ## Components
 
-| Category     | Components                                                                                                                                                                                                                                       |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Forms        | Input, TextArea, Select, Checkbox, Switch, Radio, RadioGroup, RadioCard, Counter, Datepicker, TimePicker, PhoneNumberInput, Range, Slider, Autocomplete, Filter, TagSelect, MultiSelectDropdown, ImageUpload                                       |
-| UI           | Button, Badge, Card, Alert, AlertDialog, Modal, Breadcrumb, Divider, Tag, Tooltip, Toast, Tabs, Typography                                                                                                                                         |
-| Data display | Table, VirtualizedTable, PieChart, ProgressBar, Loading, Spinner                                                                                                                                                                                   |
-| Layout       | Sidebar                                                                                                                                                                                                                                            |
-| Other        | DropdownButton, Command                                                                                                                                                                                                                            |
+| Category     | Components                                                                                                                                                                                                   |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Forms        | Input, TextArea, Select, Checkbox, Switch, Radio, RadioGroup, RadioCard, Counter, Datepicker, TimePicker, PhoneNumberInput, Range, Slider, Autocomplete, Filter, TagSelect, MultiSelectDropdown, ImageUpload |
+| UI           | Button, Badge, Card, CopyButton, Alert, AlertDialog, Modal, Breadcrumb, Divider, Tag, Tooltip, Toast, Tabs, Typography                                                                                       |
+| Data display | Table, VirtualizedTable, PieChart, ProgressBar, Loading, Spinner                                                                                                                                             |
+| Layout       | Sidebar                                                                                                                                                                                                      |
+| Other        | DropdownButton, Command                                                                                                                                                                                      |
 
 Full documentation with live examples is available in the [Storybook](https://konstructio.github.io/konstruct-ui).
 

--- a/lib/components/CopyButton/CopyButton.test.tsx
+++ b/lib/components/CopyButton/CopyButton.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { CopyButton } from './CopyButton';
+import { Props } from './CopyButton.types';
+
+describe('CopyButton', () => {
+  const defaultProps = {
+    text: '192.168.0.1',
+    label: 'Public IP',
+  } satisfies Props;
+
+  const setup = (props?: Partial<Props>) => {
+    const user = userEvent.setup();
+    const { container: component } = render(
+      <CopyButton {...defaultProps} {...props} />,
+    );
+
+    const getButton = (name = 'Copy Public IP') => {
+      return screen.getByRole('button', { name });
+    };
+
+    return { component, user, getButton };
+  };
+
+  it('should render a button named after the copy and field labels', () => {
+    const { getButton } = setup();
+
+    expect(getButton()).toBeInTheDocument();
+  });
+
+  it("should doesn't have violations", async () => {
+    const { component } = setup();
+
+    const results = await axe(component);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should write the text to the clipboard when clicked', async () => {
+    const { user, getButton } = setup();
+
+    await user.click(getButton());
+
+    expect(await navigator.clipboard.readText()).toBe('192.168.0.1');
+  });
+
+  it('should announce and show the copied label after copying', async () => {
+    const { user, getButton } = setup();
+
+    await user.click(getButton());
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Copied!');
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Copied!');
+  });
+
+  it('should clear the copied state after the reset delay', async () => {
+    const onCopy = vitest.fn();
+    const { user, getButton } = setup({ onCopy, resetDelay: 50 });
+
+    await user.click(getButton());
+
+    expect(onCopy).toHaveBeenCalledWith('192.168.0.1');
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeEmptyDOMElement();
+    });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('should show the copy label in the tooltip on hover', async () => {
+    const { user, getButton } = setup();
+
+    await user.hover(getButton());
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Copy');
+  });
+
+  it('should use the custom copy and copied labels', async () => {
+    const { user, getButton } = setup({
+      copyLabel: 'Copiar',
+      copiedLabel: '¡Copiado!',
+    });
+
+    await user.click(getButton('Copiar Public IP'));
+
+    expect(await screen.findByRole('status')).toHaveTextContent('¡Copiado!');
+  });
+
+  it('should call onCopy with the copied text', async () => {
+    const onCopy = vitest.fn();
+    const { user, getButton } = setup({ onCopy });
+
+    await user.click(getButton());
+
+    expect(onCopy).toHaveBeenCalledWith('192.168.0.1');
+  });
+
+  it('should call onCopyError and stay silent when the clipboard fails', async () => {
+    const onCopy = vitest.fn();
+    const onCopyError = vitest.fn();
+    const error = new Error('denied');
+    const { user, getButton } = setup({ onCopy, onCopyError });
+
+    vitest.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(error);
+
+    await user.click(getButton());
+
+    expect(onCopyError).toHaveBeenCalledWith(error);
+    expect(onCopy).not.toHaveBeenCalled();
+    expect(screen.getByRole('status')).toBeEmptyDOMElement();
+  });
+
+  it('should render the children instead of the icon', () => {
+    const { getButton } = setup({ children: 'my-volume' });
+
+    expect(getButton()).toHaveTextContent('my-volume');
+  });
+
+  it('should not propagate the click to the parent', async () => {
+    const onParentClick = vitest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <div onClick={onParentClick}>
+        <CopyButton {...defaultProps} />
+      </div>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Copy Public IP' }));
+
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+});

--- a/lib/components/CopyButton/CopyButton.tsx
+++ b/lib/components/CopyButton/CopyButton.tsx
@@ -1,0 +1,112 @@
+import {
+  Arrow,
+  Content,
+  Portal,
+  Provider,
+  Root,
+  Trigger,
+} from '@radix-ui/react-tooltip';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+import { FC, FocusEvent, MouseEvent, useEffect, useState } from 'react';
+
+import { CopyIcon } from '@/assets/icons/components';
+import { cn } from '@/utils';
+
+import { Props } from './CopyButton.types';
+import { copyButtonVariants } from './CopyButton.variants';
+import { useCopyToClipboard } from './hooks';
+
+const CopyButton: FC<Props> = ({
+  arrowClassName,
+  children,
+  className,
+  copiedLabel = 'Copied!',
+  copyLabel = 'Copy',
+  label,
+  resetDelay,
+  text,
+  theme,
+  tooltipClassName,
+  onCopy,
+  onCopyError,
+  ...delegated
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { copied, copy } = useCopyToClipboard({
+    resetDelay,
+    onCopy,
+    onCopyError,
+  });
+
+  useEffect(() => {
+    if (!copied) {
+      setIsOpen(false);
+    }
+  }, [copied]);
+
+  const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+
+    const ok = await copy(text);
+
+    if (ok) {
+      setIsOpen(true);
+    }
+  };
+
+  const handleFocus = (event: FocusEvent<HTMLButtonElement>) => {
+    if (!event.currentTarget.matches(':focus-visible')) {
+      event.preventDefault();
+    }
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!copied) {
+      setIsOpen(next);
+    }
+  };
+
+  return (
+    <Provider delayDuration={0}>
+      <Root open={isOpen} onOpenChange={handleOpenChange}>
+        <Trigger asChild>
+          <button
+            type="button"
+            aria-label={`${copyLabel} ${label}`}
+            data-theme={theme}
+            className={cn(
+              copyButtonVariants({ iconOnly: !children, className }),
+            )}
+            onClick={handleClick}
+            onFocus={handleFocus}
+            {...delegated}
+          >
+            {children ?? <CopyIcon size={14} aria-hidden="true" />}
+          </button>
+        </Trigger>
+
+        <Portal>
+          <Content
+            sideOffset={4}
+            className={cn(
+              'z-70 rounded bg-slate-700 px-2 py-1 text-xs text-white shadow-md',
+              'animate-in fade-in-0',
+              tooltipClassName,
+            )}
+          >
+            {copied ? copiedLabel : copyLabel}
+            <Arrow className={cn('fill-slate-700', arrowClassName)} />
+          </Content>
+        </Portal>
+      </Root>
+
+      <VisuallyHidden role="status" aria-live="polite">
+        {copied ? copiedLabel : ''}
+      </VisuallyHidden>
+    </Provider>
+  );
+};
+
+CopyButton.displayName = 'KonstructCopyButton';
+
+export { CopyButton };

--- a/lib/components/CopyButton/CopyButton.types.ts
+++ b/lib/components/CopyButton/CopyButton.types.ts
@@ -1,0 +1,20 @@
+import { ButtonHTMLAttributes, ReactNode } from 'react';
+
+import { Theme } from '@/domain/theme';
+
+export type Props = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children' | 'onClick' | 'onCopy'
+> & {
+  arrowClassName?: string;
+  children?: ReactNode;
+  copiedLabel?: string;
+  copyLabel?: string;
+  label: string;
+  resetDelay?: number;
+  text: string;
+  theme?: Theme;
+  tooltipClassName?: string;
+  onCopy?: (text: string) => void;
+  onCopyError?: (error: unknown) => void;
+};

--- a/lib/components/CopyButton/CopyButton.variants.ts
+++ b/lib/components/CopyButton/CopyButton.variants.ts
@@ -1,0 +1,34 @@
+import { cva } from 'class-variance-authority';
+
+export const copyButtonVariants = cva(
+  [
+    'inline-flex',
+    'shrink-0',
+    'items-center',
+    'justify-center',
+    'cursor-pointer',
+    'rounded-xs',
+    'transition-colors',
+    'focus-visible:outline-none',
+    'focus-visible:ring-1',
+    'focus-visible:ring-ring',
+    'disabled:pointer-events-none',
+    'disabled:opacity-45',
+  ],
+  {
+    variants: {
+      iconOnly: {
+        true: [
+          'text-slate-500',
+          'hover:text-slate-800',
+          'dark:text-metal-400',
+          'dark:hover:text-metal-100',
+        ],
+        false: '',
+      },
+    },
+    defaultVariants: {
+      iconOnly: true,
+    },
+  },
+);

--- a/lib/components/CopyButton/hooks/index.ts
+++ b/lib/components/CopyButton/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useCopyToClipboard/useCopyToClipboard';

--- a/lib/components/CopyButton/hooks/useCopyToClipboard/useCopyToClipboard.ts
+++ b/lib/components/CopyButton/hooks/useCopyToClipboard/useCopyToClipboard.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { Options } from './useCopyToClipboard.types';
+
+const DEFAULT_RESET_DELAY = 1500;
+
+export const useCopyToClipboard = ({
+  resetDelay = DEFAULT_RESET_DELAY,
+  onCopy,
+  onCopyError,
+}: Options = {}) => {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const copy = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (error) {
+      onCopyError?.(error);
+
+      return false;
+    }
+
+    setCopied(true);
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setCopied(false);
+    }, resetDelay);
+    onCopy?.(text);
+
+    return true;
+  };
+
+  return { copied, copy };
+};

--- a/lib/components/CopyButton/hooks/useCopyToClipboard/useCopyToClipboard.types.ts
+++ b/lib/components/CopyButton/hooks/useCopyToClipboard/useCopyToClipboard.types.ts
@@ -1,0 +1,5 @@
+export type Options = {
+  resetDelay?: number;
+  onCopy?: (text: string) => void;
+  onCopyError?: (error: unknown) => void;
+};

--- a/lib/components/CopyButton/stories/Dark.stories.tsx
+++ b/lib/components/CopyButton/stories/Dark.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Typography } from '@/components/Typography/Typography';
+
+import { CopyButton as CopyButtonComponent } from '../CopyButton';
+
+type Story = StoryObj<typeof CopyButtonComponent>;
+
+const meta: Meta<typeof CopyButtonComponent> = {
+  title: 'In Review/CopyButton/Dark',
+  component: CopyButtonComponent,
+};
+
+export const Dark: Story = {
+  parameters: {
+    theme: 'dark',
+  },
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-2">
+        <Typography variant="body2" className="dark:text-metal-50">
+          192.168.0.1
+        </Typography>
+        <CopyButtonComponent text="192.168.0.1" label="Public IP" />
+      </div>
+
+      <Typography
+        variant="body2"
+        className="flex items-center gap-1 dark:text-metal-50"
+      >
+        Type
+        <CopyButtonComponent
+          text="my-volume"
+          label="my-volume"
+          className="border dark:border-metal-700 dark:bg-metal-700 p-1 dark:hover:bg-metal-600"
+        >
+          my-volume
+        </CopyButtonComponent>
+        to confirm
+      </Typography>
+
+      <div className="flex items-center gap-2">
+        <Typography variant="body2" className="dark:text-metal-50">
+          ssh root@192.168.0.1
+        </Typography>
+        <CopyButtonComponent
+          text="ssh root@192.168.0.1"
+          label="SSH command"
+          copyLabel="Copiar"
+          copiedLabel="¡Copiado!"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Typography variant="body2" className="dark:text-metal-50">
+          Disabled
+        </Typography>
+        <CopyButtonComponent text="disabled" label="disabled value" disabled />
+      </div>
+    </div>
+  ),
+};
+
+export default meta;

--- a/lib/components/CopyButton/stories/Light.stories.tsx
+++ b/lib/components/CopyButton/stories/Light.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Typography } from '@/components/Typography/Typography';
+
+import { CopyButton as CopyButtonComponent } from '../CopyButton';
+
+type Story = StoryObj<typeof CopyButtonComponent>;
+
+const meta: Meta<typeof CopyButtonComponent> = {
+  title: 'In Review/CopyButton/Light',
+  component: CopyButtonComponent,
+};
+
+export const Light: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-2">
+        <Typography variant="body2">192.168.0.1</Typography>
+        <CopyButtonComponent text="192.168.0.1" label="Public IP" />
+      </div>
+
+      <Typography variant="body2" className="flex items-center gap-1">
+        Type
+        <CopyButtonComponent
+          text="my-volume"
+          label="my-volume"
+          className="border border-slate-300 bg-slate-100 p-1 hover:bg-slate-200"
+        >
+          my-volume
+        </CopyButtonComponent>
+        to confirm
+      </Typography>
+
+      <div className="flex items-center gap-2">
+        <Typography variant="body2">ssh root@192.168.0.1</Typography>
+        <CopyButtonComponent
+          text="ssh root@192.168.0.1"
+          label="SSH command"
+          copyLabel="Copiar"
+          copiedLabel="¡Copiado!"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Typography variant="body2">Disabled</Typography>
+        <CopyButtonComponent text="disabled" label="disabled value" disabled />
+      </div>
+    </div>
+  ),
+};
+
+export default meta;

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -7,6 +7,8 @@ export * from './Button/Button';
 export * from './ButtonGroup/ButtonGroup';
 export * from './Card/Card';
 export * from './Checkbox/Checkbox';
+export * from './CopyButton/CopyButton';
+export type { Props as CopyButtonProps } from './CopyButton/CopyButton.types';
 export * from './Counter/Counter';
 export * from './Datepicker/DatePicker';
 export * from './DateRangePicker/DateRangePicker';


### PR DESCRIPTION
## Summary

Adds a `CopyButton` component to the library. Every micro-frontend (volumes, compute, kubernetes, settings, vpc, dns, databases) currently ships its own copy of this button; this PR ports the volumes version, which is the most complete one, so they can all consume a single accessible implementation.

## What it does

- Renders a small copy trigger (the library `CopyIcon` by default, or `children` for inline text triggers such as a resource name).
- Radix tooltip that reads **Copy** on hover and **Copied!** right after copying, closing itself after `resetDelay` (1500 ms by default).
- Polite `role="status"` live region so screen readers announce the copy.
- Accessible name is `"<copyLabel> <label>"`, e.g. `Copy Public IP`.
- `stopPropagation` on click so it is safe inside clickable table rows.
- Focus only opens the tooltip when it is keyboard-visible (`:focus-visible`).
- `onCopy` / `onCopyError` callbacks.
- `tooltipClassName` and `arrowClassName` merge over the defaults through `cn()`, mirroring the `Tooltip` component API.
- Light and dark styling with civo-theme tokens.

Labels are plain props (`copyLabel`, `copiedLabel`, `label`) so each host translates them with its own i18n setup; the library stays framework-agnostic.

## Structure

```
lib/components/CopyButton/
├── CopyButton.tsx
├── CopyButton.types.ts
├── CopyButton.variants.ts
├── CopyButton.test.tsx
├── hooks/
│   ├── index.ts
│   └── useCopyToClipboard/
│       ├── useCopyToClipboard.ts
│       └── useCopyToClipboard.types.ts
└── stories/
    ├── Light.stories.tsx
    └── Dark.stories.tsx
```

`useCopyToClipboard` owns the `navigator.clipboard.writeText` call, the `copied` state and the reset timer.

## Usage

```tsx
<CopyButton text={row.publicIp} label="Public IP" />

<CopyButton text={volumeName} label={volumeName} className="border p-1">
  {volumeName}
</CopyButton>

<CopyButton text={cmd} label="SSH command" copyLabel="Copiar" copiedLabel="¡Copiado!" />
```

## Tests

11 tests querying by role and accessible name: rendering, clipboard write, copied announcement and tooltip, reset after the delay, hover tooltip, custom labels, `onCopy`, `onCopyError` when the clipboard rejects, `children` rendering, click propagation and jest-axe.

## Docs

`CopyButton` added to the component lists in `README.md` and `CLAUDE.md`, and exported from `lib/components/index.ts` together with the `CopyButtonProps` type.
