### PR TITLE
✨ feat: add isPortal mode to VirtualizedTable.Actions

### DIFF
--- a/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
@@ -1,19 +1,30 @@
 import { CellContext } from '@tanstack/react-table';
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
 import { Actions } from './Actions';
 import { Action, Props } from './Actions.types';
+import { CLOSE_DELAY_MS } from './components/PortalActions/constants';
 
 type Row = { id: number; name: string };
 
 const row: Row = { id: 1, name: 'Pikachu' };
 
-const buildProps = (actions: Action<Row>[] | undefined): Props<Row> => {
+const buildProps = (
+  actions: Action<Row>[] | undefined,
+  overrides: Partial<Props<Row>> = {},
+): Props<Row> => {
   return {
     ...({ row: { original: row } } as unknown as CellContext<Row, unknown>),
     actions: actions as Action<Row>[],
+    ...overrides,
   };
 };
 
@@ -110,5 +121,301 @@ describe('Actions', () => {
     const results = await axe(container);
 
     expect(results).toHaveNoViolations();
+  });
+
+  describe('with isPortal', () => {
+    const setup = (overrides: Partial<Props<Row>> = {}) => {
+      const onEdit = vi.fn();
+      const onDelete = vi.fn();
+
+      const { container } = render(
+        <table>
+          <tbody>
+            <tr>
+              <td>{row.name}</td>
+              <td>
+                <Actions
+                  {...buildProps(
+                    [
+                      { label: 'Edit', onClick: onEdit },
+                      { label: 'Delete', onClick: onDelete },
+                    ],
+                    { isPortal: true, ...overrides },
+                  )}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>,
+      );
+
+      const user = userEvent.setup();
+      const trigger = screen.getByRole('button', { name: /show actions/i });
+      const getMenu = () => {
+        return screen.findByRole('menu');
+      };
+
+      return { container, user, trigger, onEdit, onDelete, getMenu };
+    };
+
+    const mockLayout = ({
+      innerHeight,
+      menuHeight,
+      menuWidth,
+      triggerRect,
+    }: {
+      innerHeight: number;
+      menuHeight: number;
+      menuWidth: number;
+      triggerRect: Pick<DOMRect, 'top' | 'bottom' | 'right'>;
+    }) => {
+      vi.stubGlobal('innerHeight', innerHeight);
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(
+        menuHeight,
+      );
+      vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(
+        menuWidth,
+      );
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue(
+        triggerRect as DOMRect,
+      );
+    };
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.unstubAllGlobals();
+    });
+
+    it('should keep the menu closed until the trigger is used', () => {
+      const { trigger } = setup();
+
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('should open the menu on click and render it outside the table', async () => {
+      const { user, trigger, getMenu } = setup();
+
+      await user.click(trigger);
+
+      const menu = await getMenu();
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(trigger).toHaveAttribute('aria-controls', menu.id);
+      expect(
+        within(screen.getByRole('table')).queryByRole('menu'),
+      ).not.toBeInTheDocument();
+      expect(
+        within(menu).getByRole('menuitem', { name: 'Edit' }),
+      ).toBeInTheDocument();
+      expect(
+        within(menu).getByRole('menuitem', { name: 'Delete' }),
+      ).toBeInTheDocument();
+    });
+
+    it('should call the action with the row data and close the menu', async () => {
+      const { user, trigger, onEdit, getMenu } = setup();
+
+      await user.click(trigger);
+      await user.click(
+        within(await getMenu()).getByRole('menuitem', { name: 'Edit' }),
+      );
+
+      expect(onEdit).toHaveBeenCalledWith(row);
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('should keep the menu open when a mouse click follows the hover', async () => {
+      const { user, trigger, getMenu } = setup();
+
+      await user.hover(trigger);
+      await getMenu();
+      await user.click(trigger);
+
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should toggle the menu on touch taps and ignore the touch pointer leaving', async () => {
+      const { user, trigger, getMenu } = setup();
+
+      await user.pointer({ keys: '[TouchA]', target: trigger });
+      expect(await getMenu()).toBeInTheDocument();
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, CLOSE_DELAY_MS * 2);
+      });
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+
+      await user.pointer({ keys: '[TouchA]', target: trigger });
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('should toggle the menu with Enter and Space from the keyboard', async () => {
+      const { user, trigger, getMenu } = setup();
+
+      trigger.focus();
+      await user.keyboard('{Enter}');
+      expect(await getMenu()).toBeInTheDocument();
+
+      await user.keyboard('{Enter}');
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+      await user.keyboard(' ');
+      expect(await getMenu()).toBeInTheDocument();
+    });
+
+    it('should open on hover and close after leaving', async () => {
+      const { user, trigger, getMenu } = setup();
+
+      await user.hover(trigger);
+
+      expect(await getMenu()).toBeInTheDocument();
+
+      await user.unhover(trigger);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should close when clicking outside', async () => {
+      const { user, trigger, getMenu } = setup();
+
+      await user.click(trigger);
+      await getMenu();
+      await user.click(screen.getByRole('cell', { name: row.name }));
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('should highlight the row while the menu is open', async () => {
+      const { user, trigger, getMenu } = setup();
+      const tableRow = screen.getByRole('row');
+
+      expect(tableRow).not.toHaveAttribute('data-actions-open');
+
+      await user.click(trigger);
+      await getMenu();
+
+      expect(tableRow).toHaveAttribute('data-actions-open');
+
+      await user.keyboard('{Escape}');
+
+      expect(tableRow).not.toHaveAttribute('data-actions-open');
+    });
+
+    it('should support keyboard navigation and return focus to the trigger', async () => {
+      const { user, trigger, getMenu } = setup();
+
+      trigger.focus();
+      await user.keyboard('{ArrowDown}');
+
+      const menu = await getMenu();
+      const edit = within(menu).getByRole('menuitem', { name: 'Edit' });
+      const remove = within(menu).getByRole('menuitem', { name: 'Delete' });
+
+      expect(edit).toHaveFocus();
+
+      await user.keyboard('{ArrowDown}');
+      expect(remove).toHaveFocus();
+
+      await user.keyboard('{ArrowDown}');
+      expect(edit).toHaveFocus();
+
+      await user.keyboard('{End}');
+      expect(remove).toHaveFocus();
+
+      await user.keyboard('{Home}');
+      expect(edit).toHaveFocus();
+
+      await user.keyboard('{Escape}');
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+
+    it('should open with the last item focused on ArrowUp', async () => {
+      const { user, trigger, getMenu } = setup();
+
+      trigger.focus();
+      await user.keyboard('{ArrowUp}');
+
+      expect(
+        within(await getMenu()).getByRole('menuitem', { name: 'Delete' }),
+      ).toHaveFocus();
+    });
+
+    it('should position the menu below the trigger, aligned to its right edge', async () => {
+      mockLayout({
+        innerHeight: 1000,
+        menuHeight: 100,
+        menuWidth: 215,
+        triggerRect: { top: 200, bottom: 230, right: 800 },
+      });
+
+      const { user, trigger, getMenu } = setup();
+
+      await user.click(trigger);
+      const menu = await getMenu();
+
+      expect(menu).toHaveStyle({ top: '234px', left: '585px' });
+    });
+
+    it('should flip the menu above the trigger when it does not fit below', async () => {
+      mockLayout({
+        innerHeight: 300,
+        menuHeight: 100,
+        menuWidth: 215,
+        triggerRect: { top: 200, bottom: 230, right: 800 },
+      });
+
+      const { user, trigger, getMenu } = setup();
+
+      await user.click(trigger);
+      const menu = await getMenu();
+
+      expect(menu).toHaveStyle({ top: '96px', left: '585px' });
+    });
+
+    it('should follow the trigger when a container scrolls', async () => {
+      mockLayout({
+        innerHeight: 1000,
+        menuHeight: 100,
+        menuWidth: 215,
+        triggerRect: { top: 200, bottom: 230, right: 800 },
+      });
+
+      const { user, trigger, getMenu } = setup();
+
+      await user.click(trigger);
+      const menu = await getMenu();
+
+      expect(menu).toHaveStyle({ top: '234px', left: '585px' });
+
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+        top: 100,
+        bottom: 130,
+        right: 600,
+      } as DOMRect);
+      fireEvent.scroll(screen.getByRole('table'));
+
+      expect(menu).toHaveStyle({ top: '134px', left: '385px' });
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it("shouldn't have accessibility violations while open", async () => {
+      const { user, trigger, getMenu } = setup();
+
+      await user.click(trigger);
+      await getMenu();
+
+      const results = await axe(document.body, {
+        rules: { region: { enabled: false } },
+      });
+
+      expect(results).toHaveNoViolations();
+    });
   });
 });

--- a/lib/components/VirtualizedTable/components/Actions/Actions.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.tsx
@@ -1,170 +1,20 @@
-import { EllipsisVertical } from 'lucide-react';
-import { useRef, useState } from 'react';
-
-import { Button } from '@/components/Button/Button';
-import { cn } from '@/utils';
-
 import { RowData } from '../../VirtualizedTable.types';
 
 import { Props } from './Actions.types';
-
-const ITEM_HEIGHT = 36;
-const LIST_PADDING = 16;
+import { InlineActions } from './components/InlineActions/InlineActions';
+import { PortalActions } from './components/PortalActions/PortalActions';
 
 export const Actions = <TData extends RowData>({
-  actions,
-  wrapperClassName,
-  triggerButtonClassName,
-  iconTriggerButtonClassName,
-  wrapperActionsClassName,
-  wrapperContentActionsClassName,
-  ...delegated
+  isPortal = false,
+  ...props
 }: Props<TData>) => {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [openUp, setOpenUp] = useState(false);
-
-  const updateDirection = () => {
-    const root = rootRef.current;
-
-    if (!root || !actions) {
-      return;
-    }
-
-    const triggerRect = root.getBoundingClientRect();
-    const menuHeight = actions.length * ITEM_HEIGHT + LIST_PADDING;
-
-    let clipTop = 0;
-    let clipBottom = window.innerHeight;
-    let node = root.parentElement;
-
-    while (node) {
-      const { overflowY } = window.getComputedStyle(node);
-
-      if (['auto', 'scroll', 'hidden'].includes(overflowY)) {
-        const rect = node.getBoundingClientRect();
-        clipTop = rect.top;
-        clipBottom = rect.bottom;
-        break;
-      }
-
-      node = node.parentElement;
-    }
-
-    const spaceBelow = clipBottom - triggerRect.bottom;
-    const spaceAbove = triggerRect.top - clipTop;
-
-    setOpenUp(spaceBelow < menuHeight && spaceAbove > spaceBelow);
-  };
-
-  if (!actions) {
+  if (!props.actions) {
     return null;
   }
 
-  return (
-    <div
-      ref={rootRef}
-      className={cn('relative group', wrapperClassName)}
-      onMouseEnter={updateDirection}
-    >
-      <Button
-        variant="link"
-        shape="circle"
-        size="large"
-        className={cn(
-          'text-slate-400',
-          'group-hover:text-slate-800',
-          'group-hover:bg-aurora-50',
-          'dark:text-metal-400',
-          'dark:group-hover:text-aurora-500',
-          'dark:group-hover:bg-aurora-900',
-          triggerButtonClassName,
-        )}
-      >
-        <EllipsisVertical
-          aria-hidden="true"
-          className={cn('w-7 h-7', iconTriggerButtonClassName)}
-        />
-        <span className="sr-only">Show Actions</span>
-      </Button>
+  if (isPortal) {
+    return <PortalActions {...props} />;
+  }
 
-      <div
-        className={cn(
-          'absolute',
-          'right-0',
-          'w-53.75',
-          'z-10',
-          openUp ? 'bottom-full' : 'top-full',
-          openUp ? 'pb-1' : 'pt-1',
-          'invisible',
-          'opacity-0',
-          'transition-[opacity,visibility]',
-          'duration-150',
-          'delay-150',
-          'group-hover:visible',
-          'group-hover:opacity-100',
-          'group-hover:delay-0',
-          'group-hover:duration-75',
-          wrapperActionsClassName,
-        )}
-      >
-        <div
-          className={cn(
-            'bg-white',
-            'py-2',
-            'rounded-lg',
-            'shadow-lg',
-            'border',
-            'border-zinc-100',
-            'dark:bg-metal-800',
-            'dark:border-metal-700',
-            wrapperContentActionsClassName,
-          )}
-        >
-          {actions.map(
-            (
-              {
-                id,
-                label,
-                className,
-                component: Component = Button,
-                componentProps,
-                onClick,
-              },
-              index,
-            ) => (
-              <Component
-                key={
-                  id ?? (typeof label === 'string' ? label : `action-${index}`)
-                }
-                className={cn(
-                  'w-full',
-                  'text-slate-800',
-                  'cursor-pointer',
-                  'p-0',
-                  'h-9',
-                  'flex',
-                  'gap-2',
-                  'text-sm',
-                  'font-normal',
-                  'justify-start',
-                  'rounded-none',
-                  'px-6',
-                  'hover:bg-gray-50',
-                  'hover:text-slate-800',
-                  'hover:no-underline',
-                  'dark:hover:bg-metal-700',
-                  className,
-                )}
-                variant="link"
-                onClick={() => onClick(delegated.row.original)}
-                {...componentProps}
-              >
-                {label}
-              </Component>
-            ),
-          )}
-        </div>
-      </div>
-    </div>
-  );
+  return <InlineActions {...props} />;
 };

--- a/lib/components/VirtualizedTable/components/Actions/Actions.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.types.ts
@@ -1,5 +1,5 @@
 import { CellContext } from '@tanstack/react-table';
-import { FC, ReactNode } from 'react';
+import { ElementType, ReactNode } from 'react';
 
 import { RowData } from '../../VirtualizedTable.types';
 
@@ -9,7 +9,7 @@ export type Action<TData> = {
   onClick: (rowData: TData) => void;
 } & (
   | {
-      component: FC;
+      component: ElementType;
       label?: string | ReactNode;
       componentProps?: Record<string, unknown>;
     }
@@ -23,6 +23,7 @@ export type Action<TData> = {
 export type Props<TData extends RowData> = CellContext<TData, unknown> & {
   actions: Action<TData>[];
   iconTriggerButtonClassName?: string;
+  isPortal?: boolean;
   triggerButtonClassName?: string;
   wrapperActionsClassName?: string;
   wrapperClassName?: string;

--- a/lib/components/VirtualizedTable/components/Actions/Actions.variants.ts
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.variants.ts
@@ -1,0 +1,60 @@
+import { cva } from 'class-variance-authority';
+
+export const actionsTriggerVariants = cva(
+  [
+    'text-slate-400',
+    'group-hover:text-slate-800',
+    'group-hover:bg-aurora-50',
+    'dark:text-metal-400',
+    'dark:group-hover:text-aurora-500',
+    'dark:group-hover:bg-aurora-900',
+  ],
+  {
+    variants: {
+      isOpen: {
+        true: [
+          'text-slate-800',
+          'bg-aurora-50',
+          'dark:text-aurora-500',
+          'dark:bg-aurora-900',
+        ],
+        false: [],
+      },
+    },
+    defaultVariants: {
+      isOpen: false,
+    },
+  },
+);
+
+export const actionsPanelVariants = cva([
+  'bg-white',
+  'py-2',
+  'rounded-lg',
+  'shadow-lg',
+  'border',
+  'border-zinc-100',
+  'dark:bg-metal-800',
+  'dark:border-metal-700',
+]);
+
+export const actionsItemVariants = cva([
+  'w-full',
+  'text-slate-800',
+  'cursor-pointer',
+  'p-0',
+  'h-9',
+  'flex',
+  'gap-2',
+  'text-sm',
+  'font-normal',
+  'justify-start',
+  'rounded-none',
+  'px-6',
+  'hover:bg-gray-50',
+  'hover:text-slate-800',
+  'hover:no-underline',
+  'focus:no-underline',
+  'dark:hover:bg-metal-700',
+  'dark:focus:bg-metal-700',
+]);

--- a/lib/components/VirtualizedTable/components/Actions/components/ActionsList/ActionsList.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/components/ActionsList/ActionsList.tsx
@@ -1,0 +1,48 @@
+import { Button } from '@/components/Button/Button';
+import { cn } from '@/utils';
+
+import { RowData } from '../../../../VirtualizedTable.types';
+import {
+  actionsItemVariants,
+  actionsPanelVariants,
+} from '../../Actions.variants';
+
+import { Props } from './ActionsList.types';
+
+export const ActionsList = <TData extends RowData>({
+  actions,
+  className,
+  isMenu = false,
+  rowData,
+  onSelect,
+}: Props<TData>) => (
+  <div className={cn(actionsPanelVariants(), className)}>
+    {actions.map(
+      (
+        {
+          id,
+          label,
+          className: itemClassName,
+          component: Component = Button,
+          componentProps,
+          onClick,
+        },
+        index,
+      ) => (
+        <Component
+          key={id ?? (typeof label === 'string' ? label : `action-${index}`)}
+          className={cn(actionsItemVariants(), itemClassName)}
+          variant="link"
+          onClick={() => {
+            onSelect?.();
+            onClick(rowData);
+          }}
+          {...(isMenu ? { role: 'menuitem', tabIndex: -1 } : {})}
+          {...componentProps}
+        >
+          {label}
+        </Component>
+      ),
+    )}
+  </div>
+);

--- a/lib/components/VirtualizedTable/components/Actions/components/ActionsList/ActionsList.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/ActionsList/ActionsList.types.ts
@@ -1,0 +1,10 @@
+import { RowData } from '../../../../VirtualizedTable.types';
+import { Action } from '../../Actions.types';
+
+export type Props<TData extends RowData> = {
+  actions: Action<TData>[];
+  className?: string;
+  isMenu?: boolean;
+  rowData: TData;
+  onSelect?: () => void;
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/ActionsTrigger/ActionsTrigger.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/components/ActionsTrigger/ActionsTrigger.tsx
@@ -1,0 +1,31 @@
+import { EllipsisVertical } from 'lucide-react';
+import { forwardRef } from 'react';
+
+import { Button } from '@/components/Button/Button';
+import { cn } from '@/utils';
+
+import { actionsTriggerVariants } from '../../Actions.variants';
+
+import { Props } from './ActionsTrigger.types';
+
+export const ActionsTrigger = forwardRef<HTMLButtonElement, Props>(
+  ({ className, iconClassName, isOpen = false, ...delegated }, ref) => (
+    <Button
+      ref={ref}
+      type="button"
+      variant="link"
+      shape="circle"
+      size="large"
+      className={cn(actionsTriggerVariants({ isOpen }), className)}
+      {...delegated}
+    >
+      <EllipsisVertical
+        aria-hidden="true"
+        className={cn('w-7 h-7', iconClassName)}
+      />
+      <span className="sr-only">Show Actions</span>
+    </Button>
+  ),
+);
+
+ActionsTrigger.displayName = 'KonstructVirtualizedTableActionsTrigger';

--- a/lib/components/VirtualizedTable/components/Actions/components/ActionsTrigger/ActionsTrigger.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/ActionsTrigger/ActionsTrigger.types.ts
@@ -1,0 +1,8 @@
+import { ComponentProps } from 'react';
+
+import { Button } from '@/components/Button/Button';
+
+export type Props = Omit<ComponentProps<typeof Button>, 'ref'> & {
+  iconClassName?: string;
+  isOpen?: boolean;
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/InlineActions/InlineActions.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/components/InlineActions/InlineActions.tsx
@@ -1,0 +1,96 @@
+import { useRef, useState } from 'react';
+
+import { cn } from '@/utils';
+
+import { RowData } from '../../../../VirtualizedTable.types';
+import { Props } from '../../Actions.types';
+import { ActionsList } from '../ActionsList/ActionsList';
+import { ActionsTrigger } from '../ActionsTrigger/ActionsTrigger';
+
+import { ITEM_HEIGHT, LIST_PADDING } from './constants';
+
+export const InlineActions = <TData extends RowData>({
+  actions,
+  wrapperClassName,
+  triggerButtonClassName,
+  iconTriggerButtonClassName,
+  wrapperActionsClassName,
+  wrapperContentActionsClassName,
+  ...delegated
+}: Omit<Props<TData>, 'isPortal'>) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [openUp, setOpenUp] = useState(false);
+
+  const updateDirection = () => {
+    const root = rootRef.current;
+
+    if (!root) {
+      return;
+    }
+
+    const triggerRect = root.getBoundingClientRect();
+    const menuHeight = actions.length * ITEM_HEIGHT + LIST_PADDING;
+
+    let clipTop = 0;
+    let clipBottom = window.innerHeight;
+    let node = root.parentElement;
+
+    while (node) {
+      const { overflowY } = window.getComputedStyle(node);
+
+      if (['auto', 'scroll', 'hidden'].includes(overflowY)) {
+        const rect = node.getBoundingClientRect();
+        clipTop = rect.top;
+        clipBottom = rect.bottom;
+        break;
+      }
+
+      node = node.parentElement;
+    }
+
+    const spaceBelow = clipBottom - triggerRect.bottom;
+    const spaceAbove = triggerRect.top - clipTop;
+
+    setOpenUp(spaceBelow < menuHeight && spaceAbove > spaceBelow);
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn('relative group', wrapperClassName)}
+      onMouseEnter={updateDirection}
+    >
+      <ActionsTrigger
+        className={triggerButtonClassName}
+        iconClassName={iconTriggerButtonClassName}
+      />
+
+      <div
+        className={cn(
+          'absolute',
+          'right-0',
+          'w-53.75',
+          'z-10',
+          openUp ? 'bottom-full' : 'top-full',
+          openUp ? 'pb-1' : 'pt-1',
+          'invisible',
+          'opacity-0',
+          'transition-[opacity,visibility]',
+          'duration-150',
+          'delay-150',
+          'group-hover:visible',
+          'group-hover:opacity-100',
+          'group-hover:delay-0',
+          'group-hover:duration-75',
+          wrapperActionsClassName,
+        )}
+      >
+        <ActionsList
+          actions={actions}
+          className={wrapperContentActionsClassName}
+          rowData={delegated.row.original}
+        />
+      </div>
+    </div>
+  );
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/InlineActions/constants/index.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/InlineActions/constants/index.ts
@@ -1,0 +1,3 @@
+export const ITEM_HEIGHT = 36;
+
+export const LIST_PADDING = 16;

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/PortalActions.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/PortalActions.tsx
@@ -1,0 +1,84 @@
+import { createPortal } from 'react-dom';
+
+import { cn } from '@/utils';
+
+import { RowData } from '../../../../VirtualizedTable.types';
+import { Props } from '../../Actions.types';
+import { ActionsList } from '../ActionsList/ActionsList';
+import { ActionsTrigger } from '../ActionsTrigger/ActionsTrigger';
+
+import { useActionsMenu } from './hooks';
+
+export const PortalActions = <TData extends RowData>({
+  actions,
+  wrapperClassName,
+  triggerButtonClassName,
+  iconTriggerButtonClassName,
+  wrapperActionsClassName,
+  wrapperContentActionsClassName,
+  ...delegated
+}: Omit<Props<TData>, 'isPortal'>) => {
+  const {
+    buttonRef,
+    hasOpened,
+    isOpen,
+    menuId,
+    menuRef,
+    triggerRef,
+    closeMenu,
+    handleMenuKeyDown,
+    handlePointerEnter,
+    handlePointerLeave,
+    handleTriggerClick,
+    handleTriggerKeyDown,
+    handleTriggerPointerDown,
+  } = useActionsMenu();
+
+  return (
+    <div
+      ref={triggerRef}
+      className={cn('group inline-flex', wrapperClassName)}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+      onKeyDown={handleTriggerKeyDown}
+    >
+      <ActionsTrigger
+        ref={buttonRef}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-controls={hasOpened ? menuId : undefined}
+        className={triggerButtonClassName}
+        iconClassName={iconTriggerButtonClassName}
+        isOpen={isOpen}
+        onClick={handleTriggerClick}
+        onPointerDown={handleTriggerPointerDown}
+      />
+
+      {hasOpened &&
+        createPortal(
+          <div
+            id={menuId}
+            ref={menuRef}
+            role="menu"
+            hidden={!isOpen}
+            className={cn('fixed z-50 w-53.75', wrapperActionsClassName)}
+            onPointerEnter={handlePointerEnter}
+            onPointerLeave={handlePointerLeave}
+            onKeyDown={handleMenuKeyDown}
+          >
+            <ActionsList
+              actions={actions}
+              className={cn(
+                'animate-in fade-in-0',
+                wrapperContentActionsClassName,
+              )}
+              isMenu
+              rowData={delegated.row.original}
+              onSelect={closeMenu}
+            />
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/constants/index.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/constants/index.ts
@@ -1,0 +1,3 @@
+export const CLOSE_DELAY_MS = 100;
+
+export const MENU_GAP_PX = 4;

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/index.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-actions-menu/use-actions-menu';

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-actions-menu/use-actions-menu.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-actions-menu/use-actions-menu.ts
@@ -1,0 +1,57 @@
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+
+import { useMenuInteractions } from '../use-menu-interactions/use-menu-interactions';
+import { useMenuKeyboardNavigation } from '../use-menu-keyboard-navigation/use-menu-keyboard-navigation';
+import { useRowHighlight } from '../use-row-highlight/use-row-highlight';
+
+export const useActionsMenu = () => {
+  const [isOpen, setIsOpenState] = useState(false);
+  const [hasOpened, setHasOpened] = useState(false);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+
+  const setIsOpen = useCallback<Dispatch<SetStateAction<boolean>>>((value) => {
+    setHasOpened(true);
+    setIsOpenState(value);
+  }, []);
+
+  const {
+    closeMenu,
+    handlePointerEnter,
+    handlePointerLeave,
+    handleTriggerClick,
+    handleTriggerPointerDown,
+    openMenu,
+  } = useMenuInteractions({ isOpen, menuRef, triggerRef, setIsOpen });
+
+  const { handleMenuKeyDown, handleTriggerKeyDown } = useMenuKeyboardNavigation(
+    { buttonRef, isOpen, menuRef, closeMenu, openMenu },
+  );
+
+  useRowHighlight({ isOpen, triggerRef });
+
+  return {
+    buttonRef,
+    hasOpened,
+    isOpen,
+    menuId,
+    menuRef,
+    triggerRef,
+    closeMenu,
+    handleMenuKeyDown,
+    handlePointerEnter,
+    handlePointerLeave,
+    handleTriggerClick,
+    handleTriggerKeyDown,
+    handleTriggerPointerDown,
+  };
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-interactions/use-menu-interactions.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-interactions/use-menu-interactions.ts
@@ -1,0 +1,167 @@
+import {
+  PointerEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from 'react';
+
+import { CLOSE_DELAY_MS, MENU_GAP_PX } from '../../constants';
+
+import { Params } from './use-menu-interactions.types';
+
+export const useMenuInteractions = ({
+  isOpen,
+  menuRef,
+  triggerRef,
+  setIsOpen,
+}: Params) => {
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const pointerTypeRef = useRef<string | null>(null);
+
+  const openMenu = useCallback(() => {
+    clearTimeout(closeTimeoutRef.current);
+    setIsOpen(true);
+  }, [setIsOpen]);
+
+  const closeMenu = useCallback(() => {
+    clearTimeout(closeTimeoutRef.current);
+    setIsOpen(false);
+  }, [setIsOpen]);
+
+  const scheduleClose = useCallback(() => {
+    clearTimeout(closeTimeoutRef.current);
+    closeTimeoutRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, CLOSE_DELAY_MS);
+  }, [setIsOpen]);
+
+  const handlePointerEnter = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      if (event.pointerType !== 'touch') {
+        openMenu();
+      }
+    },
+    [openMenu],
+  );
+
+  const handlePointerLeave = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      if (event.pointerType !== 'touch') {
+        scheduleClose();
+      }
+    },
+    [scheduleClose],
+  );
+
+  const handleTriggerPointerDown = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      pointerTypeRef.current = event.pointerType;
+    },
+    [],
+  );
+
+  const handleTriggerClick = useCallback(() => {
+    const pointerType = pointerTypeRef.current;
+    pointerTypeRef.current = null;
+    clearTimeout(closeTimeoutRef.current);
+
+    if (pointerType && pointerType !== 'touch') {
+      setIsOpen(true);
+
+      return;
+    }
+
+    setIsOpen((previous) => {
+      return !previous;
+    });
+  }, [setIsOpen]);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(closeTimeoutRef.current);
+    };
+  }, []);
+
+  const updatePosition = useCallback(() => {
+    const trigger = triggerRef.current;
+    const menu = menuRef.current;
+
+    if (!trigger || !menu) {
+      return;
+    }
+
+    const rect = trigger.getBoundingClientRect();
+    const fitsBelow =
+      rect.bottom + MENU_GAP_PX + menu.offsetHeight <= window.innerHeight;
+    const top = fitsBelow
+      ? rect.bottom + MENU_GAP_PX
+      : rect.top - MENU_GAP_PX - menu.offsetHeight;
+
+    menu.style.top = `${Math.max(top, MENU_GAP_PX)}px`;
+    menu.style.left = `${Math.max(rect.right - menu.offsetWidth, MENU_GAP_PX)}px`;
+  }, [menuRef, triggerRef]);
+
+  useLayoutEffect(() => {
+    if (isOpen) {
+      updatePosition();
+    }
+  }, [isOpen, updatePosition]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      const isInside =
+        triggerRef.current?.contains(target) ||
+        menuRef.current?.contains(target);
+
+      if (!isInside) {
+        closeMenu();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeMenu();
+      }
+    };
+
+    document.addEventListener('mousedown', handleMouseDown, {
+      signal: controller.signal,
+    });
+    document.addEventListener('keydown', handleKeyDown, {
+      signal: controller.signal,
+    });
+    document.addEventListener('scroll', updatePosition, {
+      signal: controller.signal,
+      capture: true,
+      passive: true,
+    });
+    window.addEventListener('resize', updatePosition, {
+      signal: controller.signal,
+      passive: true,
+    });
+    window.addEventListener('blur', closeMenu, { signal: controller.signal });
+
+    return () => {
+      controller.abort();
+    };
+  }, [isOpen, menuRef, triggerRef, closeMenu, updatePosition]);
+
+  return {
+    closeMenu,
+    handlePointerEnter,
+    handlePointerLeave,
+    handleTriggerClick,
+    handleTriggerPointerDown,
+    openMenu,
+  };
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-interactions/use-menu-interactions.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-interactions/use-menu-interactions.types.ts
@@ -1,0 +1,8 @@
+import { Dispatch, RefObject, SetStateAction } from 'react';
+
+export type Params = {
+  isOpen: boolean;
+  menuRef: RefObject<HTMLDivElement | null>;
+  triggerRef: RefObject<HTMLDivElement | null>;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-keyboard-navigation/use-menu-keyboard-navigation.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-keyboard-navigation/use-menu-keyboard-navigation.ts
@@ -1,0 +1,121 @@
+import { KeyboardEvent, useCallback, useLayoutEffect, useRef } from 'react';
+
+import { Params } from './use-menu-keyboard-navigation.types';
+
+export const useMenuKeyboardNavigation = ({
+  buttonRef,
+  isOpen,
+  menuRef,
+  closeMenu,
+  openMenu,
+}: Params) => {
+  const pendingFocusRef = useRef<'first' | 'last' | null>(null);
+
+  const getMenuItems = useCallback(() => {
+    return Array.from(
+      menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [],
+    );
+  }, [menuRef]);
+
+  const focusMenuItem = useCallback(
+    (index: number) => {
+      const items = getMenuItems();
+
+      if (items.length === 0) {
+        return;
+      }
+
+      items[(index + items.length) % items.length]?.focus();
+    },
+    [getMenuItems],
+  );
+
+  const closeAndRefocus = useCallback(() => {
+    closeMenu();
+    buttonRef.current?.focus();
+  }, [buttonRef, closeMenu]);
+
+  useLayoutEffect(() => {
+    if (isOpen && pendingFocusRef.current) {
+      focusMenuItem(pendingFocusRef.current === 'first' ? 0 : -1);
+      pendingFocusRef.current = null;
+    }
+  }, [isOpen, focusMenuItem]);
+
+  const handleTriggerKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!event.currentTarget.contains(event.target as Node)) {
+        return;
+      }
+
+      const isTabIntoMenu = event.key === 'Tab' && !event.shiftKey && isOpen;
+
+      if (event.key === 'ArrowDown' || isTabIntoMenu) {
+        event.preventDefault();
+
+        if (isOpen) {
+          focusMenuItem(0);
+        } else {
+          pendingFocusRef.current = 'first';
+          openMenu();
+        }
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+
+        if (isOpen) {
+          focusMenuItem(-1);
+        } else {
+          pendingFocusRef.current = 'last';
+          openMenu();
+        }
+      }
+    },
+    [isOpen, focusMenuItem, openMenu],
+  );
+
+  const handleMenuKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const items = getMenuItems();
+      const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          focusMenuItem(currentIndex + 1);
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          focusMenuItem(currentIndex - 1);
+          break;
+        case 'Home':
+          event.preventDefault();
+          focusMenuItem(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          focusMenuItem(-1);
+          break;
+        case 'Tab': {
+          event.preventDefault();
+          const nextIndex = event.shiftKey
+            ? currentIndex - 1
+            : currentIndex + 1;
+
+          if (nextIndex < 0 || nextIndex >= items.length) {
+            closeAndRefocus();
+          } else {
+            focusMenuItem(nextIndex);
+          }
+          break;
+        }
+        case 'Escape':
+          event.preventDefault();
+          closeAndRefocus();
+          break;
+      }
+    },
+    [getMenuItems, focusMenuItem, closeAndRefocus],
+  );
+
+  return { handleMenuKeyDown, handleTriggerKeyDown };
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-keyboard-navigation/use-menu-keyboard-navigation.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-keyboard-navigation/use-menu-keyboard-navigation.types.ts
@@ -1,0 +1,9 @@
+import { RefObject } from 'react';
+
+export type Params = {
+  buttonRef: RefObject<HTMLButtonElement | null>;
+  isOpen: boolean;
+  menuRef: RefObject<HTMLDivElement | null>;
+  closeMenu: () => void;
+  openMenu: () => void;
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-row-highlight/use-row-highlight.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-row-highlight/use-row-highlight.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+import { Params } from './use-row-highlight.types';
+
+export const useRowHighlight = ({ isOpen, triggerRef }: Params) => {
+  useEffect(() => {
+    const row = triggerRef.current?.closest('tr');
+
+    if (!row || !isOpen) {
+      return;
+    }
+
+    row.setAttribute('data-actions-open', '');
+
+    return () => {
+      row.removeAttribute('data-actions-open');
+    };
+  }, [isOpen, triggerRef]);
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-row-highlight/use-row-highlight.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-row-highlight/use-row-highlight.types.ts
@@ -1,0 +1,6 @@
+import { RefObject } from 'react';
+
+export type Params = {
+  isOpen: boolean;
+  triggerRef: RefObject<HTMLElement | null>;
+};

--- a/lib/components/VirtualizedTable/components/Body/Body.tsx
+++ b/lib/components/VirtualizedTable/components/Body/Body.tsx
@@ -169,6 +169,8 @@ export const Body = <TData extends RowData = RowData>({
                       'dark:border-metal-700',
                       'dark:first:border-l',
                       'dark:last:border-r',
+                      '[tr[data-actions-open]_&]:bg-zinc-100',
+                      'dark:[tr[data-actions-open]_&]:bg-metal-800',
                       {
                         'group-hover/row:bg-zinc-100 dark:group-hover/row:bg-metal-800':
                           enableHoverRow,

--- a/lib/components/VirtualizedTable/stories/Light.stories.tsx
+++ b/lib/components/VirtualizedTable/stories/Light.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof VirtualizedTableComponent> = {
 
 const queryClient = new QueryClient();
 
-const columns: ColumnDef<Pokemon>[] = [
+const getColumns = (isPortal = false): ColumnDef<Pokemon>[] => [
   {
     header: 'Id',
     accessorKey: 'id',
@@ -89,6 +89,7 @@ const columns: ColumnDef<Pokemon>[] = [
     cell: (props) => (
       <VirtualizedTableComponent.Actions
         {...props}
+        isPortal={isPortal}
         actions={[
           {
             component: AlertDialog,
@@ -154,6 +155,8 @@ const columns: ColumnDef<Pokemon>[] = [
     },
   },
 ];
+
+const columns = getColumns();
 
 const args = {
   showFilter: true,
@@ -535,7 +538,7 @@ export const HorizontalScrollWithFilters: Story = {
     docs: {
       description: {
         story:
-          'The scroll container (classNameScrollContainer) wraps the table and the pagination bar so both scroll together; the filter row stays fixed to the container width. Filter dropdowns always render in a portal, and the page-size dropdown does so automatically when classNameScrollContainer is set, so the overflow container never clips them.',
+          'The scroll container (classNameScrollContainer) wraps the table and the pagination bar so both scroll together; the filter row stays fixed to the container width. Filter dropdowns always render in a portal, and the page-size dropdown does so automatically when classNameScrollContainer is set, so the overflow container never clips them. Row actions opt in with `isPortal` so the menu floats above the scroll container instead of being clipped by it.',
       },
     },
   },
@@ -597,7 +600,7 @@ export const HorizontalScrollWithFilters: Story = {
             id={id}
             ariaLabel="List of pokemons"
             data={data}
-            columns={columns}
+            columns={getColumns(true)}
             classNameTable="min-w-300"
             classNameScrollContainer="overflow-x-auto contain-inline-size"
             showPagination={true}


### PR DESCRIPTION
## Why

`VirtualizedTable.Actions` renders its menu as an `absolute` element inside the table. As soon as the table lives in an `overflow-x-auto` scroll container (the `HorizontalScrollWithFilters` case) the browser also clips on the Y axis and the menu gets cut off.

Every product hit this and worked around it locally: compute (`InstanceActions`), kubernetes (`ClusterActions`), databases (`DatabaseActions`), volumes (`VolumeActions`) and vpc (`TableActions`) each carry a near-identical copy that portals a `position: fixed` menu. This PR brings that behaviour into the library so those copies can go away.

It is **opt-in**. The portal adds runtime work (fixed positioning, global listeners) that a table without a scroll container does not need, so the current inline menu stays the default and consumers switch with a single prop.

## What is in here

### `isPortal` on `VirtualizedTable.Actions`

```tsx
<VirtualizedTable.Actions {...props} isPortal actions={actions} />
```

With `isPortal` the menu is rendered with `createPortal` into `document.body`, positioned from the trigger rect and flipped above the trigger when it does not fit below the viewport. Without it nothing changes.

### Interaction rules of the portal menu

- **Desktop**: hover opens, leaving closes after a short delay, same as the CSS `group-hover` version today. A mouse click on the trigger never closes the menu.
- **Mobile**: a tap toggles the menu. Touch `pointerenter`/`pointerleave` are ignored because browsers fire them around every tap and they would close the menu 100 ms after opening it.
- **Keyboard**: Enter/Space toggle, ArrowDown/ArrowUp open with the first/last item focused, Home/End/Tab move between items, Escape closes and returns focus to the trigger. Tab from the trigger enters the menu even though it lives at the end of `body`.
- **Scroll and resize** reposition the menu from the trigger instead of closing it, so it follows its row inside any scroll container. Outside click, Escape and window blur close it.
- The row gets `data-actions-open` while the menu is open and `Body` paints it with the hover colours, so the user can tell which row the floating menu belongs to.
- The menu stays mounted (with `hidden`) after the first open, so actions rendered through `component` (e.g. `AlertDialog`) survive the menu closing, exactly like they do with the inline version today.

### Structure

`Actions.tsx` only dispatches between `InlineActions` (the previous code, untouched functionally) and `PortalActions`. Both share `ActionsTrigger`, `ActionsList` and the CVA variants in `Actions.variants.ts`. The portal hooks (`use-menu-interactions`, `use-menu-keyboard-navigation`, `use-row-highlight`, composed by `use-actions-menu`) live under `PortalActions/hooks`, and each mode keeps its constants in its own `constants` folder.

`Action['component']` is now typed as `ElementType` instead of `FC`, which is what the vpc copy already needed for `Link`-style components.

## How to verify

- `npm run ci` passes (835 tests). The new tests query by role (`button`, `menu`, `menuitem`, `row`) and cover hover, click after hover, touch taps, keyboard, outside click, flip positioning, repositioning on scroll, the row highlight and jest-axe.
- Storybook → `In Review/VirtualizedTable/Light/HorizontalScrollWithFilters` now uses `isPortal`: open a row menu, scroll the table horizontally and the menu follows the trigger instead of being clipped. The other stories keep the inline menu for comparison.

## Follow-up

Once released, replace the local copies in compute, kubernetes, databases, volumes and vpc with `<VirtualizedTable.Actions isPortal />`.
