### PR TITLE
✨ feat: add disabled actions and openOnHover to VirtualizedTable.Actions

### DIFF
--- a/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
@@ -108,12 +108,150 @@ describe('Actions', () => {
     expect(panel.className).not.toContain('top-full');
   });
 
+  it('should expose a disabled action as aria-disabled and ignore its clicks', async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <Actions
+        {...buildProps([
+          { label: 'Delete', disabled: true, onClick: onDelete },
+        ])}
+      />,
+    );
+
+    const action = screen.getByRole('button', { name: 'Delete' });
+
+    expect(action).toHaveAttribute('aria-disabled', 'true');
+
+    await user.click(action);
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('should explain a disabled action with a tooltip', async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <Actions
+        {...buildProps([
+          {
+            label: 'Delete',
+            disabledReason: 'This volume is attached',
+            onClick: onDelete,
+          },
+        ])}
+      />,
+    );
+
+    const action = screen.getByRole('button', { name: 'Delete' });
+
+    expect(action).toHaveAttribute('aria-disabled', 'true');
+
+    await user.hover(action);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'This volume is attached',
+    );
+
+    await user.click(action);
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('should stop revealing the panel on hover after an action is selected until the pointer leaves', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+
+    const { container } = render(
+      <Actions {...buildProps([{ label: 'Edit', onClick: onEdit }])} />,
+    );
+
+    const root = container.querySelector('.group') as HTMLElement;
+    const panel = container.querySelector('.absolute') as HTMLElement;
+
+    expect(panel.className).toContain('group-hover:visible');
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(onEdit).toHaveBeenCalledWith(row);
+    expect(panel.className).not.toContain('group-hover:visible');
+
+    fireEvent.mouseLeave(root);
+
+    expect(panel.className).toContain('group-hover:visible');
+  });
+
+  describe('with openOnHover disabled', () => {
+    it('should toggle the panel on click instead of hover', async () => {
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <div>
+          <span>outside</span>
+          <Actions
+            {...buildProps([{ label: 'Edit', onClick: vi.fn() }], {
+              openOnHover: false,
+            })}
+          />
+        </div>,
+      );
+
+      const trigger = screen.getByRole('button', { name: /show actions/i });
+      const panel = container.querySelector('.absolute') as HTMLElement;
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(panel.className).not.toContain('group-hover:visible');
+      expect(panel.className).toContain('invisible');
+
+      await user.click(trigger);
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(panel.className).toContain('visible');
+      expect(panel.className).not.toContain('invisible');
+
+      await user.click(screen.getByText('outside'));
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(panel.className).toContain('invisible');
+    });
+
+    it('should close the panel after selecting an action or pressing Escape', async () => {
+      const onEdit = vi.fn();
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <Actions
+          {...buildProps([{ label: 'Edit', onClick: onEdit }], {
+            openOnHover: false,
+          })}
+        />,
+      );
+
+      const trigger = screen.getByRole('button', { name: /show actions/i });
+      const panel = container.querySelector('.absolute') as HTMLElement;
+
+      await user.click(trigger);
+      await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+      expect(onEdit).toHaveBeenCalledWith(row);
+      expect(panel.className).toContain('invisible');
+
+      await user.click(trigger);
+      expect(panel.className).not.toContain('invisible');
+
+      await user.keyboard('{Escape}');
+      expect(panel.className).toContain('invisible');
+    });
+  });
+
   it("shouldn't have accessibility violations", async () => {
     const { container } = render(
       <Actions
         {...buildProps([
           { label: 'Edit', onClick: vi.fn() },
-          { label: 'Delete', onClick: vi.fn() },
+          { label: 'Delete', disabledReason: 'In use', onClick: vi.fn() },
         ])}
       />,
     );
@@ -124,7 +262,20 @@ describe('Actions', () => {
   });
 
   describe('with isPortal', () => {
-    const setup = (overrides: Partial<Props<Row>> = {}) => {
+    const defaultActions = (onEdit: () => void, onDelete: () => void) => {
+      return [
+        { label: 'Edit', onClick: onEdit },
+        { label: 'Delete', onClick: onDelete },
+      ] satisfies Action<Row>[];
+    };
+
+    const setup = (
+      overrides: Partial<Props<Row>> = {},
+      buildActions: (
+        onEdit: () => void,
+        onDelete: () => void,
+      ) => Action<Row>[] = defaultActions,
+    ) => {
       const onEdit = vi.fn();
       const onDelete = vi.fn();
 
@@ -135,13 +286,10 @@ describe('Actions', () => {
               <td>{row.name}</td>
               <td>
                 <Actions
-                  {...buildProps(
-                    [
-                      { label: 'Edit', onClick: onEdit },
-                      { label: 'Delete', onClick: onDelete },
-                    ],
-                    { isPortal: true, ...overrides },
-                  )}
+                  {...buildProps(buildActions(onEdit, onDelete), {
+                    isPortal: true,
+                    ...overrides,
+                  })}
                 />
               </td>
             </tr>
@@ -181,9 +329,11 @@ describe('Actions', () => {
       );
     };
 
+    const originalInnerHeight = window.innerHeight;
+
     afterEach(() => {
       vi.restoreAllMocks();
-      vi.unstubAllGlobals();
+      vi.stubGlobal('innerHeight', originalInnerHeight);
     });
 
     it('should keep the menu closed until the trigger is used', () => {
@@ -405,8 +555,93 @@ describe('Actions', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
 
+    it('should keep a disabled item focusable but inert, and keep the menu open', async () => {
+      const { user, trigger, onDelete, getMenu } = setup(
+        {},
+        (onEdit, onDelete) => {
+          return [
+            { label: 'Edit', onClick: onEdit },
+            {
+              label: 'Delete',
+              disabledReason: 'This volume is attached',
+              onClick: onDelete,
+            },
+          ];
+        },
+      );
+
+      trigger.focus();
+      await user.keyboard('{ArrowUp}');
+
+      const remove = within(await getMenu()).getByRole('menuitem', {
+        name: 'Delete',
+      });
+
+      expect(remove).toHaveFocus();
+      expect(remove).toHaveAttribute('aria-disabled', 'true');
+
+      await user.keyboard('{Enter}');
+
+      expect(onDelete).not.toHaveBeenCalled();
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+
+      await user.hover(remove);
+
+      expect(await screen.findByRole('tooltip')).toHaveTextContent(
+        'This volume is attached',
+      );
+    });
+
+    it('should not reopen on hover right after selecting an action', async () => {
+      const { user, trigger, onEdit, getMenu } = setup();
+
+      await user.hover(trigger);
+      await user.click(
+        within(await getMenu()).getByRole('menuitem', { name: 'Edit' }),
+      );
+
+      expect(onEdit).toHaveBeenCalledWith(row);
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+      await user.hover(trigger);
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+      await user.unhover(trigger);
+      await user.hover(trigger);
+
+      expect(await getMenu()).toBeInTheDocument();
+    });
+
+    describe('with openOnHover disabled', () => {
+      it('should ignore hover and toggle on mouse clicks', async () => {
+        const { user, trigger, getMenu } = setup({ openOnHover: false });
+
+        await user.hover(trigger);
+
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+        await user.click(trigger);
+        expect(await getMenu()).toBeInTheDocument();
+
+        await user.unhover(trigger);
+        await new Promise((resolve) => {
+          setTimeout(resolve, CLOSE_DELAY_MS * 2);
+        });
+        expect(screen.getByRole('menu')).toBeInTheDocument();
+
+        await user.click(trigger);
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
+
     it("shouldn't have accessibility violations while open", async () => {
-      const { user, trigger, getMenu } = setup();
+      const { user, trigger, getMenu } = setup({}, (onEdit, onDelete) => {
+        return [
+          { label: 'Edit', onClick: onEdit },
+          { label: 'Delete', disabledReason: 'In use', onClick: onDelete },
+        ];
+      });
 
       await user.click(trigger);
       await getMenu();

--- a/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
@@ -124,9 +124,47 @@ describe('Actions', () => {
 
     expect(action).toHaveAttribute('aria-disabled', 'true');
 
+    await user.hover(action);
     await user.click(action);
 
     expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('should position the disabled reason tooltip on the requested side', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Actions
+        {...buildProps(
+          [
+            {
+              label: 'Delete',
+              disabledReason: 'In use',
+              disabledReasonSide: 'bottom',
+              onClick: vi.fn(),
+            },
+            { label: 'Detach', disabledReason: 'Busy', onClick: vi.fn() },
+          ],
+          { disabledReasonSide: 'right' },
+        )}
+      />,
+    );
+
+    await user.hover(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(
+      (await screen.findByRole('tooltip')).closest('[data-side]'),
+    ).toHaveAttribute('data-side', 'bottom');
+
+    await user.unhover(screen.getByRole('button', { name: 'Delete' }));
+    await user.hover(screen.getByRole('button', { name: 'Detach' }));
+
+    expect(
+      (await screen.findByRole('tooltip', { name: 'Busy' })).closest(
+        '[data-side]',
+      ),
+    ).toHaveAttribute('data-side', 'right');
   });
 
   it('should explain a disabled action with a tooltip', async () => {

--- a/lib/components/VirtualizedTable/components/Actions/Actions.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.types.ts
@@ -5,6 +5,8 @@ import { RowData } from '../../VirtualizedTable.types';
 
 export type Action<TData> = {
   className?: string;
+  disabled?: boolean;
+  disabledReason?: ReactNode;
   id?: string;
   onClick: (rowData: TData) => void;
 } & (
@@ -24,6 +26,7 @@ export type Props<TData extends RowData> = CellContext<TData, unknown> & {
   actions: Action<TData>[];
   iconTriggerButtonClassName?: string;
   isPortal?: boolean;
+  openOnHover?: boolean;
   triggerButtonClassName?: string;
   wrapperActionsClassName?: string;
   wrapperClassName?: string;

--- a/lib/components/VirtualizedTable/components/Actions/Actions.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.types.ts
@@ -1,12 +1,15 @@
 import { CellContext } from '@tanstack/react-table';
 import { ElementType, ReactNode } from 'react';
 
+import { Props as TooltipProps } from '@/components/Tooltip/Tooltip.types';
+
 import { RowData } from '../../VirtualizedTable.types';
 
 export type Action<TData> = {
   className?: string;
   disabled?: boolean;
   disabledReason?: ReactNode;
+  disabledReasonSide?: TooltipProps['side'];
   id?: string;
   onClick: (rowData: TData) => void;
 } & (
@@ -24,6 +27,7 @@ export type Action<TData> = {
 
 export type Props<TData extends RowData> = CellContext<TData, unknown> & {
   actions: Action<TData>[];
+  disabledReasonSide?: TooltipProps['side'];
   iconTriggerButtonClassName?: string;
   isPortal?: boolean;
   openOnHover?: boolean;

--- a/lib/components/VirtualizedTable/components/Actions/Actions.variants.ts
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.variants.ts
@@ -38,23 +38,43 @@ export const actionsPanelVariants = cva([
   'dark:border-metal-700',
 ]);
 
-export const actionsItemVariants = cva([
-  'w-full',
-  'text-slate-800',
-  'cursor-pointer',
-  'p-0',
-  'h-9',
-  'flex',
-  'gap-2',
-  'text-sm',
-  'font-normal',
-  'justify-start',
-  'rounded-none',
-  'px-6',
-  'hover:bg-gray-50',
-  'hover:text-slate-800',
-  'hover:no-underline',
-  'focus:no-underline',
-  'dark:hover:bg-metal-700',
-  'dark:focus:bg-metal-700',
-]);
+export const actionsItemVariants = cva(
+  [
+    'w-full',
+    'text-slate-800',
+    'cursor-pointer',
+    'p-0',
+    'h-9',
+    'flex',
+    'gap-2',
+    'text-sm',
+    'font-normal',
+    'justify-start',
+    'rounded-none',
+    'px-6',
+    'hover:bg-gray-50',
+    'hover:text-slate-800',
+    'hover:no-underline',
+    'focus:no-underline',
+    'dark:hover:bg-metal-700',
+    'dark:focus:bg-metal-700',
+  ],
+  {
+    variants: {
+      isDisabled: {
+        true: [
+          'cursor-not-allowed',
+          'text-slate-400',
+          'hover:bg-transparent',
+          'hover:text-slate-400',
+          'dark:text-metal-500',
+          'dark:hover:bg-transparent',
+        ],
+        false: [],
+      },
+    },
+    defaultVariants: {
+      isDisabled: false,
+    },
+  },
+);

--- a/lib/components/VirtualizedTable/components/Actions/components/ActionsList/ActionsList.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/components/ActionsList/ActionsList.tsx
@@ -13,6 +13,7 @@ import { Props } from './ActionsList.types';
 export const ActionsList = <TData extends RowData>({
   actions,
   className,
+  disabledReasonSide = 'left',
   isMenu = false,
   rowData,
   onSelect,
@@ -28,6 +29,7 @@ export const ActionsList = <TData extends RowData>({
           componentProps,
           disabled = false,
           disabledReason,
+          disabledReasonSide: itemDisabledReasonSide = disabledReasonSide,
           onClick,
         },
         index,
@@ -64,7 +66,7 @@ export const ActionsList = <TData extends RowData>({
         return (
           <Tooltip
             key={key}
-            side="left"
+            side={itemDisabledReasonSide}
             className="z-50 max-w-40 text-center"
             content={disabledReason}
           >

--- a/lib/components/VirtualizedTable/components/Actions/components/ActionsList/ActionsList.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/components/ActionsList/ActionsList.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/Button/Button';
+import { Tooltip } from '@/components/Tooltip/Tooltip';
 import { cn } from '@/utils';
 
 import { RowData } from '../../../../VirtualizedTable.types';
@@ -25,24 +26,52 @@ export const ActionsList = <TData extends RowData>({
           className: itemClassName,
           component: Component = Button,
           componentProps,
+          disabled = false,
+          disabledReason,
           onClick,
         },
         index,
-      ) => (
-        <Component
-          key={id ?? (typeof label === 'string' ? label : `action-${index}`)}
-          className={cn(actionsItemVariants(), itemClassName)}
-          variant="link"
-          onClick={() => {
-            onSelect?.();
-            onClick(rowData);
-          }}
-          {...(isMenu ? { role: 'menuitem', tabIndex: -1 } : {})}
-          {...componentProps}
-        >
-          {label}
-        </Component>
-      ),
+      ) => {
+        const key =
+          id ?? (typeof label === 'string' ? label : `action-${index}`);
+        const isDisabled = disabled || !!disabledReason;
+
+        const item = (
+          <Component
+            key={key}
+            aria-disabled={isDisabled || undefined}
+            className={cn(actionsItemVariants({ isDisabled }), itemClassName)}
+            variant="link"
+            onClick={() => {
+              if (isDisabled) {
+                return;
+              }
+
+              onSelect?.();
+              onClick(rowData);
+            }}
+            {...(isMenu ? { role: 'menuitem', tabIndex: -1 } : {})}
+            {...componentProps}
+          >
+            {label}
+          </Component>
+        );
+
+        if (!disabledReason) {
+          return item;
+        }
+
+        return (
+          <Tooltip
+            key={key}
+            side="left"
+            className="z-50 max-w-40 text-center"
+            content={disabledReason}
+          >
+            {item}
+          </Tooltip>
+        );
+      },
     )}
   </div>
 );

--- a/lib/components/VirtualizedTable/components/Actions/components/ActionsList/ActionsList.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/ActionsList/ActionsList.types.ts
@@ -1,9 +1,12 @@
+import { Props as TooltipProps } from '@/components/Tooltip/Tooltip.types';
+
 import { RowData } from '../../../../VirtualizedTable.types';
 import { Action } from '../../Actions.types';
 
 export type Props<TData extends RowData> = {
   actions: Action<TData>[];
   className?: string;
+  disabledReasonSide?: TooltipProps['side'];
   isMenu?: boolean;
   rowData: TData;
   onSelect?: () => void;

--- a/lib/components/VirtualizedTable/components/Actions/components/InlineActions/InlineActions.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/components/InlineActions/InlineActions.tsx
@@ -11,6 +11,7 @@ import { ITEM_HEIGHT, LIST_PADDING } from './constants';
 
 export const InlineActions = <TData extends RowData>({
   actions,
+  disabledReasonSide,
   openOnHover = true,
   wrapperClassName,
   triggerButtonClassName,
@@ -150,6 +151,7 @@ export const InlineActions = <TData extends RowData>({
       >
         <ActionsList
           actions={actions}
+          disabledReasonSide={disabledReasonSide}
           className={wrapperContentActionsClassName}
           rowData={delegated.row.original}
           onSelect={handleSelect}

--- a/lib/components/VirtualizedTable/components/Actions/components/InlineActions/InlineActions.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/components/InlineActions/InlineActions.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { cn } from '@/utils';
 
@@ -11,6 +11,7 @@ import { ITEM_HEIGHT, LIST_PADDING } from './constants';
 
 export const InlineActions = <TData extends RowData>({
   actions,
+  openOnHover = true,
   wrapperClassName,
   triggerButtonClassName,
   iconTriggerButtonClassName,
@@ -20,6 +21,8 @@ export const InlineActions = <TData extends RowData>({
 }: Omit<Props<TData>, 'isPortal'>) => {
   const rootRef = useRef<HTMLDivElement>(null);
   const [openUp, setOpenUp] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isHoverSuppressed, setIsHoverSuppressed] = useState(false);
 
   const updateDirection = () => {
     const root = rootRef.current;
@@ -54,15 +57,75 @@ export const InlineActions = <TData extends RowData>({
     setOpenUp(spaceBelow < menuHeight && spaceAbove > spaceBelow);
   };
 
+  const handleSelect = () => {
+    if (openOnHover) {
+      setIsHoverSuppressed(true);
+
+      return;
+    }
+
+    setIsOpen(false);
+  };
+
+  const handleTriggerClick = () => {
+    if (openOnHover) {
+      return;
+    }
+
+    updateDirection();
+    setIsOpen((previous) => {
+      return !previous;
+    });
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    document.addEventListener(
+      'mousedown',
+      (event) => {
+        if (!rootRef.current?.contains(event.target as Node)) {
+          setIsOpen(false);
+        }
+      },
+      { signal: controller.signal },
+    );
+    document.addEventListener(
+      'keydown',
+      (event) => {
+        if (event.key === 'Escape') {
+          setIsOpen(false);
+        }
+      },
+      { signal: controller.signal },
+    );
+
+    return () => {
+      controller.abort();
+    };
+  }, [isOpen]);
+
+  const showOnHover = openOnHover && !isHoverSuppressed;
+
   return (
     <div
       ref={rootRef}
       className={cn('relative group', wrapperClassName)}
       onMouseEnter={updateDirection}
+      onMouseLeave={() => {
+        setIsHoverSuppressed(false);
+      }}
     >
       <ActionsTrigger
         className={triggerButtonClassName}
         iconClassName={iconTriggerButtonClassName}
+        isOpen={isOpen}
+        onClick={handleTriggerClick}
+        {...(openOnHover ? {} : { 'aria-expanded': isOpen })}
       />
 
       <div
@@ -73,15 +136,15 @@ export const InlineActions = <TData extends RowData>({
           'z-10',
           openUp ? 'bottom-full' : 'top-full',
           openUp ? 'pb-1' : 'pt-1',
-          'invisible',
-          'opacity-0',
           'transition-[opacity,visibility]',
           'duration-150',
-          'delay-150',
-          'group-hover:visible',
-          'group-hover:opacity-100',
-          'group-hover:delay-0',
-          'group-hover:duration-75',
+          isOpen ? 'visible opacity-100' : 'invisible opacity-0 delay-150',
+          showOnHover && [
+            'group-hover:visible',
+            'group-hover:opacity-100',
+            'group-hover:delay-0',
+            'group-hover:duration-75',
+          ],
           wrapperActionsClassName,
         )}
       >
@@ -89,6 +152,7 @@ export const InlineActions = <TData extends RowData>({
           actions={actions}
           className={wrapperContentActionsClassName}
           rowData={delegated.row.original}
+          onSelect={handleSelect}
         />
       </div>
     </div>

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/PortalActions.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/PortalActions.tsx
@@ -11,6 +11,7 @@ import { useActionsMenu } from './hooks';
 
 export const PortalActions = <TData extends RowData>({
   actions,
+  openOnHover = true,
   wrapperClassName,
   triggerButtonClassName,
   iconTriggerButtonClassName,
@@ -25,14 +26,15 @@ export const PortalActions = <TData extends RowData>({
     menuId,
     menuRef,
     triggerRef,
-    closeMenu,
     handleMenuKeyDown,
     handlePointerEnter,
     handlePointerLeave,
     handleTriggerClick,
     handleTriggerKeyDown,
     handleTriggerPointerDown,
-  } = useActionsMenu();
+    handleButtonPointerLeave,
+    selectAndClose,
+  } = useActionsMenu({ openOnHover });
 
   return (
     <div
@@ -52,6 +54,7 @@ export const PortalActions = <TData extends RowData>({
         isOpen={isOpen}
         onClick={handleTriggerClick}
         onPointerDown={handleTriggerPointerDown}
+        onPointerLeave={handleButtonPointerLeave}
       />
 
       {hasOpened &&
@@ -74,7 +77,7 @@ export const PortalActions = <TData extends RowData>({
               )}
               isMenu
               rowData={delegated.row.original}
-              onSelect={closeMenu}
+              onSelect={selectAndClose}
             />
           </div>,
           document.body,

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/PortalActions.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/PortalActions.tsx
@@ -11,6 +11,7 @@ import { useActionsMenu } from './hooks';
 
 export const PortalActions = <TData extends RowData>({
   actions,
+  disabledReasonSide,
   openOnHover = true,
   wrapperClassName,
   triggerButtonClassName,
@@ -71,6 +72,7 @@ export const PortalActions = <TData extends RowData>({
           >
             <ActionsList
               actions={actions}
+              disabledReasonSide={disabledReasonSide}
               className={cn(
                 'animate-in fade-in-0',
                 wrapperContentActionsClassName,

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-actions-menu/use-actions-menu.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-actions-menu/use-actions-menu.ts
@@ -11,7 +11,9 @@ import { useMenuInteractions } from '../use-menu-interactions/use-menu-interacti
 import { useMenuKeyboardNavigation } from '../use-menu-keyboard-navigation/use-menu-keyboard-navigation';
 import { useRowHighlight } from '../use-row-highlight/use-row-highlight';
 
-export const useActionsMenu = () => {
+import { Params } from './use-actions-menu.types';
+
+export const useActionsMenu = ({ openOnHover }: Params) => {
   const [isOpen, setIsOpenState] = useState(false);
   const [hasOpened, setHasOpened] = useState(false);
   const triggerRef = useRef<HTMLDivElement>(null);
@@ -30,8 +32,16 @@ export const useActionsMenu = () => {
     handlePointerLeave,
     handleTriggerClick,
     handleTriggerPointerDown,
+    handleButtonPointerLeave,
     openMenu,
-  } = useMenuInteractions({ isOpen, menuRef, triggerRef, setIsOpen });
+    selectAndClose,
+  } = useMenuInteractions({
+    isOpen,
+    menuRef,
+    openOnHover,
+    triggerRef,
+    setIsOpen,
+  });
 
   const { handleMenuKeyDown, handleTriggerKeyDown } = useMenuKeyboardNavigation(
     { buttonRef, isOpen, menuRef, closeMenu, openMenu },
@@ -53,5 +63,7 @@ export const useActionsMenu = () => {
     handleTriggerClick,
     handleTriggerKeyDown,
     handleTriggerPointerDown,
+    handleButtonPointerLeave,
+    selectAndClose,
   };
 };

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-actions-menu/use-actions-menu.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-actions-menu/use-actions-menu.types.ts
@@ -1,0 +1,3 @@
+export type Params = {
+  openOnHover: boolean;
+};

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-interactions/use-menu-interactions.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-interactions/use-menu-interactions.ts
@@ -13,6 +13,7 @@ import { Params } from './use-menu-interactions.types';
 export const useMenuInteractions = ({
   isOpen,
   menuRef,
+  openOnHover,
   triggerRef,
   setIsOpen,
 }: Params) => {
@@ -20,6 +21,7 @@ export const useMenuInteractions = ({
     undefined,
   );
   const pointerTypeRef = useRef<string | null>(null);
+  const isHoverSuppressedRef = useRef(false);
 
   const openMenu = useCallback(() => {
     clearTimeout(closeTimeoutRef.current);
@@ -31,6 +33,11 @@ export const useMenuInteractions = ({
     setIsOpen(false);
   }, [setIsOpen]);
 
+  const selectAndClose = useCallback(() => {
+    isHoverSuppressedRef.current = true;
+    closeMenu();
+  }, [closeMenu]);
+
   const scheduleClose = useCallback(() => {
     clearTimeout(closeTimeoutRef.current);
     closeTimeoutRef.current = setTimeout(() => {
@@ -40,21 +47,33 @@ export const useMenuInteractions = ({
 
   const handlePointerEnter = useCallback(
     (event: PointerEvent<HTMLElement>) => {
-      if (event.pointerType !== 'touch') {
-        openMenu();
+      if (
+        !openOnHover ||
+        isHoverSuppressedRef.current ||
+        event.pointerType === 'touch'
+      ) {
+        return;
       }
+
+      openMenu();
     },
-    [openMenu],
+    [openMenu, openOnHover],
   );
 
   const handlePointerLeave = useCallback(
     (event: PointerEvent<HTMLElement>) => {
-      if (event.pointerType !== 'touch') {
-        scheduleClose();
+      if (!openOnHover || event.pointerType === 'touch') {
+        return;
       }
+
+      scheduleClose();
     },
-    [scheduleClose],
+    [openOnHover, scheduleClose],
   );
+
+  const handleButtonPointerLeave = useCallback(() => {
+    isHoverSuppressedRef.current = false;
+  }, []);
 
   const handleTriggerPointerDown = useCallback(
     (event: PointerEvent<HTMLElement>) => {
@@ -66,9 +85,10 @@ export const useMenuInteractions = ({
   const handleTriggerClick = useCallback(() => {
     const pointerType = pointerTypeRef.current;
     pointerTypeRef.current = null;
+    isHoverSuppressedRef.current = false;
     clearTimeout(closeTimeoutRef.current);
 
-    if (pointerType && pointerType !== 'touch') {
+    if (openOnHover && pointerType && pointerType !== 'touch') {
       setIsOpen(true);
 
       return;
@@ -77,7 +97,7 @@ export const useMenuInteractions = ({
     setIsOpen((previous) => {
       return !previous;
     });
-  }, [setIsOpen]);
+  }, [openOnHover, setIsOpen]);
 
   useEffect(() => {
     return () => {
@@ -162,6 +182,8 @@ export const useMenuInteractions = ({
     handlePointerLeave,
     handleTriggerClick,
     handleTriggerPointerDown,
+    handleButtonPointerLeave,
     openMenu,
+    selectAndClose,
   };
 };

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-interactions/use-menu-interactions.types.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-interactions/use-menu-interactions.types.ts
@@ -3,6 +3,7 @@ import { Dispatch, RefObject, SetStateAction } from 'react';
 export type Params = {
   isOpen: boolean;
   menuRef: RefObject<HTMLDivElement | null>;
+  openOnHover: boolean;
   triggerRef: RefObject<HTMLDivElement | null>;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
 };

--- a/lib/components/VirtualizedTable/stories/Dark.stories.tsx
+++ b/lib/components/VirtualizedTable/stories/Dark.stories.tsx
@@ -125,6 +125,13 @@ const columns: ColumnDef<Pokemon>[] = [
               console.log(`Viewing details for ${JSON.stringify(row)}`);
             },
           },
+          {
+            label: 'Delete',
+            disabledReason: 'This Pokémon is in use and cannot be deleted',
+            onClick: (row) => {
+              console.log(`Deleting ${JSON.stringify(row)}`);
+            },
+          },
         ]}
       />
     ),

--- a/lib/components/VirtualizedTable/stories/Light.stories.tsx
+++ b/lib/components/VirtualizedTable/stories/Light.stories.tsx
@@ -145,6 +145,13 @@ const getColumns = (isPortal = false): ColumnDef<Pokemon>[] => [
               console.log(`Viewing details for ${JSON.stringify(row)}`);
             },
           },
+          {
+            label: 'Delete',
+            disabledReason: 'This Pokémon is in use and cannot be deleted',
+            onClick: (row) => {
+              console.log(`Deleting ${JSON.stringify(row)}`);
+            },
+          },
         ]}
       />
     ),


### PR DESCRIPTION
## Summary

Upstreams behaviour the microfrontends had to reimplement on top of `VirtualizedTable.Actions`:

- **`disabled` / `disabledReason` per action**: the item renders `aria-disabled` (still focusable for keyboard navigation) and, when a reason is given, shows it in a `Tooltip`. Replaces `DisabledDeleteAction` (vpc), `VolumeActions.disabledReason` (volumes) and the tooltip-wrapped disabled buttons in settings.
- **`openOnHover={false}`**: click-only trigger for both the inline and the portal variant. Compute (`InstanceActions`) and volumes (`VolumeActions`) rewrote the whole menu just to get this.
- **No hover re-open after selecting an action** until the pointer leaves the trigger. In the inline variant the panel stayed visible after a click because the pointer was still inside the `group` (objectstore `FileActionsCell` had a pointer-events latch for this).

## Notes

- `vi.unstubAllGlobals()` in the portal test suite was removing the `ResizeObserver` stub from `tests/setup.ts`, which broke Radix Tooltip inside the menu. It now restores only `innerHeight`.
- Stories (Light/Dark) include a disabled action with a reason.

## Test plan

- [x] `npx vitest run lib/components/VirtualizedTable` (74 tests)
- [x] `npm run lint`, `npm run check:types`, prettier
- [ ] Storybook: hover the disabled "Delete" action in the Actions column, check tooltip; check click-only behaviour by toggling `openOnHover` in a story