### PR TITLE
✨ feat: make TruncateText usable outside table cells and copyable

### DIFF
--- a/lib/components/VirtualizedTable/components/TruncateText/TruncateText.test.tsx
+++ b/lib/components/VirtualizedTable/components/TruncateText/TruncateText.test.tsx
@@ -1,0 +1,126 @@
+import { CellContext } from '@tanstack/react-table';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { TruncateText } from './TruncateText';
+
+type Row = { id: string; name: string };
+
+const mockOverflow = (scrollWidth: number, clientWidth: number) => {
+  const scrollWidthSpy = vi
+    .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
+    .mockReturnValue(scrollWidth);
+  const clientWidthSpy = vi
+    .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+    .mockReturnValue(clientWidth);
+
+  return () => {
+    scrollWidthSpy.mockRestore();
+    clientWidthSpy.mockRestore();
+  };
+};
+
+describe('TruncateText', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should render the value without a tooltip when it fits', async () => {
+    mockOverflow(100, 200);
+    const user = userEvent.setup();
+
+    render(<TruncateText value="Pikachu" />);
+
+    const text = screen.getByText('Pikachu');
+
+    expect(text.tagName).toBe('P');
+    expect(text).not.toHaveClass('cursor-pointer');
+
+    await user.hover(text);
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('should show the full text in a tooltip when it overflows', async () => {
+    mockOverflow(300, 100);
+    const user = userEvent.setup();
+
+    render(<TruncateText value="A very long Pokémon name" />);
+
+    const text = screen.getByText('A very long Pokémon name');
+
+    expect(text).toHaveClass('cursor-pointer');
+
+    await user.hover(text);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'A very long Pokémon name',
+    );
+  });
+
+  it('should fall back to the cell value when no value is given', () => {
+    mockOverflow(100, 200);
+
+    render(
+      <TruncateText<Row>
+        {...({ getValue: () => 'PIKACHU' } as unknown as CellContext<
+          Row,
+          string
+        >)}
+      />,
+    );
+
+    expect(screen.getByText('pikachu')).toBeInTheDocument();
+  });
+
+  it('should render with the requested typography variant and element', () => {
+    mockOverflow(100, 200);
+
+    render(<TruncateText value="Pikachu" variant="body3" component="span" />);
+
+    const text = screen.getByText('Pikachu');
+
+    expect(text.tagName).toBe('SPAN');
+    expect(text).toHaveClass('text-xs');
+  });
+
+  it('should render a copy button next to the text when copyable', async () => {
+    mockOverflow(100, 200);
+    const user = userEvent.setup();
+
+    render(<TruncateText value="a1b2-c3d4" copyable />);
+
+    await user.click(screen.getByRole('button', { name: 'Copy a1b2-c3d4' }));
+
+    expect(await navigator.clipboard.readText()).toBe('a1b2-c3d4');
+  });
+
+  it('should forward copy button props', () => {
+    mockOverflow(100, 200);
+
+    render(
+      <TruncateText
+        value="a1b2-c3d4"
+        copyable
+        copyButtonProps={{ label: 'Volume ID' }}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Copy Volume ID' }),
+    ).toBeInTheDocument();
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    mockOverflow(300, 100);
+
+    const { container } = render(
+      <TruncateText value="A very long Pokémon name" copyable />,
+    );
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/VirtualizedTable/components/TruncateText/TruncateText.tsx
+++ b/lib/components/VirtualizedTable/components/TruncateText/TruncateText.tsx
@@ -1,16 +1,22 @@
-import debounce from 'lodash/debounce';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
+import { CopyButton } from '@/components/CopyButton/CopyButton';
 import { Tooltip } from '@/components/Tooltip/Tooltip';
 import { Typography } from '@/components/Typography/Typography';
 import { cn } from '@/utils';
 
+import { RowData } from '../../VirtualizedTable.types';
+
 import { Props } from './TruncateText.types';
 
-export const TruncateText = <TData,>({
+export const TruncateText = <TData extends RowData = RowData>({
   getValue,
   value,
   textClassName,
+  variant,
+  component = 'p',
+  copyable = false,
+  copyButtonProps,
   side = 'bottom',
   sideOffset,
   bgClassName,
@@ -18,51 +24,45 @@ export const TruncateText = <TData,>({
   className,
   delayDuration = 0,
 }: Props<TData>) => {
-  const textRef = useRef<
-    HTMLParagraphElement & HTMLHeadingElement & HTMLLabelElement
-  >(null);
+  const [element, setElement] = useState<HTMLElement | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
-  const text = value ?? getValue<string>().toLocaleLowerCase();
-
-  const handleResize = useCallback(() => {
-    const component = textRef.current;
-
-    if (component) {
-      setIsTruncated(component.scrollWidth > component.clientWidth);
-    }
-  }, []);
+  const text = value ?? getValue?.<string>().toLocaleLowerCase() ?? '';
 
   useEffect(() => {
-    const controller = new AbortController();
-    const debouncedResize = debounce(handleResize, 300);
+    if (!element) {
+      return;
+    }
 
-    window.addEventListener('resize', debouncedResize, {
-      signal: controller.signal,
-    });
+    const measure = () => {
+      setIsTruncated(element.scrollWidth > element.clientWidth);
+    };
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
 
     return () => {
-      controller.abort();
-      debouncedResize.cancel();
+      observer.disconnect();
     };
-  }, [handleResize]);
+  }, [element, text]);
 
-  useEffect(() => {
-    handleResize();
-  }, [handleResize]);
+  const content = (
+    <Typography
+      ref={setElement}
+      variant={variant}
+      component={component}
+      className={cn(
+        'w-full truncate',
+        isTruncated && 'cursor-pointer',
+        textClassName,
+      )}
+    >
+      {text}
+    </Typography>
+  );
 
-  if (!isTruncated) {
-    return (
-      <Typography
-        ref={textRef}
-        component="p"
-        className={cn('w-full truncate', textClassName)}
-      >
-        {text}
-      </Typography>
-    );
-  }
-
-  return (
+  const truncatedContent = isTruncated ? (
     <Tooltip
       content={text}
       side={side}
@@ -72,13 +72,20 @@ export const TruncateText = <TData,>({
       className={className}
       delayDuration={delayDuration}
     >
-      <Typography
-        ref={textRef}
-        component="p"
-        className={cn('w-full truncate cursor-pointer', textClassName)}
-      >
-        {text}
-      </Typography>
+      {content}
     </Tooltip>
+  ) : (
+    content
+  );
+
+  if (!copyable) {
+    return truncatedContent;
+  }
+
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <span className="min-w-0 flex-1">{truncatedContent}</span>
+      <CopyButton text={text} label={text} {...copyButtonProps} />
+    </div>
   );
 };

--- a/lib/components/VirtualizedTable/components/TruncateText/TruncateText.types.ts
+++ b/lib/components/VirtualizedTable/components/TruncateText/TruncateText.types.ts
@@ -1,12 +1,19 @@
 import { CellContext } from '@tanstack/react-table';
 
+import { Props as CopyButtonProps } from '@/components/CopyButton/CopyButton.types';
 import { Props as TooltipProps } from '@/components/Tooltip/Tooltip.types';
+import { Props as TypographyProps } from '@/components/Typography/Typography.types';
 
 import { RowData } from '../../VirtualizedTable.types';
 
-export type Props<TData extends RowData> = CellContext<TData, string> &
+export type Props<TData extends RowData = RowData> = Partial<
+  CellContext<TData, string>
+> &
   Partial<Omit<TooltipProps, 'content' | 'children' | 'textClassName'>> & {
-    value?: string;
-    /** Additional className for the text element */
+    component?: TypographyProps['component'];
+    copyable?: boolean;
+    copyButtonProps?: Partial<Omit<CopyButtonProps, 'text'>>;
     textClassName?: string;
+    value?: string;
+    variant?: TypographyProps['variant'];
   };

--- a/lib/components/VirtualizedTable/stories/Dark.stories.tsx
+++ b/lib/components/VirtualizedTable/stories/Dark.stories.tsx
@@ -61,6 +61,7 @@ const columns: ColumnDef<Pokemon>[] = [
     cell: (props) => (
       <VirtualizedTableComponent.TruncateText
         {...props}
+        copyable
         value={`${props.getValue().charAt(0).toUpperCase()}${props
           .getValue()
           .slice(1)}`}

--- a/lib/components/VirtualizedTable/stories/Light.stories.tsx
+++ b/lib/components/VirtualizedTable/stories/Light.stories.tsx
@@ -44,6 +44,7 @@ const getColumns = (isPortal = false): ColumnDef<Pokemon>[] => [
     cell: (props) => (
       <VirtualizedTableComponent.TruncateText
         {...props}
+        copyable
         value={`${props.getValue().charAt(0).toUpperCase()}${props
           .getValue()
           .slice(1)}`}


### PR DESCRIPTION
## Summary

- **Standalone props**: `TruncateText` no longer requires a TanStack `CellContext`; `value` alone works, so it can be used in cards, drawers and detail panels. Kubernetes, volumes and billing carried their own `TruncatedText` for this, and settings casts `CellContext` in four cells to reuse the table one. Spreading cell props still works.
- **Correct overflow measurement**: a `ResizeObserver` on a callback ref replaces the debounced window `resize` listener. Toggling the Tooltip wrapper remounts the text element, so the previous ref kept measuring a detached node (the fix billing's copy documents). The observer also reacts to container resizes.
- **`variant` / `component`** pass through to `Typography`.
- **`copyable`** renders a `CopyButton` next to the text (the truncated identifier + copy cell repeated in settings and billing); `copyButtonProps` customises the label and callbacks.

The `getValue()` fallback still lowercases the value as before (kubernetes and objectstore rely on that path).

## Test plan

- [x] New `TruncateText.test.tsx` (7 tests, component had no coverage before)
- [x] `npx vitest run lib/components/VirtualizedTable`, lint, types, prettier
- [ ] Storybook: `Name` column in `VirtualizedTable/Light` and `Dark` is now `copyable`