### PR TITLE
✨ feat: add isPortal and onValueChange to Select

### DIFF
--- a/lib/components/Select/Select.test.tsx
+++ b/lib/components/Select/Select.test.tsx
@@ -553,6 +553,135 @@ describe('Select', () => {
     });
   });
 
+  describe('onValueChange', () => {
+    it('should receive the selected value directly', async () => {
+      const onValueChange = vitest.fn();
+      const { user, findComboBox } = setup({ onValueChange });
+
+      await user.click(await findComboBox());
+      await user.click(screen.getByRole('option', { name: 'Option 2' }));
+
+      expect(onValueChange).toHaveBeenCalledWith('option-2');
+    });
+  });
+
+  describe('with isPortal', () => {
+    it('should render the list outside the select and keep selection working', async () => {
+      const onChange = vitest.fn();
+      const onValueChange = vitest.fn();
+      const { component, user, findComboBox } = setup({
+        isPortal: true,
+        onChange,
+        onValueChange,
+      });
+
+      const comboBox = await findComboBox();
+      await user.click(comboBox);
+
+      const listbox = await screen.findByRole('listbox');
+
+      expect(component.contains(listbox)).toBe(false);
+      expect(comboBox).toHaveAttribute('aria-expanded', 'true');
+      expect(comboBox).toHaveAttribute('aria-controls', listbox.id);
+
+      await user.click(
+        within(listbox).getByRole('option', { name: 'Option 2' }),
+      );
+
+      expect(onChange).toHaveBeenCalledWith({
+        target: { value: 'option-2', name: defaultProps.name },
+      });
+      expect(onValueChange).toHaveBeenCalledWith('option-2');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(comboBox).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should navigate the portaled list with the keyboard', async () => {
+      const onValueChange = vitest.fn();
+      const { user, findComboBox } = setup({
+        isPortal: true,
+        onValueChange,
+      });
+
+      const comboBox = await findComboBox();
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      await screen.findByRole('listbox');
+      await user.keyboard('{ArrowDown}');
+
+      expect(screen.getByRole('option', { name: 'Option 1' })).toHaveFocus();
+      expect(comboBox).toHaveAttribute('aria-expanded', 'true');
+
+      await user.keyboard('{ArrowDown}');
+
+      expect(screen.getByRole('option', { name: 'Option 2' })).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+
+      expect(onValueChange).toHaveBeenCalledWith('option-2');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('should close the portaled list when clicking outside or pressing Escape', async () => {
+      const { user, findComboBox } = setup({ isPortal: true });
+
+      const comboBox = await findComboBox();
+
+      await user.click(comboBox);
+      await screen.findByRole('listbox');
+      await user.click(document.body);
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+
+      await user.click(comboBox);
+      await screen.findByRole('listbox');
+      await user.keyboard('{Escape}');
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('should work inside a modal', async () => {
+      const OpenModalWrapper: FC<PropsWithChildren> = ({ children }) => {
+        const [isOpen, setIsOpen] = useState(true);
+
+        return (
+          <Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>
+            <Modal.Body>{children}</Modal.Body>
+          </Modal>
+        );
+      };
+      const onValueChange = vitest.fn();
+      const { user, findComboBox } = setup(
+        { isPortal: true, onValueChange },
+        OpenModalWrapper,
+      );
+
+      await user.click(await findComboBox());
+      await user.click(
+        within(await screen.findByRole('listbox')).getByRole('option', {
+          name: 'Option 3',
+        }),
+      );
+
+      expect(onValueChange).toHaveBeenCalledWith('option-3');
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it("shouldn't have accessibility violations while open", async () => {
+      const { user, findComboBox } = setup({ isPortal: true });
+
+      await user.click(await findComboBox());
+      await screen.findByRole('listbox');
+
+      const results = await axe(document.body, {
+        rules: { region: { enabled: false } },
+      });
+
+      expect(results).toHaveNoViolations();
+    });
+  });
+
   describe('select inside a drawer', () => {
     const DrawerWrapper: FC<PropsWithChildren> = ({ children }) => {
       const [isOpen, setIsOpen] = useState(false);

--- a/lib/components/Select/Select.tsx
+++ b/lib/components/Select/Select.tsx
@@ -56,6 +56,7 @@ export const Select: FC<Props> = forwardRef<ComponentRef<'input'>, Props>(
       options,
       onChange,
       onBlur,
+      onValueChange,
       ...delegated
     },
     ref,
@@ -89,6 +90,7 @@ export const Select: FC<Props> = forwardRef<ComponentRef<'input'>, Props>(
         options={flatOptions}
         onBlur={onBlur}
         onChange={onChange}
+        onValueChange={onValueChange}
       >
         <div className={cn('relative w-full', mainWrapperClassName)}>
           <Wrapper

--- a/lib/components/Select/Select.types.ts
+++ b/lib/components/Select/Select.types.ts
@@ -114,6 +114,7 @@ export type Props = VariantProps<typeof selectVariants> &
     iconClassName?: string;
     inputClassName?: string;
     isLoading?: boolean;
+    isPortal?: boolean;
     isRequired?: boolean;
     label?: string;
     labelAction?: ReactNode;
@@ -128,6 +129,7 @@ export type Props = VariantProps<typeof selectVariants> &
     loadingText?: string;
     visibleItems?: number;
     options: Option[] | OptionGroup[];
+    portalClassName?: string;
     searchable?: boolean;
     showSearchIcon?: boolean;
     theme?: Theme;
@@ -136,6 +138,7 @@ export type Props = VariantProps<typeof selectVariants> &
     onBlur?: VoidFunction;
     onChange?: OnChangeFn;
     onSearchChange?: (searchTerm: string) => void;
+    onValueChange?: (value: string) => void;
   } & (
     | {
         isInfiniteScrollEnabled: true;

--- a/lib/components/Select/components/Wrapper.tsx
+++ b/lib/components/Select/components/Wrapper.tsx
@@ -1,7 +1,9 @@
+import { Anchor, Content, Portal, Root } from '@radix-ui/react-popover';
 import { ChevronUp, Search } from 'lucide-react';
 import {
   ChangeEvent,
   ComponentRef,
+  FocusEvent,
   forwardRef,
   ForwardRefExoticComponent,
   KeyboardEvent,
@@ -55,6 +57,7 @@ export const Wrapper: ForwardRefExoticComponent<
       inputClassName,
       isInfiniteScrollEnabled = false,
       isLoading,
+      isPortal = false,
       isRequired,
       loadingText,
       label,
@@ -67,6 +70,7 @@ export const Wrapper: ForwardRefExoticComponent<
       name,
       noOptionsText,
       placeholder,
+      portalClassName,
       searchable = false,
       showSearchIcon,
       theme,
@@ -101,12 +105,19 @@ export const Wrapper: ForwardRefExoticComponent<
       return options.find(({ value: optionValue }) => optionValue === value);
     }, [options, value]);
 
-    const { wrapperRef, wrapperInputRef, handleOpen } = useSelect({
+    const { isInside, wrapperRef, wrapperInputRef, handleOpen } = useSelect({
       inputRef,
       searchInputRef,
       internalValue,
+      listRef: ulRef,
       onBlur,
     });
+
+    const handlePortalBlur = (event: FocusEvent<HTMLDivElement>) => {
+      if (!isInside(event.relatedTarget)) {
+        toggleOpen(false);
+      }
+    };
 
     const handleToggleOpen = () => {
       if (disabled) {
@@ -186,6 +197,30 @@ export const Wrapper: ForwardRefExoticComponent<
       }
     };
 
+    const list = (
+      <List
+        ref={ulRef}
+        id={listboxId}
+        labelledBy={label ? labelId : undefined}
+        additionalOptions={additionalOptions}
+        className={cn(isPortal && 'static top-auto mt-0', listClassName)}
+        groupedOptions={groupedOptions}
+        itemClassName={listItemClassName}
+        name={name}
+        wrapperInputRef={wrapperInputRef}
+        inputRef={inputRef}
+        options={options}
+        isLoading={!!isLoading}
+        searchable={searchable}
+        listItemSecondRowClassName={listItemSecondRowClassName}
+        isInfiniteScrollEnabled={isInfiniteScrollEnabled}
+        onFetchMoreOptions={onFetchMoreOptions}
+        noOptionsText={noOptionsText}
+        loadingText={loadingText}
+        visibleItems={visibleItems}
+      />
+    );
+
     return (
       <div
         ref={wrapperRef}
@@ -219,158 +254,168 @@ export const Wrapper: ForwardRefExoticComponent<
           </div>
         ) : null}
 
-        <div
-          ref={wrapperInputRef}
-          id={controlId}
-          className={cn(
-            selectVariants({ className, hasError: !!error, disabled }),
-          )}
-          role="combobox"
-          onClick={handleToggleOpen}
-          onKeyDown={handleKeyDown}
-          aria-expanded={isOpen}
-          tabIndex={isWrapperInputFocusable.current}
-          aria-labelledby={label ? labelId : undefined}
-          aria-label={label ? undefined : placeholder}
-          aria-haspopup="listbox"
-          aria-controls={isOpen ? listboxId : undefined}
-          aria-invalid={!!error || undefined}
-          aria-describedby={describedBy}
-          aria-required={isRequired || undefined}
-          aria-disabled={disabled || undefined}
-        >
-          <div className="flex gap-2.5 items-center flex-1">
-            {internalValue?.leftIcon && !showSearchIcon && (
-              <span className="w-4 h-4 flex justify-center items-center dark:text-metal-50">
-                {internalValue.leftIcon}
-              </span>
-            )}
-
-            {showSearchIcon && (
-              <Search
-                className={cn(
-                  'w-4',
-                  'h-4',
-                  'text-zinc-500',
-                  'select-none',
-                  'transition-colors',
-                  'duration-300',
-                  'dark:text-metal-300',
-                  'dark:group-focus-within:text-metal-50',
+        <Root open={isPortal && isOpen}>
+          <Anchor asChild>
+            <div
+              ref={wrapperInputRef}
+              id={controlId}
+              className={cn(
+                selectVariants({ className, hasError: !!error, disabled }),
+              )}
+              role="combobox"
+              onClick={handleToggleOpen}
+              onKeyDown={handleKeyDown}
+              aria-expanded={isOpen}
+              tabIndex={isWrapperInputFocusable.current}
+              aria-labelledby={label ? labelId : undefined}
+              aria-label={label ? undefined : placeholder}
+              aria-haspopup="listbox"
+              aria-controls={isOpen ? listboxId : undefined}
+              aria-invalid={!!error || undefined}
+              aria-describedby={describedBy}
+              aria-required={isRequired || undefined}
+              aria-disabled={disabled || undefined}
+            >
+              <div className="flex gap-2.5 items-center flex-1">
+                {internalValue?.leftIcon && !showSearchIcon && (
+                  <span className="w-4 h-4 flex justify-center items-center dark:text-metal-50">
+                    {internalValue.leftIcon}
+                  </span>
                 )}
-              />
-            )}
 
-            {searchable ? (
-              <input
-                ref={searchInputRef}
-                type="text"
-                value={
-                  isOpen ? searchTerm : (internalValue?.label ?? value ?? '')
-                }
-                onChange={handleInputChange}
-                placeholder={placeholder}
-                className={cn(inputVariants({ className: inputClassName }), {
-                  'text-red-700 placeholder:text-red-700': !!error,
-                })}
-                onClick={(e) => {
-                  e.stopPropagation();
-
-                  if (!disabled) {
-                    handleOpen();
-                  }
-                }}
-                aria-labelledby={label ? labelId : undefined}
-                aria-label={label ? undefined : placeholder}
-                aria-invalid={!!error || undefined}
-                aria-describedby={describedBy}
-                required={isRequired}
-                autoComplete="off"
-                autoCapitalize="words"
-                disabled={disabled}
-                tabIndex={-1}
-                {...delegated}
-              />
-            ) : (
-              <Typography
-                variant="body2"
-                className={cn(
-                  'flex-1 text-zinc-400 text-sm dark:text-metal-400 flex gap-2 items-center',
-                  {
-                    'text-red-700': !!error,
-                    'select-none': !internalValue,
-                    'text-metal-800 dark:text-metal-50': internalValue,
-                    'text-metal-400/50 dark:text-metal-50/50': disabled,
-                  },
-                  internalValue?.wrapperClassNameOnSelectedValue,
+                {showSearchIcon && (
+                  <Search
+                    className={cn(
+                      'w-4',
+                      'h-4',
+                      'text-zinc-500',
+                      'select-none',
+                      'transition-colors',
+                      'duration-300',
+                      'dark:text-metal-300',
+                      'dark:group-focus-within:text-metal-50',
+                    )}
+                  />
                 )}
-              >
-                {internalValue?.label || placeholder}{' '}
-                {internalValue?.showRightComponentOnselectedValue
-                  ? internalValue?.rightComponent
-                  : null}
-              </Typography>
-            )}
-          </div>
 
-          {isLoading ? (
-            <LoaderIcon
-              size={16}
-              className="text-metal-400 animate-spin select-none"
-            />
-          ) : (
-            !showSearchIcon && (
-              <ChevronUp
-                data-state={isOpen ? 'open' : 'closed'}
-                className={cn(
-                  'w-4 h-4 text-zinc-500 transition-all duration-100 data-[state=open]:rotate-0 data-[state=closed]:rotate-180 select-none dark:group-focus-within:text-metal-50',
-                  iconClassName,
-                  {
-                    'text-red-700': !!error,
-                    'text-metal-400/50 dark:group-focus-within:text-zinc-500':
-                      disabled,
-                  },
+                {searchable ? (
+                  <input
+                    ref={searchInputRef}
+                    type="text"
+                    value={
+                      isOpen
+                        ? searchTerm
+                        : (internalValue?.label ?? value ?? '')
+                    }
+                    onChange={handleInputChange}
+                    placeholder={placeholder}
+                    className={cn(
+                      inputVariants({ className: inputClassName }),
+                      {
+                        'text-red-700 placeholder:text-red-700': !!error,
+                      },
+                    )}
+                    onClick={(e) => {
+                      e.stopPropagation();
+
+                      if (!disabled) {
+                        handleOpen();
+                      }
+                    }}
+                    aria-labelledby={label ? labelId : undefined}
+                    aria-label={label ? undefined : placeholder}
+                    aria-invalid={!!error || undefined}
+                    aria-describedby={describedBy}
+                    required={isRequired}
+                    autoComplete="off"
+                    autoCapitalize="words"
+                    disabled={disabled}
+                    tabIndex={-1}
+                    {...delegated}
+                  />
+                ) : (
+                  <Typography
+                    variant="body2"
+                    className={cn(
+                      'flex-1 text-zinc-400 text-sm dark:text-metal-400 flex gap-2 items-center',
+                      {
+                        'text-red-700': !!error,
+                        'select-none': !internalValue,
+                        'text-metal-800 dark:text-metal-50': internalValue,
+                        'text-metal-400/50 dark:text-metal-50/50': disabled,
+                      },
+                      internalValue?.wrapperClassNameOnSelectedValue,
+                    )}
+                  >
+                    {internalValue?.label || placeholder}{' '}
+                    {internalValue?.showRightComponentOnselectedValue
+                      ? internalValue?.rightComponent
+                      : null}
+                  </Typography>
                 )}
-              />
-            )
-          )}
-        </div>
+              </div>
 
-        <input
-          ref={inputRef}
-          type="text"
-          name={name}
-          className="hidden"
-          aria-hidden="true"
-          required={isRequired}
-          inert
-          defaultValue={internalValue?.value ?? value ?? undefined}
-          {...delegated}
-        />
+              {isLoading ? (
+                <LoaderIcon
+                  size={16}
+                  className="text-metal-400 animate-spin select-none"
+                />
+              ) : (
+                !showSearchIcon && (
+                  <ChevronUp
+                    data-state={isOpen ? 'open' : 'closed'}
+                    className={cn(
+                      'w-4 h-4 text-zinc-500 transition-all duration-100 data-[state=open]:rotate-0 data-[state=closed]:rotate-180 select-none dark:group-focus-within:text-metal-50',
+                      iconClassName,
+                      {
+                        'text-red-700': !!error,
+                        'text-metal-400/50 dark:group-focus-within:text-zinc-500':
+                          disabled,
+                      },
+                    )}
+                  />
+                )
+              )}
+            </div>
+          </Anchor>
 
-        {isOpen && (
-          <List
-            ref={ulRef}
-            id={listboxId}
-            labelledBy={label ? labelId : undefined}
-            additionalOptions={additionalOptions}
-            className={listClassName}
-            groupedOptions={groupedOptions}
-            itemClassName={listItemClassName}
+          <input
+            ref={inputRef}
+            type="text"
             name={name}
-            wrapperInputRef={wrapperInputRef}
-            inputRef={inputRef}
-            options={options}
-            isLoading={!!isLoading}
-            searchable={searchable}
-            listItemSecondRowClassName={listItemSecondRowClassName}
-            isInfiniteScrollEnabled={isInfiniteScrollEnabled}
-            onFetchMoreOptions={onFetchMoreOptions}
-            noOptionsText={noOptionsText}
-            loadingText={loadingText}
-            visibleItems={visibleItems}
+            className="hidden"
+            aria-hidden="true"
+            required={isRequired}
+            inert
+            defaultValue={internalValue?.value ?? value ?? undefined}
+            {...delegated}
           />
-        )}
+
+          {isOpen && !isPortal && list}
+
+          {isPortal && (
+            <Portal>
+              <Content
+                role="presentation"
+                align="start"
+                sideOffset={4}
+                className={cn(
+                  'z-50 w-(--radix-popover-trigger-width)',
+                  portalClassName,
+                )}
+                onOpenAutoFocus={(event) => {
+                  event.preventDefault();
+                }}
+                onCloseAutoFocus={(event) => {
+                  event.preventDefault();
+                }}
+                onBlur={handlePortalBlur}
+              >
+                {list}
+              </Content>
+            </Portal>
+          )}
+        </Root>
       </div>
     );
   },

--- a/lib/components/Select/contexts/select.provider.tsx
+++ b/lib/components/Select/contexts/select.provider.tsx
@@ -26,6 +26,7 @@ export const SelectProvider: FC<
     options: Option[];
     onChange?: SelectProps['onChange'];
     onBlur?: SelectProps['onBlur'];
+    onValueChange?: SelectProps['onValueChange'];
   }
 > = ({
   children,
@@ -35,6 +36,7 @@ export const SelectProvider: FC<
   options: defaultOptions,
   onChange,
   onBlur,
+  onValueChange,
 }) => {
   const [options, setOptions] = useState<Option[]>(defaultOptions);
   const highlightSearchEnabled = useRef(highlightSearch);
@@ -60,13 +62,14 @@ export const SelectProvider: FC<
       setCanContinueFetching(true);
       setPage(DEFAULT_INIT_PAGE);
       onChange?.({ target: { value, name: name ?? '' } });
+      onValueChange?.(value);
       onBlur?.();
 
       timeoutRef.current = setTimeout(() => {
         setIsTyping(false);
       }, DELAY_TYPING);
     },
-    [onChange, name, onBlur],
+    [onChange, onValueChange, name, onBlur],
   );
 
   const handleToggle = useCallback(

--- a/lib/components/Select/hooks/useSelect.ts
+++ b/lib/components/Select/hooks/useSelect.ts
@@ -1,4 +1,11 @@
-import { ComponentRef, RefObject, useCallback, useEffect, useRef } from 'react';
+import {
+  ComponentRef,
+  RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 
 import { useClickOutside } from '@/hooks';
 
@@ -9,6 +16,7 @@ type UseSelectParams = {
   inputRef?: RefObject<ComponentRef<'input'> | null>;
   searchInputRef?: RefObject<ComponentRef<'input'> | null>;
   internalValue?: Option;
+  listRef?: RefObject<HTMLElement | null>;
   onBlur?: SelectProps['onBlur'];
 };
 
@@ -16,17 +24,35 @@ export const useSelect = ({
   inputRef,
   searchInputRef,
   internalValue,
+  listRef,
   onBlur,
 }: UseSelectParams) => {
   const wrapperRef = useRef<ComponentRef<'div'>>(null);
   const wrapperInputRef = useRef<ComponentRef<'div'>>(null);
   const { value, setSearchTerm, setCanFilter, toggleOpen } = useSelectContext();
 
+  const outsideRefs = useMemo(() => {
+    return [wrapperRef, listRef];
+  }, [listRef]);
+
+  const isInside = useCallback(
+    (node: Node | null) => {
+      if (!node) {
+        return false;
+      }
+
+      return outsideRefs.some((ref) => {
+        return ref?.current?.contains(node);
+      });
+    },
+    [outsideRefs],
+  );
+
   const handleClickOutside = useCallback(() => {
     toggleOpen(false);
   }, [toggleOpen]);
 
-  useClickOutside(wrapperRef, handleClickOutside);
+  useClickOutside(outsideRefs, handleClickOutside);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -89,7 +115,7 @@ export const useSelect = ({
     wrapperRef.current?.addEventListener(
       'focusout',
       (event) => {
-        if (!wrapperRef.current?.contains(event.relatedTarget as Node)) {
+        if (!isInside(event.relatedTarget as Node)) {
           toggleOpen(false);
         }
       },
@@ -115,7 +141,7 @@ export const useSelect = ({
     wrapperRef.current?.addEventListener('focusout', (event) => {
       const newFocusElement = event.relatedTarget as Node;
 
-      if (!newFocusElement || !wrapperRef.current?.contains(newFocusElement)) {
+      if (!isInside(newFocusElement)) {
         if (!inputRef?.current?.value) {
           onBlur?.();
         }
@@ -133,6 +159,7 @@ export const useSelect = ({
   };
 
   return {
+    isInside,
     wrapperRef,
     wrapperInputRef,
     handleOpen,

--- a/lib/components/Select/stories/Light.stories.tsx
+++ b/lib/components/Select/stories/Light.stories.tsx
@@ -3,6 +3,7 @@ import { Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/Button/Button';
+import { Drawer } from '@/components/Drawer/Drawer';
 import { Modal } from '@/components/Modal/Modal';
 
 import { getPokemons } from '../../../../mocks';
@@ -245,6 +246,54 @@ export const selectInModal = {
             </div>
           </Modal.Body>
         </Modal>
+      </div>
+    );
+  },
+} satisfies Story;
+
+export const selectInDrawerPortal = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`isPortal` renders the options in a portal positioned with Radix Popover, so the list is never clipped by `overflow` containers such as drawers, modals or table cells. `onValueChange` receives the selected value directly, without the event wrapper.',
+      },
+    },
+  },
+  render: function selectInDrawerPortalStory() {
+    const [isOpen, setIsOpen] = useState(false);
+    const [value, setValue] = useState<string>();
+
+    return (
+      <div>
+        <Button onClick={() => setIsOpen(true)}>Open Drawer with select</Button>
+
+        <Drawer isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <Drawer.Body>
+            <div className="p-6">
+              <SelectComponent
+                isPortal
+                label="Choose your distribution"
+                options={[
+                  {
+                    label: 'Talos',
+                    value: 'talos',
+                    leftIcon: <img src="./talos.svg" alt="Talos Logo" />,
+                  },
+                  {
+                    label: 'K3S',
+                    value: 'k3s',
+                    leftIcon: <img src="./k3s.svg" alt="K3S Logo" />,
+                  },
+                ]}
+                placeholder="Select an option..."
+                value={value}
+                onValueChange={setValue}
+                name="drawer-select"
+              />
+            </div>
+          </Drawer.Body>
+        </Drawer>
       </div>
     );
   },

--- a/lib/hooks/useClickOutside.test.ts
+++ b/lib/hooks/useClickOutside.test.ts
@@ -34,6 +34,30 @@ describe('useClickOutside', () => {
     expect(onClickOutside).not.toHaveBeenCalled();
   });
 
+  it('treats every ref in an array as inside', () => {
+    const inside = document.createElement('div');
+    const portaled = document.createElement('div');
+    const outside = document.createElement('div');
+    document.body.append(inside, portaled, outside);
+
+    const onClickOutside = vi.fn();
+    renderHook(() => {
+      useClickOutside(
+        [{ current: inside }, { current: portaled }, undefined],
+        onClickOutside,
+      );
+    });
+
+    fireEvent.mouseDown(portaled);
+    fireEvent.mouseDown(inside);
+
+    expect(onClickOutside).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(outside);
+
+    expect(onClickOutside).toHaveBeenCalledTimes(1);
+  });
+
   it('stops listening after unmount', () => {
     const { outside, onClickOutside, unmount } = setup();
 

--- a/lib/hooks/useClickOutside.ts
+++ b/lib/hooks/useClickOutside.ts
@@ -1,16 +1,23 @@
 import { RefObject, useEffect } from 'react';
 
+type Target = RefObject<HTMLElement | null> | undefined;
+
 export const useClickOutside = (
-  ref: RefObject<HTMLElement | null>,
+  refs: Target | Target[],
   onClickOutside: () => void,
 ) => {
   useEffect(() => {
     const controller = new AbortController();
+    const targets = Array.isArray(refs) ? refs : [refs];
 
     document.addEventListener(
       'mousedown',
       (event) => {
-        if (!ref.current?.contains(event.target as Node)) {
+        const isInside = targets.some((ref) => {
+          return ref?.current?.contains(event.target as Node);
+        });
+
+        if (!isInside) {
           onClickOutside();
         }
       },
@@ -20,5 +27,5 @@ export const useClickOutside = (
     return () => {
       controller.abort();
     };
-  }, [ref, onClickOutside]);
+  }, [refs, onClickOutside]);
 };


### PR DESCRIPTION
## Summary

- **`isPortal`**: renders the options list in a portal positioned with Radix Popover (same mechanism as the table page-size dropdown), so it is never clipped by `overflow` containers such as drawers, modals or table cells. Kubernetes rewrote the whole component as `PortalSelect` for this and lost keyboard navigation; here keyboard navigation, click-outside, Escape and focus handling keep working because the portaled list counts as "inside" the select. `portalClassName` lets consumers raise the z-index above custom overlays.
- **`onValueChange(value)`**: complements the event-shaped `onChange`. Every microfrontend wrote the same adapter to bridge `Select` into react-hook-form (billing `CountrySelect`, settings `TimezoneSelect`, databases `ScheduleSelect`).
- **`useClickOutside`** now accepts an array of refs (backwards compatible).

Default behaviour is unchanged: without `isPortal` the list renders inline exactly as before.

## Test plan

- [x] New tests: portal renders outside the select and selection works, keyboard navigation into the portaled list, click outside / Escape, inside a `Modal`, axe while open, `onValueChange`
- [x] `npx vitest run lib/components/Select lib/hooks lib/components/VirtualizedTable`, lint, types, prettier
- [ ] Storybook: `Select/Light` → `selectInDrawerPortal`