### PR TITLE
✨ feat: add disabled and asOverlay modes to Tooltip

### DIFF
--- a/lib/components/Tooltip/Tooltip.stories.tsx
+++ b/lib/components/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 
 import { Button } from '@/components/Button/Button';
+import { Input } from '@/components/Input/Input';
 
 import { Tooltip as TooltipComponent } from './Tooltip';
 
@@ -90,6 +92,72 @@ export const WithReactNodeContent: Story = {
       </TooltipComponent>
     </div>
   ),
+};
+
+export const Disabled: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`disabled` keeps the children mounted exactly as they are and never opens the tooltip, so it can be toggled while the user types in a field without remounting it.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-center justify-center gap-8 h-50">
+      <TooltipComponent content="You will not see me" disabled>
+        <Button>Disabled tooltip</Button>
+      </TooltipComponent>
+      <TooltipComponent content="But you will see me">
+        <Button>Enabled tooltip</Button>
+      </TooltipComponent>
+    </div>
+  ),
+};
+
+export const OverlayOnField: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`asOverlay` renders an invisible trigger over the children instead of wrapping them, for elements that cannot be wrapped or are disabled (native pointer events do not fire on disabled controls). `overlayClassName` positions the trigger; here it covers only the right edge of the input so typing still works, and the tooltip is enabled only when the name is taken.',
+      },
+    },
+  },
+  render: function OverlayOnFieldStory() {
+    const [name, setName] = useState('');
+    const isTaken = name.trim().toLowerCase() === 'taken';
+
+    return (
+      <div className="flex flex-col gap-4 w-80">
+        <TooltipComponent
+          asOverlay
+          side="right"
+          content={`The name "${name}" is already in use`}
+          disabled={!isTaken}
+          overlayClassName="right-0 top-7 h-10 w-10"
+        >
+          <Input
+            label="Name"
+            value={name}
+            error={isTaken ? 'This name is already in use' : undefined}
+            helperText='Type "taken" to see the tooltip'
+            onChange={(event) => {
+              setName(event.target.value);
+            }}
+          />
+        </TooltipComponent>
+
+        <TooltipComponent
+          asOverlay
+          side="right"
+          content="This field is locked while the resource is running"
+        >
+          <Input label="Locked field" value="prod-cluster" disabled readOnly />
+        </TooltipComponent>
+      </div>
+    );
+  },
 };
 
 export default meta;

--- a/lib/components/Tooltip/Tooltip.test.tsx
+++ b/lib/components/Tooltip/Tooltip.test.tsx
@@ -12,16 +12,17 @@ describe('Tooltip', () => {
   } satisfies TooltipProps;
 
   const setup = (props?: Partial<TooltipProps>) => {
-    const { container: component } = render(
+    const user = userEvent.setup();
+    const { container: component, rerender } = render(
       <Tooltip {...defaultProps} {...props} />,
     );
 
-    const user = userEvent.setup();
     const getTooltipBodyText = (value: string = defaultProps.children) =>
       screen.findByText(value);
 
     return {
       component,
+      rerender,
       user,
       getTooltipBodyText,
     };
@@ -53,5 +54,100 @@ describe('Tooltip', () => {
     const tooltip = await screen.findByRole('tooltip');
 
     expect(tooltip).toHaveTextContent('Sample tooltip content');
+  });
+
+  describe('disabled', () => {
+    it('should keep the children but never open', async () => {
+      const { user, getTooltipBodyText } = setup({ disabled: true });
+
+      const tooltipBody = await getTooltipBodyText();
+
+      await user.hover(tooltipBody);
+      tooltipBody.focus();
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+
+    it('should not remount the children when toggled', () => {
+      const { rerender } = setup({
+        disabled: true,
+        children: <input aria-label="Name" defaultValue="typed" />,
+      });
+
+      const input = screen.getByRole('textbox', { name: 'Name' });
+
+      rerender(
+        <Tooltip
+          {...defaultProps}
+          disabled={false}
+          children={<input aria-label="Name" defaultValue="typed" />}
+        />,
+      );
+
+      expect(screen.getByRole('textbox', { name: 'Name' })).toBe(input);
+    });
+  });
+
+  describe('asOverlay', () => {
+    it('should render the children untouched and an overlay trigger named after the content', async () => {
+      const { user } = setup({
+        asOverlay: true,
+        children: <input aria-label="Name" />,
+      });
+
+      const input = screen.getByRole('textbox', { name: 'Name' });
+      const overlay = screen.getByRole('img', {
+        name: 'Sample tooltip content',
+      });
+
+      expect(input.parentElement).toBe(overlay.parentElement);
+
+      await user.hover(overlay);
+
+      expect(await screen.findByRole('tooltip')).toHaveTextContent(
+        'Sample tooltip content',
+      );
+    });
+
+    it('should position the overlay with overlayClassName and name it with overlayLabel', () => {
+      setup({
+        asOverlay: true,
+        content: <strong>Rich content</strong>,
+        overlayLabel: 'Why this field is locked',
+        overlayClassName: 'right-0 top-7 h-10 w-8',
+        children: <input aria-label="Name" />,
+      });
+
+      const overlay = screen.getByRole('img', {
+        name: 'Why this field is locked',
+      });
+
+      expect(overlay).toHaveClass('right-0', 'top-7', 'h-10', 'w-8');
+      expect(overlay).not.toHaveClass('inset-0');
+    });
+
+    it('should hide the overlay while disabled', () => {
+      setup({
+        asOverlay: true,
+        disabled: true,
+        children: <input aria-label="Name" />,
+      });
+
+      expect(
+        screen.queryByRole('img', { name: 'Sample tooltip content' }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: 'Name' })).toBeInTheDocument();
+    });
+
+    it("shouldn't have accessibility violations", async () => {
+      const { component } = setup({
+        asOverlay: true,
+        children: <input aria-label="Name" />,
+      });
+
+      const results = await axe(component);
+
+      expect(results).toHaveNoViolations();
+    });
   });
 });

--- a/lib/components/Tooltip/Tooltip.tsx
+++ b/lib/components/Tooltip/Tooltip.tsx
@@ -6,7 +6,7 @@ import {
   Root,
   Trigger,
 } from '@radix-ui/react-tooltip';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 
 import { cn } from '@/utils';
 
@@ -29,11 +29,20 @@ import { Props } from './Tooltip.types';
  * <Tooltip content="Danger!" bgClassName="bg-red-500">
  *   <Button variant="danger">Delete</Button>
  * </Tooltip>
+ *
+ * <Tooltip content="This name is taken" asOverlay overlayClassName="right-0 top-7 h-10 w-8">
+ *   <Input label="Name" />
+ * </Tooltip>
  * ```
  */
 export const Tooltip: FC<Props> = ({
   content,
   children,
+  asOverlay = false,
+  disabled = false,
+  overlayClassName,
+  overlayLabel,
+  wrapperClassName,
   side = 'top',
   sideOffset = 4,
   bgClassName = 'bg-slate-700',
@@ -41,28 +50,54 @@ export const Tooltip: FC<Props> = ({
   textClassName = 'text-white',
   className,
   delayDuration = 0,
-}) => (
-  <Provider delayDuration={delayDuration}>
-    <Root>
-      <Trigger asChild>
-        <span>{children}</span>
-      </Trigger>
-      <Portal>
-        <Content
-          side={side}
-          sideOffset={sideOffset}
-          className={cn(
-            'rounded px-2 py-1 text-xs shadow-md',
-            'animate-in fade-in-0',
-            bgClassName,
-            textClassName,
-            className,
-          )}
-        >
-          {content}
-          <Arrow className={arrowClassName} />
-        </Content>
-      </Portal>
-    </Root>
-  </Provider>
-);
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const trigger = asOverlay ? (
+    <span
+      role="img"
+      aria-label={
+        overlayLabel ?? (typeof content === 'string' ? content : undefined)
+      }
+      hidden={disabled}
+      className={cn('absolute cursor-help', overlayClassName ?? 'inset-0')}
+    />
+  ) : (
+    <span>{children}</span>
+  );
+
+  const tooltip = (
+    <Provider delayDuration={delayDuration}>
+      <Root open={!disabled && isOpen} onOpenChange={setIsOpen}>
+        <Trigger asChild>{trigger}</Trigger>
+        <Portal>
+          <Content
+            side={side}
+            sideOffset={sideOffset}
+            className={cn(
+              'rounded px-2 py-1 text-xs shadow-md',
+              'animate-in fade-in-0',
+              bgClassName,
+              textClassName,
+              className,
+            )}
+          >
+            {content}
+            <Arrow className={arrowClassName} />
+          </Content>
+        </Portal>
+      </Root>
+    </Provider>
+  );
+
+  if (!asOverlay) {
+    return tooltip;
+  }
+
+  return (
+    <div className={cn('relative', wrapperClassName)}>
+      {children}
+      {tooltip}
+    </div>
+  );
+};

--- a/lib/components/Tooltip/Tooltip.types.ts
+++ b/lib/components/Tooltip/Tooltip.types.ts
@@ -23,6 +23,16 @@ export interface Props {
   content: ReactNode | string;
   /** The trigger element */
   children: ReactNode;
+  /** Render an invisible trigger over the children instead of wrapping them, for fields that cannot be wrapped or are disabled */
+  asOverlay?: boolean;
+  /** Keep the children as they are and never open the tooltip */
+  disabled?: boolean;
+  /** Position and size of the overlay trigger (defaults to `inset-0`) */
+  overlayClassName?: string;
+  /** Accessible name of the overlay trigger; defaults to `content` when it is a string */
+  overlayLabel?: string;
+  /** Additional className for the relative wrapper used in overlay mode */
+  wrapperClassName?: string;
   /** Tooltip position relative to trigger */
   side?: 'top' | 'bottom' | 'left' | 'right';
   /** Distance from trigger in px */


### PR DESCRIPTION
## Summary

- **`disabled`**: keeps the Radix tree mounted and forces the tooltip closed instead of unwrapping the children, so toggling it while the user types in a field does not remount the field. Volumes (`NameTakenTooltip`) and vpc (`LockedFieldTooltip`) implemented an `enabled` flag locally, the vpc one by returning the children untouched (which remounts them).
- **`asOverlay`**: renders an invisible, positionable trigger over the children instead of wrapping them, for controls that cannot be wrapped or are disabled (native pointer events do not fire on disabled buttons/inputs). `overlayClassName` positions the hit area (whole control by default; e.g. `right-0 top-7 h-10 w-8` to cover only the right edge of an input so typing still works). `overlayLabel` names it for assistive technology when `content` is not a string. `wrapperClassName` styles the relative wrapper.

Default behaviour is unchanged.

## Test plan

- [x] New tests: disabled never opens, children not remounted when toggled, overlay trigger named and positioned, overlay hidden while disabled, axe
- [x] `npx vitest run lib/components/Tooltip`, lint, types, prettier
- [ ] Storybook: `Tooltip` → `Disabled`, `OverlayOnField`