### PR TITLE
✨ feat: add declarative items to Tabs and derive the active trigger state

### DIFF
--- a/lib/components/Tabs/Tabs.test.tsx
+++ b/lib/components/Tabs/Tabs.test.tsx
@@ -92,4 +92,101 @@ describe('Tabs', () => {
 
     expect(results).toHaveNoViolations();
   });
+
+  describe('Trigger without isActive', () => {
+    it('derives the active styles from the tabs state', async () => {
+      render(
+        <Tabs defaultValue="tab1">
+          <Tabs.List orientation="horizontal">
+            <Tabs.Trigger tab="tab1" label="Tab 1" />
+            <Tabs.Trigger tab="tab2" label="Tab 2" />
+          </Tabs.List>
+          <Tabs.Content value="tab1">Content 1</Tabs.Content>
+          <Tabs.Content value="tab2">Content 2</Tabs.Content>
+        </Tabs>,
+      );
+
+      const firstTab = screen.getByRole('tab', { name: 'Tab 1' });
+      const secondTab = screen.getByRole('tab', { name: 'Tab 2' });
+
+      expect(firstTab).toHaveAttribute('data-state', 'active');
+      expect(screen.getByText('Tab 2')).toHaveClass(
+        'group-data-[state=active]/tab:after:scale-y-100',
+      );
+
+      await userEvent.click(secondTab);
+
+      expect(secondTab).toHaveAttribute('data-state', 'active');
+      expect(firstTab).toHaveAttribute('data-state', 'inactive');
+      expect(screen.getByText('Content 2')).toBeInTheDocument();
+    });
+  });
+
+  describe('with items', () => {
+    const items = [
+      { value: 'overview', label: 'Overview', content: 'Overview content' },
+      { value: 'settings', label: 'Settings', content: 'Settings content' },
+      { value: 'billing', label: 'Billing', content: 'Billing content' },
+    ];
+
+    it('renders the list, triggers and contents and starts on the first item', async () => {
+      const onValueChange = vi.fn();
+
+      render(<Tabs items={items} onValueChange={onValueChange} />);
+
+      expect(screen.getAllByRole('tab')).toHaveLength(3);
+      expect(screen.getByText('Overview content')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+
+      expect(onValueChange).toHaveBeenCalledWith('settings');
+      expect(screen.getByText('Settings content')).toBeInTheDocument();
+      expect(screen.queryByText('Overview content')).not.toBeInTheDocument();
+    });
+
+    it('respects defaultValue', () => {
+      render(<Tabs items={items} defaultValue="billing" />);
+
+      expect(screen.getByText('Billing content')).toBeInTheDocument();
+    });
+
+    it('falls back to the first item when the active one disappears', async () => {
+      const { rerender } = render(<Tabs items={items} />);
+
+      await userEvent.click(screen.getByRole('tab', { name: 'Billing' }));
+
+      expect(screen.getByText('Billing content')).toBeInTheDocument();
+
+      rerender(<Tabs items={items.slice(0, 2)} />);
+
+      expect(screen.getByText('Overview content')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('tab', { name: 'Billing' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('stays controlled when value is provided', async () => {
+      const onValueChange = vi.fn();
+
+      render(
+        <Tabs items={items} value="settings" onValueChange={onValueChange} />,
+      );
+
+      expect(screen.getByText('Settings content')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('tab', { name: 'Billing' }));
+
+      expect(onValueChange).toHaveBeenCalledWith('billing');
+      expect(screen.getByText('Settings content')).toBeInTheDocument();
+      expect(screen.queryByText('Billing content')).not.toBeInTheDocument();
+    });
+
+    it("shouldn't have accessibility violations", async () => {
+      const { container } = render(<Tabs items={items} />);
+
+      const results = await axe(container);
+
+      expect(results).toHaveNoViolations();
+    });
+  });
 });

--- a/lib/components/Tabs/Tabs.tsx
+++ b/lib/components/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import * as ReactTabs from '@radix-ui/react-tabs';
-import { FC } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import { cn } from '@/utils';
 
@@ -9,27 +9,27 @@ import { Content, List, Trigger } from './components';
 
 /**
  * A tabs component built on Radix UI primitives.
- * Supports horizontal and vertical orientations with List, Trigger, and Content sub-components.
+ * Supports horizontal and vertical orientations with List, Trigger, and Content sub-components,
+ * or a declarative `items` list.
  *
  * @example
  * ```tsx
  * <Tabs defaultValue="overview">
  *   <Tabs.List orientation="horizontal">
- *     <Tabs.Trigger tab="overview" label="Overview" isActive />
- *     <Tabs.Trigger tab="settings" label="Settings" isActive={false} />
- *     <Tabs.Trigger tab="billing" label="Billing" isActive={false} />
+ *     <Tabs.Trigger tab="overview" label="Overview" />
+ *     <Tabs.Trigger tab="settings" label="Settings" />
  *   </Tabs.List>
  *
- *   <Tabs.Content value="overview">
- *     Overview content here
- *   </Tabs.Content>
- *   <Tabs.Content value="settings">
- *     Settings content here
- *   </Tabs.Content>
- *   <Tabs.Content value="billing">
- *     Billing content here
- *   </Tabs.Content>
+ *   <Tabs.Content value="overview">Overview content here</Tabs.Content>
+ *   <Tabs.Content value="settings">Settings content here</Tabs.Content>
  * </Tabs>
+ *
+ * <Tabs
+ *   items={[
+ *     { value: 'overview', label: 'Overview', content: <Overview /> },
+ *     { value: 'settings', label: 'Settings', content: <Settings /> },
+ *   ]}
+ * />
  * ```
  *
  * @see {@link https://konstructio.github.io/konstruct-ui/?path=/docs/components-tabs--docs Storybook}
@@ -38,17 +38,90 @@ const Tabs: FC<TabsProps> & {
   List: FC<ListProps>;
   Trigger: FC<TriggerProps>;
   Content: FC<ReactTabs.TabsContentProps>;
-} = ({ children, theme, className, orientation, ...rest }) => (
-  <ReactTabs.Root
-    {...rest}
-    data-theme={theme}
-    data-orientation={orientation}
-    aria-orientation={orientation}
-    className={cn(rootVariants({ variant: orientation, className }))}
-  >
-    {children}
-  </ReactTabs.Root>
-);
+} = ({
+  children,
+  className,
+  defaultValue,
+  items,
+  listClassName,
+  orientation,
+  theme,
+  value,
+  onValueChange,
+  ...rest
+}) => {
+  const firstValue = items?.at(0)?.value;
+  const [internalValue, setInternalValue] = useState(
+    defaultValue ?? firstValue,
+  );
+  const isControlled = value !== undefined;
+  const isManaged = !!items && !isControlled;
+
+  useEffect(() => {
+    if (!isManaged) {
+      return;
+    }
+
+    const isCurrentAvailable = items.some((item) => {
+      return item.value === internalValue;
+    });
+
+    if (!isCurrentAvailable) {
+      setInternalValue(firstValue);
+    }
+  }, [firstValue, internalValue, isManaged, items]);
+
+  const handleValueChange = (nextValue: string) => {
+    if (isManaged) {
+      setInternalValue(nextValue);
+    }
+
+    onValueChange?.(nextValue);
+  };
+
+  return (
+    <ReactTabs.Root
+      {...rest}
+      value={isManaged ? internalValue : value}
+      defaultValue={isManaged ? undefined : defaultValue}
+      onValueChange={handleValueChange}
+      data-theme={theme}
+      data-orientation={orientation}
+      aria-orientation={orientation}
+      className={cn(rootVariants({ variant: orientation, className }))}
+    >
+      {items ? (
+        <>
+          <List
+            orientation={orientation ?? 'horizontal'}
+            className={listClassName}
+          >
+            {items.map(({ label, triggerClassName, value: itemValue }) => (
+              <Trigger
+                key={itemValue}
+                tab={itemValue}
+                label={label}
+                className={triggerClassName}
+              />
+            ))}
+          </List>
+
+          {items.map(({ content, contentClassName, value: itemValue }) => (
+            <Content
+              key={itemValue}
+              value={itemValue}
+              className={contentClassName}
+            >
+              {content}
+            </Content>
+          ))}
+        </>
+      ) : null}
+
+      {children}
+    </ReactTabs.Root>
+  );
+};
 
 Tabs.displayName = 'KonstructTabs';
 Tabs.Content = Content;

--- a/lib/components/Tabs/Tabs.types.ts
+++ b/lib/components/Tabs/Tabs.types.ts
@@ -1,7 +1,7 @@
 import * as ReactTabs from '@radix-ui/react-tabs';
 
 import { VariantProps } from 'class-variance-authority';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 import { triggerVariants } from './Tabs.variants';
 import { Theme } from '@/domain/theme';
 
@@ -20,7 +20,19 @@ import { Theme } from '@/domain/theme';
  * </Tabs>
  * ```
  */
+export type TabItem = {
+  content: ReactNode;
+  contentClassName?: string;
+  label: string;
+  triggerClassName?: string;
+  value: string;
+};
+
 export interface Props extends ReactTabs.TabsProps, PropsWithChildren {
+  /** Declarative tabs: renders the list, triggers and contents; falls back to the first item when the active one disappears */
+  items?: TabItem[];
+  /** Additional className for the generated Tabs.List when using `items` */
+  listClassName?: string;
   /** Theme override for this component */
   theme?: Theme;
 }
@@ -39,8 +51,8 @@ export interface TriggerProps
   tab: string;
   /** Display label for the tab */
   label: string;
-  /** Whether this tab is active */
-  isActive: boolean;
+  /** Whether this tab is active; derived from the Tabs state when omitted */
+  isActive?: boolean;
 }
 
 /**

--- a/lib/components/Tabs/Tabs.variants.ts
+++ b/lib/components/Tabs/Tabs.variants.ts
@@ -70,6 +70,15 @@ export const triggerVariants = cva(
           'dark:text-metal-100',
         ],
         inactive: ['text-slate-500', 'font-semibold', 'dark:text-metal-400'],
+        auto: [
+          'text-slate-500',
+          'font-semibold',
+          'dark:text-metal-400',
+          'group-data-[state=active]/tab:text-zinc-700',
+          'group-data-[state=active]/tab:after:scale-y-100',
+          'group-data-[state=active]/tab:hover:after:scale-y-140',
+          'dark:group-data-[state=active]/tab:text-metal-100',
+        ],
       },
     },
     defaultVariants: {

--- a/lib/components/Tabs/components/Trigger.tsx
+++ b/lib/components/Tabs/components/Trigger.tsx
@@ -7,14 +7,22 @@ import { cn } from '@/utils';
 import { TriggerProps } from '../Tabs.types';
 import { triggerVariants } from '../Tabs.variants';
 
+const getVariant = (isActive?: boolean) => {
+  if (isActive === undefined) {
+    return 'auto';
+  }
+
+  return isActive ? 'active' : 'inactive';
+};
+
 const Trigger: FC<TriggerProps> = ({ tab, label, isActive, className }) => (
-  <Tabs.Trigger value={tab}>
+  <Tabs.Trigger value={tab} className="group/tab">
     <Typography
       variant="body2"
       component="span"
       className={cn(
         triggerVariants({
-          variant: isActive ? 'active' : 'inactive',
+          variant: getVariant(isActive),
           className,
         }),
       )}

--- a/lib/components/Tabs/stories/Dark.stories.tsx
+++ b/lib/components/Tabs/stories/Dark.stories.tsx
@@ -126,4 +126,63 @@ export const Dark: Story = {
   },
 };
 
+export const DeclarativeItems: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`items` renders the list, triggers and contents from an array. Uncontrolled by default: the first item is selected and, if the active item disappears (for example after changing a region), the selection falls back to the first one. `Tabs.Trigger` no longer needs `isActive`; it derives the active styles from the tabs state.',
+      },
+    },
+  },
+  render: function DeclarativeItemsStory() {
+    const [showBilling, setShowBilling] = useState(true);
+    const items = [
+      {
+        value: 'account',
+        label: 'Account',
+        content: <p className="mt-6">Account settings</p>,
+      },
+      {
+        value: 'security',
+        label: 'Security',
+        content: <p className="mt-6">Security settings</p>,
+      },
+      ...(showBilling
+        ? [
+            {
+              value: 'billing',
+              label: 'Billing',
+              content: <p className="mt-6">Billing settings</p>,
+            },
+          ]
+        : []),
+    ];
+
+    return (
+      <div className="flex flex-col gap-6">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={showBilling}
+            onChange={(event) => {
+              setShowBilling(event.target.checked);
+            }}
+          />
+          Show the Billing tab
+        </label>
+
+        <TabsComponent
+          items={items}
+          orientation="horizontal"
+          listClassName="gap-6"
+          onValueChange={(value) => {
+            console.log('value', value);
+          }}
+        />
+      </div>
+    );
+  },
+};
+
 export default meta;

--- a/lib/components/Tabs/stories/Light.stories.tsx
+++ b/lib/components/Tabs/stories/Light.stories.tsx
@@ -112,4 +112,63 @@ export const Light: Story = {
   },
 };
 
+export const DeclarativeItems: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`items` renders the list, triggers and contents from an array. Uncontrolled by default: the first item is selected and, if the active item disappears (for example after changing a region), the selection falls back to the first one. `Tabs.Trigger` no longer needs `isActive`; it derives the active styles from the tabs state.',
+      },
+    },
+  },
+  render: function DeclarativeItemsStory() {
+    const [showBilling, setShowBilling] = useState(true);
+    const items = [
+      {
+        value: 'account',
+        label: 'Account',
+        content: <p className="mt-6">Account settings</p>,
+      },
+      {
+        value: 'security',
+        label: 'Security',
+        content: <p className="mt-6">Security settings</p>,
+      },
+      ...(showBilling
+        ? [
+            {
+              value: 'billing',
+              label: 'Billing',
+              content: <p className="mt-6">Billing settings</p>,
+            },
+          ]
+        : []),
+    ];
+
+    return (
+      <div className="flex flex-col gap-6">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={showBilling}
+            onChange={(event) => {
+              setShowBilling(event.target.checked);
+            }}
+          />
+          Show the Billing tab
+        </label>
+
+        <TabsComponent
+          items={items}
+          orientation="horizontal"
+          listClassName="gap-6"
+          onValueChange={(value) => {
+            console.log('value', value);
+          }}
+        />
+      </div>
+    );
+  },
+};
+
 export default meta;


### PR DESCRIPTION
## Summary

- **`Tabs.Trigger` without `isActive`**: when omitted, the active styles are derived from Radix's `data-state` through a named group, so consumers stop mirroring the active value into every trigger. Compute (detail `Tabs`), kubernetes (cpu/gpu `Tabs`), settings and billing pages all repeat `isActive={activeTab === tab}`. Passing `isActive` still works.
- **`items`**: declarative API that renders the list, triggers and contents from an array (`value`, `label`, `content`, optional class names, `listClassName`). Uncontrolled by default: starts on the first item (or `defaultValue`) and falls back to the first item when the active one disappears, which compute `SizeTabs` and kubernetes node pool `Tabs` implemented locally with `useState` + `useEffect`. Passing `value` keeps the tabs controlled.

Existing children-based usage is unchanged.

## Test plan

- [x] New tests: derived active state, items render/switch/`onValueChange`, `defaultValue`, fallback when the active item disappears, controlled `value`, axe
- [x] `npx vitest run lib/components/Tabs`, lint, types, prettier
- [ ] Storybook: `Tabs/Light` and `Dark` → `DeclarativeItems`