### PR TITLE
✨ feat: add step, unit, error, helperText and labelAction to Counter

### DIFF
--- a/lib/components/Counter/Counter.test.tsx
+++ b/lib/components/Counter/Counter.test.tsx
@@ -271,4 +271,100 @@ describe('Counter', () => {
     await user.click(getDecrementButton());
     expect(input).toHaveValue(7);
   });
+  describe('step, unit and messages', () => {
+    it('should add and subtract the step and clamp to the limits', async () => {
+      const { user, getInput, getIncrementButton, getDecrementButton } = setup({
+        step: 500,
+        min: 0,
+        max: 1200,
+      });
+
+      await user.click(getIncrementButton());
+      await user.click(getIncrementButton());
+
+      expect(await getInput()).toHaveValue(1000);
+
+      await user.click(getIncrementButton());
+
+      expect(await getInput()).toHaveValue(1200);
+
+      await user.click(getDecrementButton());
+      await user.click(getDecrementButton());
+      await user.click(getDecrementButton());
+
+      expect(await getInput()).toHaveValue(0);
+    });
+
+    it('should render the unit next to the value', async () => {
+      setup({ unit: 'GB' });
+
+      expect(screen.getByText('GB')).toBeInTheDocument();
+    });
+
+    it('should associate the label with the input and render the label action', async () => {
+      setup({ label: 'Size', labelAction: <span>$12.00/mo</span> });
+
+      expect(screen.getByLabelText('Size')).toBe(
+        await screen.findByRole('spinbutton'),
+      );
+      expect(screen.getByText('$12.00/mo')).toBeInTheDocument();
+    });
+
+    it('should describe the input with the error and hide the helper text', async () => {
+      setup({ error: 'Quota exceeded', helperText: 'Increments of 500 GB' });
+
+      const input = await screen.findByRole('spinbutton');
+      const error = screen.getByText('Quota exceeded');
+
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+      expect(input).toHaveAttribute('aria-describedby', error.id);
+      expect(
+        screen.queryByText('Increments of 500 GB'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should describe the input with the helper text', async () => {
+      setup({ helperText: 'Increments of 500 GB' });
+
+      const input = await screen.findByRole('spinbutton');
+      const helper = screen.getByText('Increments of 500 GB');
+
+      expect(input).toHaveAttribute('aria-describedby', helper.id);
+      expect(input).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('should disable the buttons and the input when disabled', async () => {
+      const { getInput, getIncrementButton, getDecrementButton } = setup({
+        disabled: true,
+        editable: true,
+      });
+
+      expect(await getInput()).toBeDisabled();
+      expect(getIncrementButton()).toBeDisabled();
+      expect(getDecrementButton()).toBeDisabled();
+    });
+
+    it('should use the custom button labels', () => {
+      setup({ decrementLabel: 'Remove 500 GB', incrementLabel: 'Add 500 GB' });
+
+      expect(
+        screen.getByRole('button', { name: 'Remove 500 GB' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Add 500 GB' }),
+      ).toBeInTheDocument();
+    });
+
+    it("shouldn't have accessibility violations with unit, error and label action", async () => {
+      const { component } = setup({
+        unit: 'GB',
+        error: 'Quota exceeded',
+        labelAction: <span>$12.00/mo</span>,
+      });
+
+      const results = await axe(component);
+
+      expect(results).toHaveNoViolations();
+    });
+  });
 });

--- a/lib/components/Counter/Counter.tsx
+++ b/lib/components/Counter/Counter.tsx
@@ -3,13 +3,15 @@ import { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { ChangeEvent, FC, forwardRef, useId, useState } from 'react';
 import { Minus, Plus } from 'react-feather';
 
-import { cn } from '@/utils';
+import { cn, composeIds } from '@/utils';
 
 import { Props } from './Counter.types';
 import {
   buttonVariants,
-  labelVariants,
   counterVariants,
+  fieldVariants,
+  labelVariants,
+  unitVariants,
 } from './Counter.variants';
 import { Typography } from '../Typography/Typography';
 
@@ -35,11 +37,14 @@ import { Typography } from '../Typography/Typography';
  *   onChange={({ target }) => setNodes(target.value)}
  * />
  *
- * // Disabled increment/decrement
+ * // Stepping by 500 GB with a unit, price and helper text
  * <Counter
- *   value={5}
- *   canIncrement={value < max}
- *   canDecrement={value > min}
+ *   label="Size"
+ *   value={size}
+ *   step={500}
+ *   unit="GB"
+ *   labelAction={<span>$12.00/mo</span>}
+ *   helperText="Increments of 500 GB"
  *   onChange={handleChange}
  * />
  * ```
@@ -53,21 +58,41 @@ export const Counter: FC<Props> = forwardRef<HTMLInputElement, Props>(
       canIncrement = true,
       className,
       decrementButtonClassName,
+      decrementLabel = 'Decrement',
+      disabled = false,
       editable = false,
+      error,
+      errorClassName,
+      fullWidth = false,
+      helperText,
+      helperTextClassName,
       incrementButtonClassName,
+      incrementLabel = 'Increment',
       isRequired,
       label,
+      labelAction,
       labelWrapperClassName,
       max = -Infinity,
       min = Infinity,
       name,
+      step = 1,
       theme,
+      unit,
       value,
       onChange,
     },
     ref,
   ) => {
     const id = useId();
+    const inputId = name ?? id;
+    const errorId = `${id}-error`;
+    const helperTextId = `${id}-helper-text`;
+    const hasError = typeof error === 'string' && error.length > 0;
+    const hasHelperText = !hasError && !!helperText;
+    const describedBy = composeIds(
+      hasError && errorId,
+      hasHelperText && helperTextId,
+    );
 
     const count = value ?? 0;
     const [draft, setDraft] = useState<string | null>(null);
@@ -77,9 +102,9 @@ export const Counter: FC<Props> = forwardRef<HTMLInputElement, Props>(
       let newValue: number = 0;
 
       if (min === Infinity) {
-        newValue = count - 1;
+        newValue = count - step;
       } else {
-        newValue = Math.max(min, count - 1);
+        newValue = Math.max(min, count - step);
       }
 
       setDraft(null);
@@ -90,9 +115,9 @@ export const Counter: FC<Props> = forwardRef<HTMLInputElement, Props>(
       let newValue: number = 0;
 
       if (max === -Infinity) {
-        newValue = count + 1;
+        newValue = count + step;
       } else {
-        newValue = Math.min(max, count + 1);
+        newValue = Math.min(max, count + step);
       }
 
       setDraft(null);
@@ -123,20 +148,32 @@ export const Counter: FC<Props> = forwardRef<HTMLInputElement, Props>(
     };
 
     return (
-      <div className="flex flex-col gap-2" data-theme={theme}>
-        {label ? (
-          <div className={cn(labelWrapperClassName)}>
-            <Typography
-              component="label"
-              htmlFor={name ?? id}
-              variant="labelLarge"
-              className={cn(labelVariants())}
-            >
-              {label}{' '}
-              {isRequired && (
-                <span className="text-red-600 dark:text-red-500">*</span>
-              )}
-            </Typography>
+      <div
+        className={cn('flex flex-col gap-2', fullWidth && 'w-full')}
+        data-theme={theme}
+      >
+        {label || labelAction ? (
+          <div
+            className={cn(
+              'flex items-center justify-between',
+              labelWrapperClassName,
+            )}
+          >
+            {label ? (
+              <Typography
+                component="label"
+                htmlFor={inputId}
+                variant="labelLarge"
+                className={cn(labelVariants())}
+              >
+                {label}{' '}
+                {isRequired && (
+                  <span className="text-red-600 dark:text-red-500">*</span>
+                )}
+              </Typography>
+            ) : null}
+
+            {labelAction}
           </div>
         ) : null}
 
@@ -147,26 +184,36 @@ export const Counter: FC<Props> = forwardRef<HTMLInputElement, Props>(
             className={cn(
               buttonVariants({
                 button: 'rigth',
+                hasError,
                 className: decrementButtonClassName,
               }),
             )}
-            disabled={!canDecrement}
+            disabled={disabled || !canDecrement}
           >
             <Minus className="w-4 h-4" />
-            <VisuallyHidden>Decrement</VisuallyHidden>
+            <VisuallyHidden>{decrementLabel}</VisuallyHidden>
           </button>
 
-          <input
-            ref={ref}
-            type="number"
-            value={editable ? displayed : count}
-            name={name}
-            className={cn(counterVariants({ className }))}
-            {...(editable
-              ? { onChange: handleChange, onBlur: handleBlur }
-              : { readOnly: true })}
-            aria-label={typeof label === 'string' ? label : 'number input'}
-          />
+          <div className={cn(fieldVariants({ fullWidth, hasError, disabled }))}>
+            <input
+              ref={ref}
+              id={inputId}
+              type="number"
+              value={editable ? displayed : count}
+              name={name}
+              disabled={disabled}
+              className={cn(counterVariants({ fullWidth, className }))}
+              {...(editable
+                ? { onChange: handleChange, onBlur: handleBlur }
+                : { readOnly: true })}
+              aria-label={typeof label === 'string' ? label : 'number input'}
+              aria-invalid={hasError || undefined}
+              aria-describedby={describedBy}
+              aria-required={isRequired || undefined}
+            />
+
+            {unit ? <span className={cn(unitVariants())}>{unit}</span> : null}
+          </div>
 
           <button
             type="button"
@@ -174,15 +221,42 @@ export const Counter: FC<Props> = forwardRef<HTMLInputElement, Props>(
             className={cn(
               buttonVariants({
                 button: 'left',
+                hasError,
                 className: incrementButtonClassName,
               }),
             )}
-            disabled={!canIncrement}
+            disabled={disabled || !canIncrement}
           >
             <Plus className="w-4 h-4" />
-            <VisuallyHidden>Increment</VisuallyHidden>
+            <VisuallyHidden>{incrementLabel}</VisuallyHidden>
           </button>
         </div>
+
+        {hasError ? (
+          <Typography
+            component="span"
+            id={errorId}
+            className={cn(
+              'text-xs tracking-normal text-red-700 dark:text-red-400',
+              errorClassName,
+            )}
+          >
+            {error}
+          </Typography>
+        ) : null}
+
+        {hasHelperText ? (
+          <Typography
+            component="span"
+            id={helperTextId}
+            className={cn(
+              'text-xs text-slate-600 dark:text-slate-200',
+              helperTextClassName,
+            )}
+          >
+            {helperText}
+          </Typography>
+        ) : null}
       </div>
     );
   },

--- a/lib/components/Counter/Counter.types.ts
+++ b/lib/components/Counter/Counter.types.ts
@@ -1,4 +1,5 @@
 import { VariantProps } from 'class-variance-authority';
+import { ReactNode } from 'react';
 
 import { Theme } from '@/domain/theme';
 
@@ -27,16 +28,34 @@ export interface Props extends VariantProps<typeof counterVariants> {
   className?: string;
   /** CSS classes for decrement button */
   decrementButtonClassName?: string;
+  /** Accessible label of the decrement button */
+  decrementLabel?: string;
+  /** Disable the whole control */
+  disabled?: boolean;
   /** Allow typing values directly into the input. Defaults to false (read-only) */
   editable?: boolean;
+  /** Error message displayed below the control */
+  error?: string;
+  /** Additional CSS classes for the error message */
+  errorClassName?: string;
+  /** Stretch the control to the width of its container */
+  fullWidth?: boolean;
+  /** Helper text displayed below the control when there is no error */
+  helperText?: string;
+  /** Additional CSS classes for the helper text */
+  helperTextClassName?: string;
   /** CSS classes for increment button */
   incrementButtonClassName?: string;
+  /** Accessible label of the increment button */
+  incrementLabel?: string;
   /** Initial value (deprecated, use value) */
   init?: number;
   /** Show required indicator */
   isRequired?: boolean;
   /** Label displayed above the counter */
   label?: string;
+  /** Content displayed at the right end of the label row */
+  labelAction?: ReactNode;
   /** Additional CSS classes for the label wrapper */
   labelWrapperClassName?: string;
   /** Maximum allowed value */
@@ -45,8 +64,12 @@ export interface Props extends VariantProps<typeof counterVariants> {
   min?: number;
   /** Form field name */
   name?: string;
+  /** Amount added or subtracted by the buttons. Defaults to 1 */
+  step?: number;
   /** Theme override for this component */
   theme?: Theme;
+  /** Unit displayed inside the field, after the value */
+  unit?: ReactNode;
   /** Current numeric value */
   value?: number;
   /** Callback when value changes */

--- a/lib/components/Counter/Counter.variants.ts
+++ b/lib/components/Counter/Counter.variants.ts
@@ -1,30 +1,85 @@
 import { cva } from 'class-variance-authority';
 
-export const counterVariants = cva([
-  '[&::-webkit-inner-spin-button]:appearance-none',
-  '[&::-webkit-outer-spin-button]:appearance-none',
-  '[-moz-appearance:textfield]',
-  'appearance-none',
-  'border',
-  'border-x-0',
-  'focus-visible:outline-none',
-  'focus-visible:ring-transparent',
-  'h-9',
-  'max-w-16',
-  'text-right',
-  'px-3',
-  'border-gray-300',
-  'text-slate-800',
-  'bg-white',
-  'dark:bg-metal-800',
-  'dark:border-metal-700',
-  'dark:text-metal-50',
+export const fieldVariants = cva(
+  [
+    'flex',
+    'items-center',
+    'h-9',
+    'border',
+    'border-x-0',
+    'border-gray-300',
+    'bg-white',
+    'dark:bg-metal-800',
+    'dark:border-metal-700',
+  ],
+  {
+    variants: {
+      fullWidth: {
+        true: ['flex-1', 'w-full'],
+        false: [],
+      },
+      hasError: {
+        true: ['border-red-600', 'dark:border-red-500'],
+        false: [],
+      },
+      disabled: {
+        true: ['bg-gray-100', 'dark:bg-metal-900'],
+        false: [],
+      },
+    },
+    defaultVariants: {
+      fullWidth: false,
+      hasError: false,
+      disabled: false,
+    },
+  },
+);
+
+export const counterVariants = cva(
+  [
+    '[&::-webkit-inner-spin-button]:appearance-none',
+    '[&::-webkit-outer-spin-button]:appearance-none',
+    '[-moz-appearance:textfield]',
+    'appearance-none',
+    'bg-transparent',
+    'border-none',
+    'focus-visible:outline-none',
+    'focus-visible:ring-transparent',
+    'h-full',
+    'max-w-16',
+    'text-right',
+    'px-3',
+    'text-slate-800',
+    'disabled:text-slate-400',
+    'dark:text-metal-50',
+    'dark:disabled:text-metal-400',
+  ],
+  {
+    variants: {
+      fullWidth: {
+        true: ['max-w-none', 'flex-1', 'min-w-0', 'w-full'],
+        false: [],
+      },
+    },
+    defaultVariants: {
+      fullWidth: false,
+    },
+  },
+);
+
+export const unitVariants = cva([
+  'pr-3',
+  'text-sm',
+  'select-none',
+  'text-slate-400',
+  'dark:text-slate-500',
 ]);
 
 export const buttonVariants = cva(
   [
     'h-9',
     'w-9',
+    'shrink-0',
     'flex',
     'items-center',
     'justify-center',
@@ -54,6 +109,13 @@ export const buttonVariants = cva(
         left: ['rounded-e'],
         rigth: ['rounded-s'],
       },
+      hasError: {
+        true: ['border-red-600', 'dark:border-red-500'],
+        false: [],
+      },
+    },
+    defaultVariants: {
+      hasError: false,
     },
   },
 );

--- a/lib/components/Counter/stories/Dark.stories.tsx
+++ b/lib/components/Counter/stories/Dark.stories.tsx
@@ -48,4 +48,56 @@ export const Dark = {
   },
 } satisfies Story;
 
+export const WithUnitAndMessages = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`step` moves the value by a fixed amount, `unit` renders a suffix inside the field, `labelAction` fills the right end of the label row, and `error` / `helperText` describe the control the same way `Input` does. `fullWidth` stretches the field to its container.',
+      },
+    },
+  },
+  render: function WithUnitAndMessagesStory() {
+    const [size, setSize] = useState<number>(1000);
+    const isQuotaReached = size >= 2000;
+
+    return (
+      <div className="flex flex-col gap-6 max-w-100">
+        <CounterComponent
+          label="Size"
+          isRequired
+          value={size}
+          step={500}
+          min={500}
+          max={2000}
+          unit="GB"
+          fullWidth
+          labelAction={
+            <span className="text-sm font-medium text-aurora-500">
+              ${((size / 500) * 5).toFixed(2)}/mo
+            </span>
+          }
+          decrementLabel="Remove 500 GB"
+          incrementLabel="Add 500 GB"
+          error={
+            isQuotaReached
+              ? 'You reached the quota for this account'
+              : undefined
+          }
+          helperText="Increments of 500 GB"
+          onChange={({ target: { value } }) => setSize(value)}
+        />
+
+        <CounterComponent
+          label="Disabled"
+          value={3}
+          unit="nodes"
+          disabled
+          helperText="This pool cannot be resized while updating"
+        />
+      </div>
+    );
+  },
+} satisfies Story;
+
 export default meta;

--- a/lib/components/Counter/stories/Light.stories.tsx
+++ b/lib/components/Counter/stories/Light.stories.tsx
@@ -53,4 +53,56 @@ export const Light = {
   },
 } satisfies Story;
 
+export const WithUnitAndMessages = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`step` moves the value by a fixed amount, `unit` renders a suffix inside the field, `labelAction` fills the right end of the label row, and `error` / `helperText` describe the control the same way `Input` does. `fullWidth` stretches the field to its container.',
+      },
+    },
+  },
+  render: function WithUnitAndMessagesStory() {
+    const [size, setSize] = useState<number>(1000);
+    const isQuotaReached = size >= 2000;
+
+    return (
+      <div className="flex flex-col gap-6 max-w-100">
+        <CounterComponent
+          label="Size"
+          isRequired
+          value={size}
+          step={500}
+          min={500}
+          max={2000}
+          unit="GB"
+          fullWidth
+          labelAction={
+            <span className="text-sm font-medium text-aurora-500">
+              ${((size / 500) * 5).toFixed(2)}/mo
+            </span>
+          }
+          decrementLabel="Remove 500 GB"
+          incrementLabel="Add 500 GB"
+          error={
+            isQuotaReached
+              ? 'You reached the quota for this account'
+              : undefined
+          }
+          helperText="Increments of 500 GB"
+          onChange={({ target: { value } }) => setSize(value)}
+        />
+
+        <CounterComponent
+          label="Disabled"
+          value={3}
+          unit="nodes"
+          disabled
+          helperText="This pool cannot be resized while updating"
+        />
+      </div>
+    );
+  },
+} satisfies Story;
+
 export default meta;


### PR DESCRIPTION
## Summary

Objectstore rewrote `Counter` from scratch as `SizeCounter` because the control lacked everything a sized field needs. This adds:

- **`step`**: amount added/subtracted by the buttons (clamped to `min`/`max`), e.g. 500 GB increments.
- **`unit`**: suffix rendered inside the field after the value.
- **`error` / `helperText`** (+ class name props): message line below the control, wired with `aria-invalid` / `aria-describedby` like `Input`; error also colours the field border.
- **`labelAction`**: right end of the label row (live price in objectstore).
- **`disabled`**: disables buttons and input.
- **`fullWidth`**: stretches the field to its container (volumes `ResizeDrawer` overrides `max-w-none w-full` for this).
- **`decrementLabel` / `incrementLabel`**: localisable button names.

Also fixes the label association: the `<label>` pointed at an id the input never had, so it now sets `id` on the input.

Defaults are unchanged (step 1, no unit, no messages).

## Test plan

- [x] New tests: step with clamping, unit, label association + labelAction, error/helper `aria-describedby`, disabled, custom button labels, axe
- [x] `npx vitest run lib/components/Counter` (24), lint, types, prettier
- [ ] Storybook: `Counter/Light` and `Dark` → `WithUnitAndMessages`