### PR TITLE
✨ feat: add error, helperText and disabled to MultiSelectDropdown

### DIFF
--- a/lib/components/MultiSelectDropdown/MultiSelectDropdown.test.tsx
+++ b/lib/components/MultiSelectDropdown/MultiSelectDropdown.test.tsx
@@ -202,4 +202,65 @@ describe('MultiSelectDropdown', () => {
 
     expect(results).toHaveNoViolations();
   });
+  describe('error, helper text and disabled', () => {
+    it('should describe the combobox with the error and hide the helper text', async () => {
+      const { findMultiSelectDropdown } = setup({
+        error: 'Pick at least one instance',
+        helperText: 'Instances in the selected region',
+      });
+
+      const combobox = await findMultiSelectDropdown();
+      const error = screen.getByText('Pick at least one instance');
+
+      expect(combobox).toHaveAttribute('aria-invalid', 'true');
+      expect(combobox).toHaveAttribute('aria-describedby', error.id);
+      expect(
+        screen.queryByText('Instances in the selected region'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should describe the combobox with the helper text', async () => {
+      const { findMultiSelectDropdown } = setup({
+        helperText: 'Instances in the selected region',
+      });
+
+      const combobox = await findMultiSelectDropdown();
+      const helper = screen.getByText('Instances in the selected region');
+
+      expect(combobox).toHaveAttribute('aria-describedby', helper.id);
+      expect(combobox).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('should not open nor remove selections when disabled', async () => {
+      const onChange = vi.fn();
+      const { user, findMultiSelectDropdown } = setup({
+        disabled: true,
+        label: 'Instances',
+        value: [options[0]],
+        onChange,
+      });
+
+      const combobox = await findMultiSelectDropdown();
+
+      expect(combobox).toHaveAttribute('aria-disabled', 'true');
+
+      await user.click(combobox);
+      await user.click(screen.getByText('Instances'));
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(screen.getByText(options[0].label)).toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("shouldn't have accessibility violations with an error", async () => {
+      const { component } = setup({
+        label: 'Instances',
+        error: 'Pick at least one instance',
+      });
+
+      const results = await axe(component);
+
+      expect(results).toHaveNoViolations();
+    });
+  });
 });

--- a/lib/components/MultiSelectDropdown/MultiSelectDropdown.types.ts
+++ b/lib/components/MultiSelectDropdown/MultiSelectDropdown.types.ts
@@ -52,6 +52,16 @@ export interface Props
       InputHTMLAttributes<HTMLInputElement>,
       'value' | 'onChange' | 'onBlur'
     > {
+  /** Disable opening the list and removing selections */
+  disabled?: boolean;
+  /** Error message displayed below the dropdown */
+  error?: string;
+  /** Additional CSS classes for the error message */
+  errorClassName?: string;
+  /** Helper text displayed below the dropdown when there is no error */
+  helperText?: string;
+  /** Additional CSS classes for the helper text */
+  helperTextClassName?: string;
   /** Whether the dropdown is in a loading state */
   isLoading?: boolean;
   /** Whether the field is required */

--- a/lib/components/MultiSelectDropdown/MultiSelectDropdown.variants.ts
+++ b/lib/components/MultiSelectDropdown/MultiSelectDropdown.variants.ts
@@ -11,21 +11,39 @@ export const wrapperVariants = cva([
 
 export const labelVariants = cva(['cursor-pointer', 'select-none']);
 
-export const multiSelectDropdownVariants = cva([
-  'min-h-9',
-  'border',
-  'cursor-pointer',
-  'duration-250',
-  'ease-in-out',
-  'flex',
-  'items-center',
-  'justify-between',
-  'px-2',
-  'py-1',
-  'rounded-md',
-  'transition-all',
-  'w-full',
-  'border-gray-200',
-  'dark:border-metal-700',
-  'dark:bg-metal-800',
-]);
+export const multiSelectDropdownVariants = cva(
+  [
+    'min-h-9',
+    'border',
+    'cursor-pointer',
+    'duration-250',
+    'ease-in-out',
+    'flex',
+    'items-center',
+    'justify-between',
+    'px-2',
+    'py-1',
+    'rounded-md',
+    'transition-all',
+    'w-full',
+    'border-gray-200',
+    'dark:border-metal-700',
+    'dark:bg-metal-800',
+  ],
+  {
+    variants: {
+      hasError: {
+        true: ['border-red-600', 'dark:border-red-500'],
+        false: [],
+      },
+      disabled: {
+        true: ['cursor-default', 'bg-gray-100', 'dark:bg-metal-700/80'],
+        false: [],
+      },
+    },
+    defaultVariants: {
+      hasError: false,
+      disabled: false,
+    },
+  },
+);

--- a/lib/components/MultiSelectDropdown/components/Wrapper/Wrapper.tsx
+++ b/lib/components/MultiSelectDropdown/components/Wrapper/Wrapper.tsx
@@ -5,7 +5,7 @@ import { ChevronUp } from 'react-feather';
 import { LoaderIcon } from '@/assets/icons/components';
 import { Badge } from '@/components/Badge/Badge';
 import { Typography } from '@/components/Typography/Typography';
-import { cn } from '@/utils';
+import { cn, composeIds } from '@/utils';
 
 import { useMultiSelectDropdown as useMultiSelectDropdownContext } from '../../contexts';
 import { useMultiSelectDropdown } from '../../hooks/useMultiSelectDropdown';
@@ -24,6 +24,11 @@ export const Wrapper: FC<WrapperProps> = forwardRef<
 >(
   (
     {
+      disabled = false,
+      error,
+      errorClassName,
+      helperText,
+      helperTextClassName,
       isRequired,
       label,
       labelClassName,
@@ -37,6 +42,14 @@ export const Wrapper: FC<WrapperProps> = forwardRef<
   ) => {
     const id = useId();
     const htmlFor = name ? `${id}-name` : 'id';
+    const errorId = `${id}-error`;
+    const helperTextId = `${id}-helper-text`;
+    const hasError = typeof error === 'string' && error.length > 0;
+    const hasHelperText = !hasError && !!helperText;
+    const describedBy = composeIds(
+      hasError && errorId,
+      hasHelperText && helperTextId,
+    );
     const {
       inputRef,
       isLoading,
@@ -71,7 +84,11 @@ export const Wrapper: FC<WrapperProps> = forwardRef<
                   className: labelClassName,
                 }),
               )}
-              onClick={() => onOpen(true)}
+              onClick={() => {
+                if (!disabled) {
+                  onOpen(true);
+                }
+              }}
             >
               {label}{' '}
               {isRequired && (
@@ -88,11 +105,15 @@ export const Wrapper: FC<WrapperProps> = forwardRef<
 
         <div
           id={htmlFor}
-          className={cn(multiSelectDropdownVariants())}
+          className={cn(multiSelectDropdownVariants({ hasError, disabled }))}
           role="combobox"
-          onClick={handleOpen}
+          onClick={disabled ? undefined : handleOpen}
           aria-expanded={isOpen}
           aria-labelledby={label ? `${id}-label` : undefined}
+          aria-invalid={hasError || undefined}
+          aria-describedby={describedBy}
+          aria-disabled={disabled || undefined}
+          aria-required={isRequired || undefined}
         >
           {selectedOptions.length === 0 ? (
             <span className="text-base text-inherit select-none">
@@ -106,7 +127,15 @@ export const Wrapper: FC<WrapperProps> = forwardRef<
                   data-value={option.label}
                   label={option.value ?? option.label ?? ''}
                   className="select-none"
-                  rightIcon={<X onClick={() => onRemoveOption(option)} />}
+                  rightIcon={
+                    <X
+                      onClick={() => {
+                        if (!disabled) {
+                          onRemoveOption(option);
+                        }
+                      }}
+                    />
+                  }
                 />
               ))}
             </div>
@@ -137,7 +166,33 @@ export const Wrapper: FC<WrapperProps> = forwardRef<
           readOnly
         />
 
-        {isOpen ? <List /> : null}
+        {isOpen && !disabled ? <List /> : null}
+
+        {hasError ? (
+          <Typography
+            component="span"
+            id={errorId}
+            className={cn(
+              'text-xs tracking-normal text-red-700 dark:text-red-400',
+              errorClassName,
+            )}
+          >
+            {error}
+          </Typography>
+        ) : null}
+
+        {hasHelperText ? (
+          <Typography
+            component="span"
+            id={helperTextId}
+            className={cn(
+              'text-xs text-slate-600 dark:text-slate-200',
+              helperTextClassName,
+            )}
+          >
+            {helperText}
+          </Typography>
+        ) : null}
       </div>
     );
   },

--- a/lib/components/MultiSelectDropdown/stories/Dark.stories.tsx
+++ b/lib/components/MultiSelectDropdown/stories/Dark.stories.tsx
@@ -49,4 +49,38 @@ export const Dark = {
   ),
 } satisfies Story;
 
+export const WithMessagesAndDisabled = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`error` and `helperText` describe the combobox the same way `Input` does, and `disabled` blocks opening and removing selections. vpc styled these states from outside with `**:[[role=combobox]]:` selectors before.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="max-w-75 flex flex-col gap-6">
+      <MultiSelectDropdownComponent
+        {...args}
+        label="With helper text"
+        helperText="Instances in the selected region"
+      />
+
+      <MultiSelectDropdownComponent
+        {...args}
+        label="With error"
+        error="Pick at least one instance"
+      />
+
+      <MultiSelectDropdownComponent
+        {...args}
+        label="Disabled"
+        disabled
+        value={[args.options[0]]}
+        helperText="Select a region first"
+      />
+    </div>
+  ),
+} satisfies Story;
+
 export default meta;

--- a/lib/components/MultiSelectDropdown/stories/Light.stories.tsx
+++ b/lib/components/MultiSelectDropdown/stories/Light.stories.tsx
@@ -46,4 +46,38 @@ export const Light = {
   ),
 } satisfies Story;
 
+export const WithMessagesAndDisabled = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`error` and `helperText` describe the combobox the same way `Input` does, and `disabled` blocks opening and removing selections. vpc styled these states from outside with `**:[[role=combobox]]:` selectors before.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="max-w-75 flex flex-col gap-6">
+      <MultiSelectDropdownComponent
+        {...args}
+        label="With helper text"
+        helperText="Instances in the selected region"
+      />
+
+      <MultiSelectDropdownComponent
+        {...args}
+        label="With error"
+        error="Pick at least one instance"
+      />
+
+      <MultiSelectDropdownComponent
+        {...args}
+        label="Disabled"
+        disabled
+        value={[args.options[0]]}
+        helperText="Select a region first"
+      />
+    </div>
+  ),
+} satisfies Story;
+
 export default meta;


### PR DESCRIPTION
## Summary

vpc's `InstanceNamesSelect` forced these states from outside with `**:[[role=combobox]]:border-red-600` descendant selectors and a `pointer-events-none` wrapper because `MultiSelectDropdown` exposed none of them.

- **`error` / `helperText`** (+ class name props): message line below the combobox, wired with `aria-invalid` / `aria-describedby` like `Input` and `Select`; error colours the border.
- **`disabled`**: blocks opening the list and removing selected badges, styled like the disabled `Select`. The attribute was already accepted through `InputHTMLAttributes` but silently dropped.

Defaults are unchanged.

## Test plan

- [x] New tests: error describes the combobox and hides helper text, helper text description, disabled does not open nor remove, axe with error
- [x] `npx vitest run lib/components/MultiSelectDropdown` (10), lint, types, prettier
- [ ] Storybook: `MultiSelectDropdown/Light` and `Dark` → `WithMessagesAndDisabled`