### PR TITLE
✨ feat: add tag, content and hideIndicator to RadioCard

### DIFF
--- a/lib/components/RadioCard/RadioCard.stories.tsx
+++ b/lib/components/RadioCard/RadioCard.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 
 import CivoLogo from '@/assets/icons/civo-logo.svg';
+
+import { Select } from '../Select/Select';
 
 import { RadioCard as RadioCardComponent } from './RadioCard';
 
@@ -22,6 +25,59 @@ export const RadioCard = {
       <RadioCardComponent {...args} name="input-name-2" checked={true} />
     </div>
   ),
+} satisfies Story;
+
+export const WithTagAndContent = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`tag` renders a badge next to the label, `hideIndicator` removes the radio circle so the card border communicates the selection, and `content` renders interactive content below the label, outside the selectable area, receiving the checked state. Compute built a ToggleGroup and databases forced this layout with `!` overrides before.',
+      },
+    },
+  },
+  render: function WithTagAndContentStory() {
+    const [value, setValue] = useState('existing');
+
+    return (
+      <div className="flex gap-4">
+        <RadioCardComponent
+          name="network"
+          value="existing"
+          label="Existing network"
+          tag="Recommended"
+          description="Attach the instance to a network you already manage"
+          hideIndicator
+          wrapperClassName="w-80 rounded-lg"
+          checked={value === 'existing'}
+          onChange={setValue}
+          content={(checked) =>
+            checked ? (
+              <Select
+                label="Network"
+                placeholder="Pick a network"
+                options={[
+                  { label: 'default', value: 'default' },
+                  { label: 'staging', value: 'staging' },
+                ]}
+              />
+            ) : null
+          }
+        />
+
+        <RadioCardComponent
+          name="network"
+          value="new"
+          label="New network"
+          description="Create a network for this instance"
+          hideIndicator
+          wrapperClassName="w-80 rounded-lg"
+          checked={value === 'new'}
+          onChange={setValue}
+        />
+      </div>
+    );
+  },
 } satisfies Story;
 
 export default meta;

--- a/lib/components/RadioCard/RadioCard.test.tsx
+++ b/lib/components/RadioCard/RadioCard.test.tsx
@@ -100,4 +100,59 @@ describe('RadioCard', () => {
       }),
     );
   });
+  describe('tag, content and hideIndicator', () => {
+    it('should render the tag next to the label', () => {
+      setup({ label: 'Existing network', tag: 'Recommended' });
+
+      expect(screen.getByText('Existing network')).toBeInTheDocument();
+      expect(screen.getByText('Recommended')).toBeInTheDocument();
+    });
+
+    it('should hide the radio indicator', async () => {
+      const { getRadio } = setup({ label: 'Option', hideIndicator: true });
+
+      const radio = await getRadio();
+
+      expect(radio.nextElementSibling).toHaveClass('hidden');
+    });
+
+    it('should render the content with the checked state and keep it interactive', async () => {
+      const onChange = vi.fn();
+      const onContentClick = vi.fn();
+      const { user } = setup({
+        label: 'Existing network',
+        checked: true,
+        onChange,
+        content: (checked) => (
+          <button type="button" onClick={onContentClick}>
+            {checked ? 'Pick a network' : 'Select this option first'}
+          </button>
+        ),
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Pick a network' }));
+
+      expect(onContentClick).toHaveBeenCalledTimes(1);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should render static content below the label', () => {
+      setup({ label: 'Option', content: <p>Extra details</p> });
+
+      expect(screen.getByText('Extra details')).toBeInTheDocument();
+    });
+
+    it("shouldn't have accessibility violations with tag and content", async () => {
+      const { component } = setup({
+        label: 'Existing network',
+        tag: 'Recommended',
+        hideIndicator: true,
+        content: <p>Extra details</p>,
+      });
+
+      const results = await axe(component);
+
+      expect(results).toHaveNoViolations();
+    });
+  });
 });

--- a/lib/components/RadioCard/RadioCard.tsx
+++ b/lib/components/RadioCard/RadioCard.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 
 import { cn } from '@/utils';
 
+import { Badge } from '../Badge/Badge';
 import { Card } from '../Card/Card';
 import { Radio } from '../Radio/Radio';
 
@@ -22,6 +23,17 @@ import { radioCardVariants } from './RadioCard.variants';
  *   checked={tier === 'enterprise'}
  *   onChange={(value) => setTier(value)}
  * />
+ *
+ * <RadioCard
+ *   name="network"
+ *   value="existing"
+ *   label="Existing network"
+ *   tag="Recommended"
+ *   hideIndicator
+ *   checked={network === 'existing'}
+ *   content={(checked) => checked && <Select options={networks} />}
+ *   onChange={setNetwork}
+ * />
  * ```
  *
  * @see {@link https://konstructio.github.io/konstruct-ui/?path=/docs/components-radiocard--docs Storybook}
@@ -31,27 +43,56 @@ const RadioCard: FC<Props> = ({
   theme,
   labelWrapperClassName,
   checked,
+  className,
+  content,
+  contentClassName,
   description,
+  hideIndicator = false,
+  label,
+  tag,
   ...delegated
-}) => (
-  <Card
-    data-theme={theme}
-    className={cn(
-      radioCardVariants({
-        className: wrapperClassName,
-      }),
-    )}
-    wrapperClassName={cn('w-max', wrapperClassName)}
-    isActive={checked}
-  >
-    <Radio
-      wrapperClassName={cn('w-full h-full p-3 gap-3', labelWrapperClassName)}
-      checked={checked}
-      description={description}
-      {...delegated}
-    />
-  </Card>
-);
+}) => {
+  const resolvedContent =
+    typeof content === 'function' ? content(!!checked) : content;
+
+  const composedLabel = tag ? (
+    <span className="flex items-center gap-2">
+      {label}
+      <Badge variant="info" label={tag} />
+    </span>
+  ) : (
+    label
+  );
+
+  return (
+    <Card
+      data-theme={theme}
+      className={cn(
+        radioCardVariants({
+          hasContent: !!resolvedContent,
+          className: wrapperClassName,
+        }),
+      )}
+      wrapperClassName={cn('w-max', wrapperClassName)}
+      isActive={checked}
+    >
+      <Radio
+        wrapperClassName={cn('w-full h-full p-3 gap-3', labelWrapperClassName)}
+        className={cn(hideIndicator && 'hidden', className)}
+        checked={checked}
+        description={description}
+        label={composedLabel}
+        {...delegated}
+      />
+
+      {resolvedContent ? (
+        <div className={cn('relative w-full px-3 pb-3', contentClassName)}>
+          {resolvedContent}
+        </div>
+      ) : null}
+    </Card>
+  );
+};
 
 RadioCard.displayName = 'KonstructRadioCard';
 

--- a/lib/components/RadioCard/RadioCard.types.ts
+++ b/lib/components/RadioCard/RadioCard.types.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 import { Theme } from '@/domain/theme';
 
 import { Props as CardProps } from '../Card/Card.types';
@@ -19,7 +21,10 @@ import { Props as RadioProps } from '../Radio/Radio.types';
  * />
  * ```
  */
-export type Props = Omit<CardProps, 'canHover' | 'isActive'> &
+export type Props = Omit<
+  CardProps,
+  'canHover' | 'isActive' | 'content' | 'onChange'
+> &
   Pick<
     RadioProps,
     | 'name'
@@ -33,7 +38,15 @@ export type Props = Omit<CardProps, 'canHover' | 'isActive'> &
     | 'description'
     | 'descriptionClassName'
   > & {
+    /** Interactive content rendered below the label, outside the selectable area; receives the checked state */
+    content?: ReactNode | ((checked: boolean) => ReactNode);
+    /** Additional CSS classes for the content wrapper */
+    contentClassName?: string;
+    /** Hide the radio indicator and let the card itself communicate the selection */
+    hideIndicator?: boolean;
     labelWrapperClassName?: string;
+    /** Short badge displayed next to the label */
+    tag?: string;
     theme?: Theme;
   };
 

--- a/lib/components/RadioCard/RadioCard.variants.ts
+++ b/lib/components/RadioCard/RadioCard.variants.ts
@@ -1,3 +1,16 @@
 import { cva } from 'class-variance-authority';
 
-export const radioCardVariants = cva(['flex', 'items-center', 'p-0', 'border']);
+export const radioCardVariants = cva(
+  ['flex', 'items-center', 'p-0', 'border'],
+  {
+    variants: {
+      hasContent: {
+        true: ['flex-col', 'items-stretch'],
+        false: [],
+      },
+    },
+    defaultVariants: {
+      hasContent: false,
+    },
+  },
+);


### PR DESCRIPTION
## Summary

Compute built a `ToggleGroup` from scratch to get a selectable card with a badge next to the label and an interactive panel inside the selected option; databases forced a "title + description, no visible radio" card out of `RadioCard` with four `!` overrides and `className="hidden"`.

- **`tag`**: renders a `Badge` next to the label.
- **`hideIndicator`**: hides the radio circle so the card border carries the selection.
- **`content`**: rendered below the label, outside the `<label>`, so its controls (a `Select`, inputs) are usable without toggling the radio. As a function it receives the checked state.

Type fix: `Props` no longer inherits `content` and `onChange` from the Card's HTML attributes. `onChange` was typed as a div change handler intersected with the radio callback, which is why databases had to narrow with `typeof value === 'string'`.

`RadioCardGroup` options pick up the new props automatically.

## Test plan

- [x] New tests: tag, hidden indicator, interactive content with checked state (clicking inside does not toggle), static content, axe
- [x] `npx vitest run lib/components/RadioCard lib/components/RadioCardGroup` (17), lint, types, prettier
- [ ] Storybook: `RadioCard` → `WithTagAndContent`