### PR TITLE
✨ feat: close small API gaps in DropdownButton, Switch, Alert, Stepper and Button

### DIFF
--- a/lib/components/Alert/Alert.test.tsx
+++ b/lib/components/Alert/Alert.test.tsx
@@ -97,4 +97,46 @@ describe('Alert', () => {
       expect(alert.querySelector('svg')).toBeInTheDocument();
     },
   );
+  describe('action and icon', () => {
+    it('should render the action next to the content', async () => {
+      const onAction = vi.fn();
+      const { user } = setup({
+        type: 'warning',
+        title: 'Add a payment method',
+        action: (
+          <button type="button" onClick={onAction}>
+            Add card
+          </button>
+        ),
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Add card' }));
+
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render a custom icon instead of the type icon', () => {
+      setup({
+        type: 'info',
+        icon: <img alt="Credit card" src="card.svg" />,
+      });
+
+      expect(
+        screen.getByRole('img', { name: 'Credit card' }),
+      ).toBeInTheDocument();
+    });
+
+    it("shouldn't have accessibility violations with an action", async () => {
+      const { component } = setup({
+        type: 'warning',
+        title: 'Add a payment method',
+        description: 'Your trial ends in 3 days.',
+        action: <button type="button">Add card</button>,
+      });
+
+      const results = await axe(component);
+
+      expect(results).toHaveNoViolations();
+    });
+  });
 });

--- a/lib/components/Alert/Alert.tsx
+++ b/lib/components/Alert/Alert.tsx
@@ -46,6 +46,8 @@ const ICON_MAP = {
  * @see {@link https://konstructio.github.io/konstruct-ui/?path=/docs/components-alert--docs Storybook}
  */
 export const Alert: FC<Props> = ({
+  action,
+  icon,
   theme,
   type,
   title,
@@ -94,7 +96,7 @@ export const Alert: FC<Props> = ({
       role="alert"
       aria-live="polite"
     >
-      {Icon && <Icon className={cn(iconVariants({ type }))} />}
+      {icon ?? (Icon && <Icon className={cn(iconVariants({ type }))} />)}
 
       <div className="flex flex-col gap-1 flex-1">
         {title && <p className={cn(titleVariants({ type }))}>{title}</p>}
@@ -102,6 +104,8 @@ export const Alert: FC<Props> = ({
           <div className={cn(descriptionVariants({ type }))}>{description}</div>
         )}
       </div>
+
+      {action ? <div className="shrink-0 self-center">{action}</div> : null}
 
       {showCloseButton && (
         <button type="button" onClick={handleCloseClick}>

--- a/lib/components/Alert/Alert.types.ts
+++ b/lib/components/Alert/Alert.types.ts
@@ -16,6 +16,10 @@ import { alertVariants } from './Alert.variants';
  * ```
  */
 type AlertBaseProps = VariantProps<typeof alertVariants> & {
+  /** Call to action rendered at the right end of the alert */
+  action?: ReactNode;
+  /** Custom icon replacing the one derived from `type` */
+  icon?: ReactNode;
   /** Whether the alert is visible */
   isVisible?: boolean;
   /** Show close button to dismiss alert */

--- a/lib/components/Alert/stories/Dark.stories.tsx
+++ b/lib/components/Alert/stories/Dark.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import { BillingIcon } from '@/assets/icons/components';
+import { Button } from '@/components/Button/Button';
+
 import { Alert as AlertComponent } from '../Alert';
 
 type Story = StoryObj<typeof AlertComponent>;
@@ -57,6 +60,39 @@ export const Dark: Story = {
         type="info"
         title="Information"
         description="If you think this is incorrect, please contact your Konstruct administrators."
+        showCloseButton
+      />
+    </div>
+  ),
+};
+
+export const WithAction: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`action` renders a call to action at the right end of the alert and `icon` replaces the icon derived from `type`. Billing built an AlertBanner from scratch to get this layout.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-3 w-150">
+      <AlertComponent
+        type="warning"
+        title="Add a payment method"
+        description="Your trial ends in 3 days. Add a card to keep your resources running."
+        action={
+          <Button variant="tertiary" appearance="compact">
+            Add card
+          </Button>
+        }
+      />
+      <AlertComponent
+        type="info"
+        title="Billing address updated"
+        icon={
+          <BillingIcon className="size-6 text-blue-800 dark:text-blue-300" />
+        }
         showCloseButton
       />
     </div>

--- a/lib/components/Alert/stories/Light.stories.tsx
+++ b/lib/components/Alert/stories/Light.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import { BillingIcon } from '@/assets/icons/components';
+import { Button } from '@/components/Button/Button';
+
 import { Alert as AlertComponent } from '../Alert';
 
 type Story = StoryObj<typeof AlertComponent>;
@@ -54,6 +57,39 @@ export const Light: Story = {
         type="info"
         title="Information"
         description="If you think this is incorrect, please contact your Konstruct administrators."
+        showCloseButton
+      />
+    </div>
+  ),
+};
+
+export const WithAction: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`action` renders a call to action at the right end of the alert and `icon` replaces the icon derived from `type`. Billing built an AlertBanner from scratch to get this layout.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-3 w-150">
+      <AlertComponent
+        type="warning"
+        title="Add a payment method"
+        description="Your trial ends in 3 days. Add a card to keep your resources running."
+        action={
+          <Button variant="tertiary" appearance="compact">
+            Add card
+          </Button>
+        }
+      />
+      <AlertComponent
+        type="info"
+        title="Billing address updated"
+        icon={
+          <BillingIcon className="size-6 text-blue-800 dark:text-blue-300" />
+        }
         showCloseButton
       />
     </div>

--- a/lib/components/Button/Button.test.tsx
+++ b/lib/components/Button/Button.test.tsx
@@ -82,4 +82,32 @@ describe('Button', () => {
 
     expect(results).toHaveNoViolations();
   });
+  describe('asChild', () => {
+    it('should render a disabled link as inert and aria-disabled', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Button asChild disabled>
+          <a href="#billing">Manage billing</a>
+        </Button>,
+      );
+
+      const link = screen.getByRole('link', { name: 'Manage billing' });
+
+      expect(link).toHaveAttribute('aria-disabled', 'true');
+      expect(link).toHaveAttribute('tabindex', '-1');
+      expect(link).not.toHaveAttribute('disabled');
+      expect(link).toHaveClass('pointer-events-none');
+
+      await user.tab();
+
+      expect(link).not.toHaveFocus();
+    });
+  });
+
+  it('should render the pill shape', () => {
+    const { button } = setup({ shape: 'pill' });
+
+    expect(button).toHaveClass('rounded-full', 'px-6');
+  });
 });

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -52,6 +52,10 @@ const Button: FC<Props> = forwardRef<ComponentRef<'button'>, Props>(
     ref,
   ) => {
     const Comp = asChild ? Slot : 'button';
+    const disabledProps =
+      asChild && disabled
+        ? { 'aria-disabled': true, tabIndex: -1 }
+        : { disabled };
 
     return (
       <Comp
@@ -67,8 +71,9 @@ const Button: FC<Props> = forwardRef<ComponentRef<'button'>, Props>(
             variant,
             version,
           }),
+          asChild && disabled && 'pointer-events-none',
         )}
-        disabled={disabled}
+        {...disabledProps}
         {...delegated}
       />
     );

--- a/lib/components/Button/Button.variants.ts
+++ b/lib/components/Button/Button.variants.ts
@@ -65,6 +65,7 @@ export const buttonVariants = cva(
       },
       shape: {
         circle: ['rounded-full', 'p-1'],
+        pill: ['rounded-full', 'px-6'],
       },
       version: {
         default: '',

--- a/lib/components/Button/stories/light/Pill.stories.tsx
+++ b/lib/components/Button/stories/light/Pill.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ArrowBackIcon } from '@/assets/icons/components';
+
+import { Button } from '../../Button';
+
+type Story = StoryObj<typeof Button>;
+
+const meta: Meta<typeof Button> = {
+  title: 'In Review/Button/Light/Pill',
+  component: Button,
+};
+
+export const Pill: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`shape="pill"` rounds the button fully. With `asChild` and `disabled`, the rendered child (a link here) becomes inert and `aria-disabled` instead of receiving an invalid `disabled` attribute.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-5 w-fit">
+      <Button shape="pill">
+        Continue
+        <ArrowBackIcon className="rotate-180" />
+      </Button>
+
+      <Button shape="pill" variant="secondary">
+        Secondary pill
+      </Button>
+
+      <Button asChild>
+        <a href="#billing">Manage billing</a>
+      </Button>
+
+      <Button asChild disabled>
+        <a href="#billing">Manage billing (disabled link)</a>
+      </Button>
+    </div>
+  ),
+};
+
+export default meta;

--- a/lib/components/DropdownButton/DropdownButton.stories.tsx
+++ b/lib/components/DropdownButton/DropdownButton.stories.tsx
@@ -29,4 +29,31 @@ export const DropdownButton: Story = {
   },
 };
 
+export const States: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`isLoading` swaps the chevron for a spinner and disables the trigger while a download is in flight; `disabled` keeps the menu closed. `variant`, `appearance` and `version` are forwarded to the trigger Button. Billing fell back to a plain Button for the loading state before.',
+      },
+    },
+  },
+  args: {
+    label: 'Download invoice as',
+    options: [{ label: 'PDF' }, { label: 'CSV' }],
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-4 max-w-60">
+      <DropdownButtonComponent {...args} isLoading />
+      <DropdownButtonComponent {...args} disabled />
+      <DropdownButtonComponent {...args} variant="secondary" />
+      <DropdownButtonComponent
+        {...args}
+        variant="tertiary"
+        appearance="compact"
+      />
+    </div>
+  ),
+};
+
 export default meta;

--- a/lib/components/DropdownButton/DropdownButton.test.tsx
+++ b/lib/components/DropdownButton/DropdownButton.test.tsx
@@ -75,4 +75,54 @@ describe('DropdownButton', () => {
 
     expect(results).toHaveNoViolations();
   });
+  describe('disabled and loading', () => {
+    it('should not open the menu while disabled', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <DropdownButton
+          label="Download as"
+          disabled
+          options={[{ label: 'PDF', onClick: vi.fn() }]}
+        />,
+      );
+
+      const trigger = screen.getByRole('button', { name: /download as/i });
+
+      expect(trigger).toBeDisabled();
+
+      await user.click(trigger);
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('should disable the trigger and announce it as busy while loading', () => {
+      render(
+        <DropdownButton
+          label="Download as"
+          isLoading
+          options={[{ label: 'PDF', onClick: vi.fn() }]}
+        />,
+      );
+
+      const trigger = screen.getByRole('button', { name: /download as/i });
+
+      expect(trigger).toBeDisabled();
+      expect(trigger).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('should forward the button variant to the trigger', () => {
+      render(
+        <DropdownButton
+          label="Download as"
+          variant="link"
+          options={[{ label: 'PDF', onClick: vi.fn() }]}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /download as/i })).toHaveClass(
+        'bg-transparent',
+      );
+    });
+  });
 });

--- a/lib/components/DropdownButton/DropdownButton.tsx
+++ b/lib/components/DropdownButton/DropdownButton.tsx
@@ -2,6 +2,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { FC } from 'react';
 import { ChevronDown } from 'react-feather';
 
+import { LoaderIcon } from '@/assets/icons/components';
 import { cn } from '@/utils';
 
 import { Button } from '../Button/Button';
@@ -25,25 +26,39 @@ import { Props } from './DropdownButton.types';
  * ```
  */
 export const DropdownButton: FC<Props> = ({
+  appearance,
   buttonClassName,
   className,
+  disabled = false,
+  isLoading = false,
   itemClassName,
   label = 'Download Invoice as',
   listClassName,
   options,
+  variant,
+  version,
 }) => {
   return (
     <DropdownMenu.Root modal={false}>
       <div className={cn('relative w-full', className)}>
-        <DropdownMenu.Trigger asChild>
+        <DropdownMenu.Trigger asChild disabled={disabled || isLoading}>
           <Button
+            appearance={appearance}
+            variant={variant}
+            version={version}
+            disabled={disabled || isLoading}
+            aria-busy={isLoading || undefined}
             className={cn(
               'group flex gap-2 items-center justify-between w-full',
               buttonClassName,
             )}
           >
             {label}
-            <ChevronDown className="transition-transform duration-200 group-data-[state=open]:rotate-180" />
+            {isLoading ? (
+              <LoaderIcon size={16} className="animate-spin shrink-0" />
+            ) : (
+              <ChevronDown className="transition-transform duration-200 group-data-[state=open]:rotate-180" />
+            )}
           </Button>
         </DropdownMenu.Trigger>
 

--- a/lib/components/DropdownButton/DropdownButton.types.ts
+++ b/lib/components/DropdownButton/DropdownButton.types.ts
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 
+import { Props as ButtonProps } from '../Button/Button.types';
+
 /**
  * Configuration for a dropdown menu option.
  */
@@ -25,10 +27,16 @@ export type Option = {
  * ```
  */
 export type Props = {
+  /** Appearance of the trigger button */
+  appearance?: ButtonProps['appearance'];
   /** Additional CSS classes for the trigger button */
   buttonClassName?: string;
   /** Additional CSS classes for the wrapper container */
   className?: string;
+  /** Disable the trigger and keep the menu closed */
+  disabled?: boolean;
+  /** Show a spinner in place of the chevron and disable the trigger */
+  isLoading?: boolean;
   /** Additional CSS classes for each dropdown item */
   itemClassName?: string;
   /** Content of the trigger button */
@@ -37,4 +45,8 @@ export type Props = {
   listClassName?: string;
   /** Array of options to display in the dropdown */
   options: Option[];
+  /** Variant of the trigger button */
+  variant?: ButtonProps['variant'];
+  /** Version of the trigger button */
+  version?: ButtonProps['version'];
 };

--- a/lib/components/Stepper/Stepper.test.tsx
+++ b/lib/components/Stepper/Stepper.test.tsx
@@ -538,4 +538,26 @@ describe('Stepper', () => {
       expect(getStepText('Select platform')).toHaveClass('custom-label-style');
     });
   });
+  describe('fullWidth', () => {
+    it('should stretch the stepper and distribute horizontal steps evenly', () => {
+      const { getNavigation, getList, getListItems } = setup({
+        fullWidth: true,
+        variant: 'horizontal',
+      });
+
+      const items = getListItems();
+
+      expect(getNavigation()).toHaveClass('w-full');
+      expect(getList()).toHaveClass('w-full');
+      expect(items[0]).toHaveClass('flex-1', 'last:flex-none');
+      expect(items[items.length - 1]).toHaveClass('flex-1', 'last:flex-none');
+    });
+
+    it('should not distribute vertical steps', () => {
+      const { getNavigation, getListItems } = setup({ fullWidth: true });
+
+      expect(getNavigation()).toHaveClass('w-full');
+      expect(getListItems()[0]).not.toHaveClass('flex-1');
+    });
+  });
 });

--- a/lib/components/Stepper/Stepper.tsx
+++ b/lib/components/Stepper/Stepper.tsx
@@ -63,6 +63,7 @@ export const Stepper: FC<Props> = ({
   classNames,
   clickable = false,
   currentStep,
+  fullWidth = false,
   icons,
   orientation = 'vertical',
   showConnector = true,
@@ -105,7 +106,7 @@ export const Stepper: FC<Props> = ({
   return (
     <nav
       className={cn(
-        stepperVariants({ orientation: resolvedOrientation }),
+        stepperVariants({ orientation: resolvedOrientation, fullWidth }),
         className,
         classNames?.root,
       )}
@@ -114,7 +115,7 @@ export const Stepper: FC<Props> = ({
     >
       <ol
         className={cn(
-          stepListVariants({ orientation: resolvedOrientation }),
+          stepListVariants({ orientation: resolvedOrientation, fullWidth }),
           classNames?.list,
         )}
       >
@@ -122,7 +123,7 @@ export const Stepper: FC<Props> = ({
           <li
             key={step.id}
             className={cn(
-              stepItemVariants({ orientation: resolvedOrientation }),
+              stepItemVariants({ orientation: resolvedOrientation, fullWidth }),
               classNames?.item,
             )}
           >

--- a/lib/components/Stepper/Stepper.types.ts
+++ b/lib/components/Stepper/Stepper.types.ts
@@ -66,6 +66,8 @@ export type Props = VariantProps<typeof stepperVariants> & {
   clickable?: boolean;
   /** Index of the current active step (0-based). When provided, step statuses are auto-calculated. */
   currentStep?: number;
+  /** Stretch the stepper to its container, distributing horizontal steps evenly */
+  fullWidth?: boolean;
   /** Custom icons for step statuses */
   icons?: StepperIcons;
   /** Show connector lines between steps */

--- a/lib/components/Stepper/Stepper.variants.ts
+++ b/lib/components/Stepper/Stepper.variants.ts
@@ -6,9 +6,14 @@ export const stepperVariants = cva(['flex'], {
       vertical: ['flex-col'],
       horizontal: ['flex-row', 'items-start'],
     },
+    fullWidth: {
+      true: ['w-full'],
+      false: [],
+    },
   },
   defaultVariants: {
     orientation: 'vertical',
+    fullWidth: false,
   },
 });
 
@@ -18,9 +23,14 @@ export const stepListVariants = cva(['flex', 'list-none', 'p-0', 'm-0'], {
       vertical: ['flex-col'],
       horizontal: ['flex-row'],
     },
+    fullWidth: {
+      true: ['w-full'],
+      false: [],
+    },
   },
   defaultVariants: {
     orientation: 'vertical',
+    fullWidth: false,
   },
 });
 
@@ -30,9 +40,21 @@ export const stepItemVariants = cva(['list-none'], {
       vertical: [],
       horizontal: [],
     },
+    fullWidth: {
+      true: [],
+      false: [],
+    },
   },
+  compoundVariants: [
+    {
+      orientation: 'horizontal',
+      fullWidth: true,
+      class: ['flex-1', 'min-w-0', 'last:flex-none'],
+    },
+  ],
   defaultVariants: {
     orientation: 'vertical',
+    fullWidth: false,
   },
 });
 

--- a/lib/components/Stepper/stories/Dark.stories.tsx
+++ b/lib/components/Stepper/stories/Dark.stories.tsx
@@ -117,3 +117,54 @@ export const Clickable: Story = {
     />
   ),
 };
+
+export const HorizontalFullWidth: Story = {
+  name: 'Dark - Horizontal full width',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`fullWidth` stretches the stepper to its container and gives every horizontal step the same width, which dashboard-manager and billing reproduced with `classNames` overrides.',
+      },
+    },
+  },
+  render: () => (
+    <StepperComponent
+      steps={horizontalSteps}
+      variant="horizontal"
+      size="md"
+      fullWidth
+    />
+  ),
+};
+
+export const HorizontalFullWidthWithDescriptions: Story = {
+  name: 'Dark - Horizontal full width (descriptions)',
+  render: () => (
+    <StepperComponent
+      steps={[
+        {
+          id: 1,
+          label: 'Account',
+          description: 'Your details',
+          status: 'completed',
+        },
+        {
+          id: 2,
+          label: 'Company',
+          description: 'Billing entity',
+          status: 'active',
+        },
+        {
+          id: 3,
+          label: 'Payment',
+          description: 'Card on file',
+          status: 'pending',
+        },
+      ]}
+      variant="horizontal"
+      size="md"
+      fullWidth
+    />
+  ),
+};

--- a/lib/components/Stepper/stories/Light.stories.tsx
+++ b/lib/components/Stepper/stories/Light.stories.tsx
@@ -110,3 +110,54 @@ export const Clickable: Story = {
     />
   ),
 };
+
+export const HorizontalFullWidth: Story = {
+  name: 'Light - Horizontal full width',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`fullWidth` stretches the stepper to its container and gives every horizontal step the same width, which dashboard-manager and billing reproduced with `classNames` overrides.',
+      },
+    },
+  },
+  render: () => (
+    <StepperComponent
+      steps={horizontalSteps}
+      variant="horizontal"
+      size="md"
+      fullWidth
+    />
+  ),
+};
+
+export const HorizontalFullWidthWithDescriptions: Story = {
+  name: 'Light - Horizontal full width (descriptions)',
+  render: () => (
+    <StepperComponent
+      steps={[
+        {
+          id: 1,
+          label: 'Account',
+          description: 'Your details',
+          status: 'completed',
+        },
+        {
+          id: 2,
+          label: 'Company',
+          description: 'Billing entity',
+          status: 'active',
+        },
+        {
+          id: 3,
+          label: 'Payment',
+          description: 'Card on file',
+          status: 'pending',
+        },
+      ]}
+      variant="horizontal"
+      size="md"
+      fullWidth
+    />
+  ),
+};

--- a/lib/components/Switch/Switch.test.tsx
+++ b/lib/components/Switch/Switch.test.tsx
@@ -139,4 +139,59 @@ describe('Switch', () => {
 
     expect(handleSubmit).toHaveBeenCalledWith({ switch: 'false' });
   });
+  describe('labels and isLoading', () => {
+    it('should show the label of the current state and switch it on toggle', async () => {
+      const { user, getSwitch } = setup({
+        label: undefined,
+        labels: { on: 'Enabled', off: 'Disabled' },
+        defaultChecked: false,
+      });
+
+      const switchComponent = await getSwitch();
+
+      expect(screen.getByText('Disabled')).toBeInTheDocument();
+      expect(switchComponent).toHaveAccessibleName('Disabled');
+
+      await user.click(switchComponent);
+
+      expect(screen.getByText('Enabled')).toBeInTheDocument();
+      expect(switchComponent).toHaveAccessibleName('Enabled');
+    });
+
+    it('should follow the controlled value when using labels', async () => {
+      const { getSwitch } = setup({
+        label: undefined,
+        labels: { on: 'Enabled', off: 'Disabled' },
+        value: true,
+      });
+
+      expect(await getSwitch()).toHaveAccessibleName('Enabled');
+    });
+
+    it('should disable the switch and announce it as busy while loading', async () => {
+      const onChange = vi.fn();
+      const { user, getSwitch } = setup({ isLoading: true, onChange });
+
+      const switchComponent = await getSwitch();
+
+      expect(switchComponent).toBeDisabled();
+      expect(switchComponent).toHaveAttribute('aria-busy', 'true');
+
+      await user.click(switchComponent);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("shouldn't have accessibility violations with labels and loading", async () => {
+      const { component } = setup({
+        label: undefined,
+        labels: { on: 'Enabled', off: 'Disabled' },
+        isLoading: true,
+      });
+
+      const results = await axe(component);
+
+      expect(results).toHaveNoViolations();
+    });
+  });
 });

--- a/lib/components/Switch/Switch.tsx
+++ b/lib/components/Switch/Switch.tsx
@@ -6,8 +6,10 @@ import {
   useId,
   useImperativeHandle,
   useRef,
+  useState,
 } from 'react';
 
+import { LoaderIcon } from '@/assets/icons/components';
 import { Typography } from '@/components/Typography/Typography';
 import { cn } from '@/utils';
 
@@ -49,7 +51,9 @@ export const Switch: FC<Props> = forwardRef<HTMLInputElement, Props>(
       disabled = false,
       helperText,
       helperTextClassName,
+      isLoading = false,
       label,
+      labels,
       labelClassName,
       labelWrapperClassName,
       name,
@@ -64,6 +68,10 @@ export const Switch: FC<Props> = forwardRef<HTMLInputElement, Props>(
     const inputRef = useRef<HTMLInputElement>(null);
     const id = useId();
     const componentId = name ? `${id}-${name}` : id;
+    const [isChecked, setIsChecked] = useState(
+      value ?? defaultChecked ?? false,
+    );
+    const resolvedLabel = labels ? (isChecked ? labels.on : labels.off) : label;
 
     useImperativeHandle(ref, () => inputRef.current!, [inputRef]);
 
@@ -71,7 +79,16 @@ export const Switch: FC<Props> = forwardRef<HTMLInputElement, Props>(
       if (inputRef.current) {
         inputRef.current.value = `${value}`;
       }
+
+      if (value !== undefined) {
+        setIsChecked(value);
+      }
     }, [value]);
+
+    const handleCheckedChange = (checked: boolean) => {
+      setIsChecked(checked);
+      onChange?.(checked);
+    };
 
     return (
       <div
@@ -88,10 +105,11 @@ export const Switch: FC<Props> = forwardRef<HTMLInputElement, Props>(
           id={componentId}
           defaultChecked={defaultChecked}
           checked={value}
-          onCheckedChange={(e) => onChange?.(e)}
+          onCheckedChange={handleCheckedChange}
           className={cn(switchVariants({ variant, className }))}
-          aria-label={label}
-          disabled={disabled}
+          aria-label={resolvedLabel}
+          aria-busy={isLoading || undefined}
+          disabled={disabled || isLoading}
         >
           <Thumb
             className={thumbVariants({
@@ -100,7 +118,15 @@ export const Switch: FC<Props> = forwardRef<HTMLInputElement, Props>(
           />
         </Root>
 
-        {label ? (
+        {isLoading ? (
+          <LoaderIcon
+            size={16}
+            aria-hidden="true"
+            className="animate-spin shrink-0 self-center text-metal-400"
+          />
+        ) : null}
+
+        {resolvedLabel ? (
           <Typography
             component="label"
             className={cn(
@@ -114,7 +140,7 @@ export const Switch: FC<Props> = forwardRef<HTMLInputElement, Props>(
             htmlFor={componentId}
             style={{ paddingRight: 15 }}
           >
-            {label}
+            {resolvedLabel}
             {helperText ? (
               <Typography
                 component="span"

--- a/lib/components/Switch/Switch.types.ts
+++ b/lib/components/Switch/Switch.types.ts
@@ -27,8 +27,12 @@ export interface Props extends VariantProps<typeof switchVariants> {
   helperText?: string;
   /** CSS classes for helper text */
   helperTextClassName?: string;
+  /** Disable the switch and show a spinner while a change is pending */
+  isLoading?: boolean;
   /** Label text displayed next to switch */
   label?: string;
+  /** Label text for each state; overrides `label` visually and for assistive technology */
+  labels?: { off: string; on: string };
   /** CSS classes for the label */
   labelClassName?: string;
   /** Additional CSS classes for the label wrapper */

--- a/lib/components/Switch/stories/Dark.stories.tsx
+++ b/lib/components/Switch/stories/Dark.stories.tsx
@@ -75,4 +75,40 @@ export const Dark = {
   },
 } satisfies Story;
 
+export const StateLabelsAndLoading = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`labels` renders a different label for each state, and `isLoading` disables the switch and shows a spinner while the change is pending. Settings composed both around the switch before.',
+      },
+    },
+  },
+  render: function StateLabelsAndLoadingStory() {
+    const [enabled, setEnabled] = useState(true);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleChange = (next: boolean) => {
+      setIsLoading(true);
+      setTimeout(() => {
+        setEnabled(next);
+        setIsLoading(false);
+      }, 1200);
+    };
+
+    return (
+      <div className="flex flex-col gap-5">
+        <SwitchComponent
+          labels={{ on: 'Webhook enabled', off: 'Webhook disabled' }}
+          value={enabled}
+          isLoading={isLoading}
+          onChange={handleChange}
+        />
+
+        <SwitchComponent label="Saving…" value isLoading />
+      </div>
+    );
+  },
+} satisfies Story;
+
 export default meta;

--- a/lib/components/Switch/stories/Light.stories.tsx
+++ b/lib/components/Switch/stories/Light.stories.tsx
@@ -72,4 +72,40 @@ export const Light = {
   },
 } satisfies Story;
 
+export const StateLabelsAndLoading = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`labels` renders a different label for each state, and `isLoading` disables the switch and shows a spinner while the change is pending. Settings composed both around the switch before.',
+      },
+    },
+  },
+  render: function StateLabelsAndLoadingStory() {
+    const [enabled, setEnabled] = useState(true);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleChange = (next: boolean) => {
+      setIsLoading(true);
+      setTimeout(() => {
+        setEnabled(next);
+        setIsLoading(false);
+      }, 1200);
+    };
+
+    return (
+      <div className="flex flex-col gap-5">
+        <SwitchComponent
+          labels={{ on: 'Webhook enabled', off: 'Webhook disabled' }}
+          value={enabled}
+          isLoading={isLoading}
+          onChange={handleChange}
+        />
+
+        <SwitchComponent label="Saving…" value isLoading />
+      </div>
+    );
+  },
+} satisfies Story;
+
 export default meta;


### PR DESCRIPTION
## Summary

Five small, independent additions that microfrontends were working around:

- **DropdownButton**: `disabled`, `isLoading` (spinner replaces the chevron, trigger disabled + `aria-busy`) and `variant` / `appearance` / `version` forwarded to the trigger. Billing (`DownloadInvoiceButton`) fell back to a plain `Button` for the in-flight download.
- **Switch**: `isLoading` (disabled + spinner + `aria-busy`) and `labels: { on, off }` that switch the visible label and the accessible name with the state. Settings (`StatusCell`) composed both around the switch.
- **Alert**: `action` (call to action at the right end) and `icon` (replaces the type icon). Billing built `AlertBanner` from scratch for this layout.
- **Stepper**: `fullWidth` stretches nav and list and gives horizontal steps equal width. Dashboard-manager (`SignupStepper`) and billing (`Stepper`) reproduced it with the same `classNames` overrides.
- **Button**: `asChild` + `disabled` now sets `aria-disabled`, `tabIndex=-1` and `pointer-events-none` on the child instead of an invalid `disabled` attribute on a link (dashboard-manager `BillingStatCard` swapped the `Link` for a `span` and styled it by hand). `shape="pill"` covers the signup `PillButton`.

All defaults unchanged.

## Test plan

- [x] New tests per component (disabled/loading trigger, state labels + loading switch, alert action/icon, full-width distribution, inert disabled link + pill)
- [x] `npx vitest run` on the five components (128), lint, types, prettier
- [ ] Storybook: `DropdownButton` → `States`; `Switch` → `StateLabelsAndLoading`; `Alert` → `WithAction`; `Stepper` → `Horizontal full width`; `Button/Light/Pill`