### PR TITLE
✨ feat: add onModeChange, badge and onIntent to Sidebar

### DIFF
--- a/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/lib/components/Sidebar/Sidebar.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/assets/icons/components';
 import { Theme } from '@/domain/theme';
 
+import { Badge } from '../Badge/Badge';
 import { Typography } from '../Typography/Typography';
 import {
   CollapseTrigger,
@@ -140,6 +141,8 @@ const renderSidebarContent = (
           role="button"
           onClick={() => onThemeChange('light')}
           isActive={theme === 'light'}
+          badge={<Badge variant="info" label="New" />}
+          onIntent={() => console.log('prefetch billing')}
         >
           <a>
             <ReceiptLongIcon className="w-6 h-6 shrink-0" />

--- a/lib/components/Sidebar/Sidebar.test.tsx
+++ b/lib/components/Sidebar/Sidebar.test.tsx
@@ -440,4 +440,124 @@ describe('Sidebar', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
   });
+  describe('mode change callbacks', () => {
+    it('should report user toggles through onModeChange and CollapseTrigger onToggle', async () => {
+      const onModeChange = vitest.fn();
+      const onToggle = vitest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Sidebar mode="expanded" onModeChange={onModeChange}>
+          <Logo>
+            Header
+            <CollapseTrigger onToggle={onToggle} />
+          </Logo>
+          <Navigation>
+            <NavigationGroup>
+              <NavigationOption>
+                <Label>Clusters</Label>
+              </NavigationOption>
+            </NavigationGroup>
+          </Navigation>
+        </Sidebar>,
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: 'Collapse navigation' }),
+      );
+
+      expect(onModeChange).toHaveBeenCalledWith('collapsed', 'user');
+      expect(onToggle).toHaveBeenCalledWith('collapsed');
+
+      await user.click(
+        screen.getByRole('button', { name: 'Expand navigation' }),
+      );
+
+      expect(onModeChange).toHaveBeenLastCalledWith('expanded', 'user');
+      expect(onToggle).toHaveBeenLastCalledWith('expanded');
+    });
+
+    it('should report viewport-driven changes with the viewport source', () => {
+      const onModeChange = vitest.fn();
+
+      const { rerender } = render(
+        <Sidebar mode="expanded" onModeChange={onModeChange}>
+          <Logo>Header</Logo>
+        </Sidebar>,
+      );
+
+      expect(onModeChange).not.toHaveBeenCalled();
+
+      rerender(
+        <Sidebar mode="collapsed" onModeChange={onModeChange}>
+          <Logo>Header</Logo>
+        </Sidebar>,
+      );
+
+      expect(onModeChange).toHaveBeenCalledWith('collapsed', 'viewport');
+    });
+  });
+
+  describe('badge and onIntent', () => {
+    it('should render the badge at the end of the option', () => {
+      setup({
+        options: (
+          <NavigationOption badge={<span>New</span>}>
+            <a href="#clusters">Clusters</a>
+          </NavigationOption>
+        ),
+      });
+
+      expect(screen.getByText('New')).toBeInTheDocument();
+    });
+
+    it('should fire onIntent after hovering for the intent delay and cancel when leaving early', async () => {
+      const onIntent = vitest.fn();
+      const { user, getLink } = setup({
+        options: (
+          <NavigationOption onIntent={onIntent} intentDelay={30}>
+            <a href="#clusters">Clusters</a>
+          </NavigationOption>
+        ),
+      });
+
+      const link = await getLink(/clusters/);
+
+      await user.hover(link);
+      await user.unhover(link);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 60);
+      });
+
+      expect(onIntent).not.toHaveBeenCalled();
+
+      await user.hover(link);
+
+      await waitFor(() => {
+        expect(onIntent).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should fire onIntent immediately on focus and pointer down', async () => {
+      const onIntent = vitest.fn();
+      const { user, getLink } = setup({
+        options: (
+          <NavigationOption onIntent={onIntent}>
+            <a href="#clusters">Clusters</a>
+          </NavigationOption>
+        ),
+      });
+
+      const link = await getLink(/clusters/);
+
+      await user.tab();
+
+      expect(link).toHaveFocus();
+      expect(onIntent).toHaveBeenCalledTimes(1);
+
+      await user.pointer({ keys: '[MouseLeft>]', target: link });
+
+      expect(onIntent).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/lib/components/Sidebar/Sidebar.types.ts
+++ b/lib/components/Sidebar/Sidebar.types.ts
@@ -4,6 +4,7 @@ import { CSSProperties, FC, PropsWithChildren } from 'react';
 import { ClassNames as DrawerClassNames } from '@/components/Drawer/Drawer.types';
 import { Theme } from '@/domain/theme';
 
+import { SidebarMode } from './contexts';
 import { SidebarModeProp } from './hooks/useSidebarMode';
 import { wrapperSiderbarVariants } from './Sidebar.variants';
 import {
@@ -129,7 +130,11 @@ export interface Props
    * micro-frontends.
    */
   style?: CSSProperties;
+  /** Fired when the effective mode changes, because the user toggled it or the viewport crossed a breakpoint */
+  onModeChange?: (mode: SidebarMode, source: SidebarModeChangeSource) => void;
 }
+
+export type SidebarModeChangeSource = 'user' | 'viewport';
 
 /** @deprecated Use Props instead */
 export type SidebarProps = Props;

--- a/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.tsx
+++ b/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.tsx
@@ -8,7 +8,7 @@ import { useSidebarContext } from '../../contexts';
 import { Props } from './CollapseTrigger.types';
 import { collapseTriggerVariants } from './CollapseTrigger.variants';
 
-const CollapseTrigger: FC<Props> = ({ className }) => {
+const CollapseTrigger: FC<Props> = ({ className, onToggle }) => {
   const { isCollapsed, canToggle, toggleMode } = useSidebarContext();
 
   if (!canToggle) {
@@ -27,6 +27,7 @@ const CollapseTrigger: FC<Props> = ({ className }) => {
       onClick={(event) => {
         event.stopPropagation();
         toggleMode();
+        onToggle?.(isCollapsed ? 'expanded' : 'collapsed');
       }}
     >
       {isCollapsed ? (

--- a/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.types.ts
+++ b/lib/components/Sidebar/components/CollapseTrigger/CollapseTrigger.types.ts
@@ -1,5 +1,7 @@
 export interface Props {
   className?: string;
+  /** Fired after the sidebar toggles, with the mode it switched to */
+  onToggle?: (mode: 'collapsed' | 'expanded') => void;
 }
 
 export type CollapseTriggerProps = Props;

--- a/lib/components/Sidebar/components/NavigationOption/NavigationOption.tsx
+++ b/lib/components/Sidebar/components/NavigationOption/NavigationOption.tsx
@@ -13,7 +13,9 @@ import {
   ReactElement,
   ReactNode,
   useCallback,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -46,14 +48,19 @@ const toSingleTriggerChild = (children: ReactNode): ReactElement => {
   );
 };
 
+const DEFAULT_INTENT_DELAY_MS = 80;
+
 const NavigationOption: FC<Props> = ({
+  badge,
   children,
   className,
   closeDrawerOnClick = true,
+  intentDelay = DEFAULT_INTENT_DELAY_MS,
   isVisible = true,
   isActive,
   role,
   tooltip,
+  onIntent,
   tooltipBgClassName = 'bg-kubefirst-dark-blue-900',
   tooltipArrowClassName = 'fill-kubefirst-dark-blue-900',
   tooltipTextClassName = 'text-white',
@@ -64,6 +71,32 @@ const NavigationOption: FC<Props> = ({
   const isHoverExpandable = isCollapsed && expandOnHover;
 
   const [registeredContent, setRegisteredContent] = useState<ReactNode>(null);
+  const intentTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  const cancelIntent = useCallback(() => {
+    clearTimeout(intentTimerRef.current);
+    intentTimerRef.current = undefined;
+  }, []);
+
+  const fireIntent = useCallback(() => {
+    cancelIntent();
+    onIntent?.();
+  }, [cancelIntent, onIntent]);
+
+  const scheduleIntent = useCallback(() => {
+    if (!onIntent) {
+      return;
+    }
+
+    cancelIntent();
+    intentTimerRef.current = setTimeout(fireIntent, intentDelay);
+  }, [cancelIntent, fireIntent, intentDelay, onIntent]);
+
+  useEffect(() => {
+    return cancelIntent;
+  }, [cancelIntent]);
 
   const registerTooltipContent = useCallback((content: ReactNode) => {
     setRegisteredContent(content);
@@ -95,6 +128,20 @@ const NavigationOption: FC<Props> = ({
 
   const tooltipContent = tooltip ?? registeredContent;
   const renderTooltip = isHoverExpandable && Boolean(tooltipContent);
+  const intentHandlers = onIntent
+    ? {
+        onPointerEnter: scheduleIntent,
+        onPointerLeave: cancelIntent,
+        onPointerDown: fireIntent,
+        onTouchStart: fireIntent,
+        onFocus: fireIntent,
+      }
+    : {};
+  const badgeContent = badge ? (
+    <span className="ml-auto flex shrink-0 items-center group-data-[mode=collapsed]/sidebar:hidden">
+      {badge}
+    </span>
+  ) : null;
 
   const body = renderTooltip ? (
     <Provider delayDuration={0}>
@@ -126,9 +173,16 @@ const NavigationOption: FC<Props> = ({
     <NavigationOptionContext.Provider value={contextValue}>
       <li
         {...delegated}
+        {...intentHandlers}
         data-active={isActive ? 'true' : undefined}
         onClick={role === 'button' ? undefined : handleClick}
-        className={cn(navigationOptionVariants({ className, isActive }))}
+        className={cn(
+          navigationOptionVariants({
+            className,
+            isActive,
+            hasBadge: !!badge,
+          }),
+        )}
       >
         {role === 'button' ? (
           <button
@@ -137,9 +191,13 @@ const NavigationOption: FC<Props> = ({
             className="flex w-full cursor-pointer items-center gap-2"
           >
             {body}
+            {badgeContent}
           </button>
         ) : (
-          body
+          <>
+            {body}
+            {badgeContent}
+          </>
         )}
       </li>
     </NavigationOptionContext.Provider>

--- a/lib/components/Sidebar/components/NavigationOption/NavigationOption.types.ts
+++ b/lib/components/Sidebar/components/NavigationOption/NavigationOption.types.ts
@@ -4,9 +4,15 @@ import { ReactNode } from 'react';
 import { navigationOptionVariants } from './NavigationOption.variants';
 
 type NavigationOption = VariantProps<typeof navigationOptionVariants> & {
+  /** Content rendered at the end of the option in expanded mode, e.g. a Badge */
+  badge?: ReactNode;
   className?: string;
+  /** Delay in ms before `onIntent` fires on hover. Defaults to 80 */
+  intentDelay?: number;
   isVisible?: boolean;
   isActive?: boolean;
+  /** Fired when the user shows intent to navigate: hover (debounced), focus, pointer down or touch start. Useful for prefetching */
+  onIntent?: () => void;
   /**
    * Whether clicking this option should close the drawer when the Sidebar
    * is in `drawer` mode. Defaults to `true`. Has no effect in `expanded` or

--- a/lib/components/Sidebar/components/NavigationOption/NavigationOption.variants.ts
+++ b/lib/components/Sidebar/components/NavigationOption/NavigationOption.variants.ts
@@ -35,6 +35,10 @@ export const navigationOptionVariants = cva(
         true: '',
         false: '',
       },
+      hasBadge: {
+        true: ['[&>a]:flex-1', '[&>a]:min-w-0'],
+        false: '',
+      },
     },
     compoundVariants: [
       {

--- a/lib/components/Sidebar/components/Wrapper/Wrapper.tsx
+++ b/lib/components/Sidebar/components/Wrapper/Wrapper.tsx
@@ -39,6 +39,7 @@ const Wrapper: FC<Props> = ({
   triggerClassName,
   openNavigationLabel,
   wrapperClassName,
+  onModeChange,
 }) => {
   const resolvedMode = useSidebarMode(
     mode,
@@ -62,6 +63,21 @@ const Wrapper: FC<Props> = ({
   const asideRef = useRef<ComponentRef<'aside'>>(null);
   const isResizingRef = useRef(false);
   const hasAppliedInitialWidthRef = useRef(false);
+  const onModeChangeRef = useRef(onModeChange);
+  const previousResolvedModeRef = useRef(resolvedMode);
+
+  useEffect(() => {
+    onModeChangeRef.current = onModeChange;
+  }, [onModeChange]);
+
+  useEffect(() => {
+    if (previousResolvedModeRef.current === resolvedMode) {
+      return;
+    }
+
+    previousResolvedModeRef.current = resolvedMode;
+    onModeChangeRef.current?.(resolvedMode, 'viewport');
+  }, [resolvedMode]);
 
   useEffect(() => {
     if (resolvedMode !== 'drawer') {
@@ -180,12 +196,12 @@ const Wrapper: FC<Props> = ({
   }, []);
 
   const handleToggleMode = useCallback(() => {
-    setModeOverride((current) => {
-      const base = current ?? resolvedMode;
+    const base = modeOverride ?? resolvedMode;
+    const next = base === 'collapsed' ? 'expanded' : 'collapsed';
 
-      return base === 'collapsed' ? 'expanded' : 'collapsed';
-    });
-  }, [resolvedMode]);
+    setModeOverride(next);
+    onModeChangeRef.current?.(next, 'user');
+  }, [modeOverride, resolvedMode]);
 
   if (resolvedMode === 'drawer') {
     const drawerWidth =


### PR DESCRIPTION
## Summary

Dashboard-manager persists the user's collapse preference by listening for clicks on `[data-konstruct-sidebar-collapse-trigger]` in the capture phase, because neither `Sidebar` nor `CollapseTrigger` exposed a callback. It also wires hover/focus/pointerdown handlers on every `Link` to prefetch routes and remote bundles, and composes a `Badge` inside `Sidebar.Label`.

- **`Sidebar.onModeChange(mode, source)`**: fires with `'user'` when the collapse trigger toggles the mode and with `'viewport'` when the resolved responsive mode changes.
- **`CollapseTrigger.onToggle(mode)`**: the mode the trigger switched to.
- **`NavigationOption.badge`**: rendered at the end of the option, hidden in collapsed mode; the anchor flexes to leave room for it.
- **`NavigationOption.onIntent` / `intentDelay`**: debounced hover (80 ms default) plus immediate focus, pointer down and touch start.

No behaviour changes without the new props.

## Test plan

- [x] New tests: user toggle reported by both callbacks, viewport source on mode prop change, badge rendering, intent debounce/cancel and immediate triggers
- [x] `npx vitest run lib/components/Sidebar` (27), lint, types, prettier
- [ ] Storybook: `Sidebar` → "Plans & Billing" option shows a badge and logs the intent