### PR TITLE
✨ feat: add maxVisibleItems to Breadcrumb

### DIFF
--- a/lib/components/Breadcrumb/Breadcrumb.types.ts
+++ b/lib/components/Breadcrumb/Breadcrumb.types.ts
@@ -70,6 +70,10 @@ export interface Props
   steps: Step[];
   /** Optional back button rendered before the steps */
   backButton?: BackButton;
+  /** Accessible name of the ellipsis button that reveals the collapsed steps */
+  collapsedLabel?: string;
+  /** Collapse the middle steps into an ellipsis menu when there are more steps than this; the first and the last ones stay visible */
+  maxVisibleItems?: number;
   /** CSS classes for the nav wrapper */
   wrapperClassName?: string;
   /** Theme override for this component */

--- a/lib/components/Breadcrumb/components/CollapsedSteps/CollapsedSteps.tsx
+++ b/lib/components/Breadcrumb/components/CollapsedSteps/CollapsedSteps.tsx
@@ -1,0 +1,87 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { FC } from 'react';
+import { MoreHorizontal } from 'react-feather';
+import { Link } from 'react-router-dom';
+
+import { cn } from '@/utils';
+
+import { useBreadcrumb } from '../../hooks/useBreadcrumb';
+
+import { Props } from './CollapsedSteps.types';
+
+const itemClassName = cn(
+  'flex w-full items-center gap-1 px-4 py-1.5 text-sm font-semibold outline-none',
+  'text-gray-600 hover:bg-gray-50 focus:bg-gray-50 hover:cursor-pointer',
+  'dark:text-gray-300 dark:hover:bg-metal-700 dark:focus:bg-metal-700',
+);
+
+export const CollapsedSteps: FC<Props> = ({ label, steps }) => {
+  const { isInsideRouter } = useBreadcrumb();
+
+  return (
+    <li className="flex items-center">
+      <DropdownMenu.Root modal={false}>
+        <DropdownMenu.Trigger
+          aria-label={label}
+          className={cn(
+            'flex items-center rounded-xs text-gray-400 hover:text-gray-500',
+            'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500',
+            'dark:hover:text-gray-300 cursor-pointer',
+          )}
+        >
+          <MoreHorizontal className="w-5 h-5" aria-hidden="true" />
+        </DropdownMenu.Trigger>
+
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={4}
+          loop
+          className={cn(
+            'z-50 min-w-40 rounded border border-gray-200 bg-white py-2 shadow-xs',
+            'animate-in fade-in-0',
+            'dark:border-metal-700 dark:bg-metal-800',
+          )}
+        >
+          {steps.map(({ label: stepLabel, to, target, component }) => {
+            if (!to) {
+              return (
+                <DropdownMenu.Item
+                  key={stepLabel}
+                  disabled
+                  className={cn(itemClassName, 'cursor-default')}
+                >
+                  {stepLabel}
+                </DropdownMenu.Item>
+              );
+            }
+
+            if (isInsideRouter && !component) {
+              return (
+                <DropdownMenu.Item key={stepLabel} asChild>
+                  <Link to={to} target={target} className={itemClassName}>
+                    {stepLabel}
+                  </Link>
+                </DropdownMenu.Item>
+              );
+            }
+
+            const Component = (component ?? 'a') as FC<Record<string, unknown>>;
+
+            return (
+              <DropdownMenu.Item key={stepLabel} asChild>
+                <Component
+                  href={component ? undefined : to}
+                  to={component ? to : undefined}
+                  target={target}
+                  className={itemClassName}
+                >
+                  {stepLabel}
+                </Component>
+              </DropdownMenu.Item>
+            );
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </li>
+  );
+};

--- a/lib/components/Breadcrumb/components/CollapsedSteps/CollapsedSteps.types.ts
+++ b/lib/components/Breadcrumb/components/CollapsedSteps/CollapsedSteps.types.ts
@@ -1,0 +1,6 @@
+import { Step } from '../../Breadcrumb.types';
+
+export type Props = {
+  label: string;
+  steps: Step[];
+};

--- a/lib/components/Breadcrumb/components/index.ts
+++ b/lib/components/Breadcrumb/components/index.ts
@@ -1,2 +1,3 @@
 export * from './BackButton/BackButton';
 export * from './Item/Item';
+export * from './CollapsedSteps/CollapsedSteps';


### PR DESCRIPTION
## Summary

Long paths (object storage folders, nested resources) overflow the breadcrumb. Objectstore's `FolderBreadcrumb` reproduced a collapsed breadcrumb with a CSS hover-only menu that keyboard users cannot reach.

- **`maxVisibleItems`**: when there are more steps than this, the first and the last ones stay visible and the middle steps collapse into an ellipsis menu (Radix DropdownMenu, keyboard navigable). Hidden steps keep their `to`, `target` and `component`, and respect react-router when present.
- **`collapsedLabel`**: accessible name of the ellipsis button (default "Show hidden steps").

Without `maxVisibleItems` nothing changes.

## Test plan

- [x] New tests: collapse keeps first/last and lists hidden steps as menu links, no collapse when steps fit, custom label, axe
- [x] `npx vitest run lib/components/Breadcrumb` (14), lint, types, prettier
- [ ] Storybook: `Breadcrumb/Light` and `Dark` → `Collapsed`