### PR TITLE
✨ feat: add CheckboxCard component

### DIFF
--- a/lib/components/CheckboxCard/CheckboxCard.stories.tsx
+++ b/lib/components/CheckboxCard/CheckboxCard.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { CheckboxCard as CheckboxCardComponent } from './CheckboxCard';
+
+type Story = StoryObj<typeof CheckboxCardComponent>;
+
+const meta = {
+  title: 'In Review/CheckboxCard',
+  component: CheckboxCardComponent,
+} satisfies Meta<typeof CheckboxCardComponent>;
+
+const EVENTS = [
+  {
+    value: 'instance.created',
+    label: 'Instance created',
+    description: 'Sent when a new instance finishes provisioning',
+  },
+  {
+    value: 'instance.deleted',
+    label: 'Instance deleted',
+    description: 'Sent when an instance is removed from the account',
+  },
+  {
+    value: 'instance.rebooted',
+    label: 'Instance rebooted',
+    description: 'Not available on this plan',
+    disabled: true,
+  },
+];
+
+export const CheckboxCard = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The multi-select counterpart of RadioCard: a clickable card with a title, a description and a checkbox, reflecting the checked state on its border. Settings built this as EventCheckboxCard for webhook events.',
+      },
+    },
+  },
+  render: function CheckboxCardStory() {
+    const [selected, setSelected] = useState<string[]>(['instance.created']);
+
+    return (
+      <div className="grid max-w-160 grid-cols-2 gap-4">
+        {EVENTS.map(({ value, label, description, disabled }) => (
+          <CheckboxCardComponent
+            key={value}
+            name="events"
+            value={value}
+            label={label}
+            description={description}
+            disabled={disabled}
+            checked={selected.includes(value)}
+            onChange={(checked) => {
+              setSelected((current) =>
+                checked
+                  ? [...current, value]
+                  : current.filter((item) => item !== value),
+              );
+            }}
+          />
+        ))}
+      </div>
+    );
+  },
+} satisfies Story;
+
+export default meta;

--- a/lib/components/CheckboxCard/CheckboxCard.test.tsx
+++ b/lib/components/CheckboxCard/CheckboxCard.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { CheckboxCard } from './CheckboxCard';
+import { Props } from './CheckboxCard.types';
+
+describe('CheckboxCard', () => {
+  const defaultProps = {
+    label: 'Instance created',
+    description: 'Sent when a new instance finishes provisioning',
+    name: 'events',
+    value: 'instance.created',
+  } satisfies Props;
+
+  const setup = (props?: Partial<Props>) => {
+    const user = userEvent.setup();
+    const { container } = render(<CheckboxCard {...defaultProps} {...props} />);
+
+    return {
+      component: container,
+      user,
+      getCheckbox: () =>
+        screen.getByRole('checkbox', { name: 'Instance created' }),
+    };
+  };
+
+  it('should name the checkbox after the label and render the description', () => {
+    const { getCheckbox } = setup();
+
+    expect(getCheckbox()).toBeInTheDocument();
+    expect(
+      screen.getByText('Sent when a new instance finishes provisioning'),
+    ).toBeInTheDocument();
+  });
+
+  it('should toggle when clicking anywhere on the card text', async () => {
+    const onChange = vi.fn();
+    const { user, getCheckbox } = setup({ onChange });
+
+    await user.click(
+      screen.getByText('Sent when a new instance finishes provisioning'),
+    );
+
+    expect(onChange).toHaveBeenCalledWith(true);
+    expect(getCheckbox()).toBeChecked();
+
+    await user.click(getCheckbox());
+
+    expect(onChange).toHaveBeenLastCalledWith(false);
+    expect(getCheckbox()).not.toBeChecked();
+  });
+
+  it('should follow the controlled checked value', async () => {
+    const onChange = vi.fn();
+    const { user, getCheckbox } = setup({ checked: true, onChange });
+
+    expect(getCheckbox()).toBeChecked();
+
+    await user.click(getCheckbox());
+
+    expect(onChange).toHaveBeenCalledWith(false);
+    expect(getCheckbox()).toBeChecked();
+  });
+
+  it('should not toggle when disabled', async () => {
+    const onChange = vi.fn();
+    const { user, getCheckbox } = setup({ disabled: true, onChange });
+
+    expect(getCheckbox()).toBeDisabled();
+
+    await user.click(screen.getByText('Instance created'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { component } = setup({ defaultChecked: true });
+
+    const results = await axe(component);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/CheckboxCard/CheckboxCard.tsx
+++ b/lib/components/CheckboxCard/CheckboxCard.tsx
@@ -1,0 +1,114 @@
+import { FC, useId, useState } from 'react';
+
+import { cn } from '@/utils';
+
+import { Card } from '../Card/Card';
+import { Checkbox } from '../Checkbox/Checkbox';
+import { Typography } from '../Typography/Typography';
+
+import { Props } from './CheckboxCard.types';
+
+/**
+ * A card-style checkbox for multi-select options with a title and a description.
+ * The whole card is clickable and reflects the checked state on its border.
+ *
+ * @example
+ * ```tsx
+ * <CheckboxCard
+ *   name="events"
+ *   value="instance.created"
+ *   label="Instance created"
+ *   description="Sent when a new instance finishes provisioning"
+ *   checked={events.includes('instance.created')}
+ *   onChange={(checked) => toggle('instance.created', checked)}
+ * />
+ * ```
+ */
+const CheckboxCard: FC<Props> = ({
+  checked,
+  className,
+  contentClassName,
+  defaultChecked,
+  description,
+  disabled = false,
+  id,
+  label,
+  name,
+  theme,
+  value,
+  wrapperClassName,
+  onChange,
+}) => {
+  const generatedId = useId();
+  const controlId = id ?? generatedId;
+  const labelId = `${controlId}-label`;
+  const descriptionId = `${controlId}-description`;
+  const [internalChecked, setInternalChecked] = useState(
+    defaultChecked ?? false,
+  );
+  const isChecked = checked ?? internalChecked;
+
+  const handleChange = (nextChecked: boolean) => {
+    setInternalChecked(nextChecked);
+    onChange?.(nextChecked);
+  };
+
+  return (
+    <Card
+      data-theme={theme}
+      isActive={isChecked}
+      canHover={!disabled}
+      wrapperClassName={cn('w-full', wrapperClassName)}
+      className={cn(
+        'flex items-start p-0',
+        disabled && 'cursor-not-allowed opacity-50',
+      )}
+    >
+      <label
+        htmlFor={controlId}
+        className={cn(
+          'flex w-full items-start gap-3 p-4',
+          disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+        )}
+      >
+        <Checkbox
+          id={controlId}
+          name={name}
+          value={value}
+          checked={isChecked}
+          disabled={disabled}
+          ariaLabelledBy={labelId}
+          aria-describedby={description ? descriptionId : undefined}
+          className={cn('mt-0.5 shrink-0', className)}
+          onChange={handleChange}
+        />
+
+        <span className={cn('flex flex-col gap-1', contentClassName)}>
+          <Typography
+            id={labelId}
+            component="span"
+            variant="body2"
+            className="font-medium text-slate-800 dark:text-metal-50"
+          >
+            {label}
+          </Typography>
+
+          {description ? (
+            <Typography
+              id={descriptionId}
+              component="span"
+              variant="body3"
+              className="text-slate-500 dark:text-metal-400"
+            >
+              {description}
+            </Typography>
+          ) : null}
+        </span>
+      </label>
+    </Card>
+  );
+};
+
+CheckboxCard.displayName = 'KonstructCheckboxCard';
+
+export { CheckboxCard };

--- a/lib/components/CheckboxCard/CheckboxCard.types.ts
+++ b/lib/components/CheckboxCard/CheckboxCard.types.ts
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+
+import { Props as CheckboxProps } from '../Checkbox/Checkbox.types';
+
+export type Props = Pick<
+  CheckboxProps,
+  | 'checked'
+  | 'className'
+  | 'defaultChecked'
+  | 'disabled'
+  | 'id'
+  | 'name'
+  | 'theme'
+  | 'value'
+  | 'onChange'
+> & {
+  /** Additional CSS classes for the text column */
+  contentClassName?: string;
+  /** Secondary text displayed below the label */
+  description?: ReactNode;
+  /** Primary text of the option */
+  label: ReactNode;
+  /** Additional CSS classes for the card */
+  wrapperClassName?: string;
+};
+
+export type CheckboxCardProps = Props;

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -7,6 +7,7 @@ export * from './Button/Button';
 export * from './ButtonGroup/ButtonGroup';
 export * from './Card/Card';
 export * from './Checkbox/Checkbox';
+export * from './CheckboxCard/CheckboxCard';
 export * from './CopyButton/CopyButton';
 export type { Props as CopyButtonProps } from './CopyButton/CopyButton.types';
 export * from './Counter/Counter';


### PR DESCRIPTION
## Summary

New `CheckboxCard`, the multi-select counterpart of `RadioCard`: a clickable card with a title, an optional description and a `Checkbox`, reflecting the checked state on the card border. Settings built this as `EventCheckboxCard` for webhook events (with a `key` remount hack to sync an uncontrolled `Checkbox`).

- Works controlled (`checked`) and uncontrolled (`defaultChecked`).
- The checkbox is named after the title only (`aria-labelledby`) and described by the secondary text (`aria-describedby`), so screen readers do not hear the description as part of the name.
- `disabled` blocks toggling and dims the card.
- Exported from the package root.

## Test plan

- [x] New tests: accessible name/description, toggling from the text, controlled value, disabled, axe
- [x] `npx vitest run lib/components/CheckboxCard lib/components/Checkbox`, lint, types, prettier
- [ ] Storybook: `CheckboxCard`