### PR TITLE
✨ feat: add ConfirmDialog and accessible names for Modal

### DIFF
--- a/lib/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/lib/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Alert } from '../Alert/Alert';
+import { Button } from '../Button/Button';
+
+import { ConfirmDialog as ConfirmDialogComponent } from './ConfirmDialog';
+
+type Story = StoryObj<typeof ConfirmDialogComponent>;
+
+const meta = {
+  title: 'In Review/ConfirmDialog',
+  component: ConfirmDialogComponent,
+} satisfies Meta<typeof ConfirmDialogComponent>;
+
+export const TypeToConfirm: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A destructive confirmation gated behind typing the resource name. The chip copies the name, Enter submits once it matches, and `isPending` locks the dialog while the request runs. Seven microfrontends carried their own copy of this modal.',
+      },
+    },
+  },
+  render: function TypeToConfirmStory() {
+    const [isOpen, setIsOpen] = useState(false);
+    const [isPending, setIsPending] = useState(false);
+
+    const handleConfirm = () => {
+      setIsPending(true);
+      setTimeout(() => {
+        setIsPending(false);
+        setIsOpen(false);
+      }, 1500);
+    };
+
+    return (
+      <div className="flex gap-4">
+        <Button variant="danger" onClick={() => setIsOpen(true)}>
+          Delete cluster
+        </Button>
+
+        <ConfirmDialogComponent
+          isOpen={isOpen}
+          title="Delete prod-cluster?"
+          description="Are you sure you want to permanently delete this cluster? All node pools and workloads will be removed."
+          confirmationText="prod-cluster"
+          confirmLabel="Yes, delete"
+          pendingLabel="Deleting…"
+          isPending={isPending}
+          onClose={() => setIsOpen(false)}
+          onConfirm={handleConfirm}
+        >
+          <Alert
+            type="warning"
+            description="This volume is attached to web-01 and will be detached first."
+          />
+        </ConfirmDialogComponent>
+      </div>
+    );
+  },
+};
+
+export const Simple: Story = {
+  render: function SimpleStory() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <div className="flex gap-4">
+        <Button onClick={() => setIsOpen(true)}>Restart instance</Button>
+
+        <ConfirmDialogComponent
+          isOpen={isOpen}
+          variant="primary"
+          title="Restart web-01?"
+          description="The instance will be unavailable for about a minute."
+          confirmLabel="Restart"
+          onClose={() => setIsOpen(false)}
+          onConfirm={() => setIsOpen(false)}
+        />
+      </div>
+    );
+  },
+};
+
+export default meta;

--- a/lib/components/ConfirmDialog/ConfirmDialog.test.tsx
+++ b/lib/components/ConfirmDialog/ConfirmDialog.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { ConfirmDialog } from './ConfirmDialog';
+import { Props } from './ConfirmDialog.types';
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    title: 'Delete prod-cluster?',
+    description: 'This cannot be undone.',
+    confirmLabel: 'Yes, delete',
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+  } satisfies Props;
+
+  const setup = (props?: Partial<Props>) => {
+    const onClose = vi.fn();
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    const utils = render(
+      <ConfirmDialog
+        {...defaultProps}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        {...props}
+      />,
+    );
+
+    return {
+      ...utils,
+      user,
+      onClose,
+      onConfirm,
+      getConfirm: () => screen.getByRole('button', { name: 'Yes, delete' }),
+      getCancel: () => screen.getByRole('button', { name: 'Cancel' }),
+    };
+  };
+
+  it('should render the title and description inside a dialog', () => {
+    setup();
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Delete prod-cluster?' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('This cannot be undone.')).toBeInTheDocument();
+  });
+
+  it('should confirm and cancel without a confirmation text', async () => {
+    const { user, onClose, onConfirm, getConfirm, getCancel } = setup();
+
+    await user.click(getConfirm());
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    await user.click(getCancel());
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe('with confirmationText', () => {
+    it('should enable the confirm button only when the exact text is typed', async () => {
+      const { user, onConfirm, getConfirm } = setup({
+        confirmationText: 'prod-cluster',
+      });
+
+      const input = screen.getByRole('textbox', {
+        name: 'Type prod-cluster to confirm',
+      });
+
+      expect(getConfirm()).toBeDisabled();
+
+      await user.type(input, 'prod-clus');
+
+      expect(getConfirm()).toBeDisabled();
+
+      await user.type(input, 'ter');
+
+      expect(getConfirm()).toBeEnabled();
+
+      await user.keyboard('{Enter}');
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('should offer to copy the confirmation text', () => {
+      setup({ confirmationText: 'prod-cluster' });
+
+      expect(
+        screen.getByRole('button', { name: 'Copy prod-cluster' }),
+      ).toBeInTheDocument();
+    });
+
+    it('should clear the typed text when reopened', async () => {
+      const { user, rerender, onClose, onConfirm } = setup({
+        confirmationText: 'prod-cluster',
+      });
+
+      await user.type(
+        screen.getByRole('textbox', { name: 'Type prod-cluster to confirm' }),
+        'prod-cluster',
+      );
+
+      rerender(
+        <ConfirmDialog
+          {...defaultProps}
+          confirmationText="prod-cluster"
+          isOpen={false}
+          onClose={onClose}
+          onConfirm={onConfirm}
+        />,
+      );
+      rerender(
+        <ConfirmDialog
+          {...defaultProps}
+          confirmationText="prod-cluster"
+          isOpen
+          onClose={onClose}
+          onConfirm={onConfirm}
+        />,
+      );
+
+      expect(
+        screen.getByRole('textbox', { name: 'Type prod-cluster to confirm' }),
+      ).toHaveValue('');
+      expect(
+        screen.getByRole('button', { name: 'Yes, delete' }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe('isPending', () => {
+    it('should disable both buttons, show the pending label and ignore close requests', async () => {
+      const { user, onClose, getCancel } = setup({
+        isPending: true,
+        pendingLabel: 'Deleting…',
+      });
+
+      const confirm = screen.getByRole('button', { name: 'Deleting…' });
+
+      expect(confirm).toBeDisabled();
+      expect(getCancel()).toBeDisabled();
+
+      await user.keyboard('{Escape}');
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    setup({ confirmationText: 'prod-cluster' });
+
+    const results = await axe(screen.getByRole('dialog'));
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/lib/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,0 +1,208 @@
+import { FC, FormEvent, useEffect, useId, useState } from 'react';
+
+import { WarningIcon } from '@/assets/icons/components';
+import { cn } from '@/utils';
+
+import { Button } from '../Button/Button';
+import { CopyButton } from '../CopyButton/CopyButton';
+import { Input } from '../Input/Input';
+import { Modal } from '../Modal/Modal';
+import { Typography } from '../Typography/Typography';
+
+import { Props } from './ConfirmDialog.types';
+
+/**
+ * A confirmation dialog for destructive or important actions, optionally
+ * gated behind typing a confirmation text (usually the resource name).
+ *
+ * @example
+ * ```tsx
+ * <ConfirmDialog
+ *   isOpen={isOpen}
+ *   title={`Delete ${cluster.name}?`}
+ *   description="This cannot be undone. All node pools will be removed."
+ *   confirmationText={cluster.name}
+ *   confirmLabel="Yes, delete"
+ *   pendingLabel="Deleting…"
+ *   isPending={isDeleting}
+ *   onClose={() => setIsOpen(false)}
+ *   onConfirm={deleteCluster}
+ * />
+ * ```
+ */
+const ConfirmDialog: FC<Props> = ({
+  cancelLabel = 'Cancel',
+  children,
+  className,
+  confirmationInputClassName,
+  confirmationInputLabel,
+  confirmationPrompt,
+  confirmationText,
+  confirmLabel = 'Confirm',
+  containerClassName,
+  copyLabel = 'Copy',
+  description,
+  icon,
+  isOpen,
+  isPending = false,
+  pendingLabel,
+  theme,
+  title,
+  variant = 'danger',
+  onClose,
+  onConfirm,
+}) => {
+  const formId = useId();
+  const titleId = `${formId}-title`;
+  const [typedText, setTypedText] = useState('');
+  const requiresConfirmation = !!confirmationText;
+  const isConfirmationMet =
+    !requiresConfirmation || typedText === confirmationText;
+
+  useEffect(() => {
+    if (isOpen) {
+      setTypedText('');
+    }
+  }, [isOpen]);
+
+  const handleClose = () => {
+    if (isPending) {
+      return;
+    }
+
+    onClose();
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isPending || !isConfirmationMet) {
+      return;
+    }
+
+    onConfirm();
+  };
+
+  const resolvedIcon =
+    icon === undefined ? (
+      <WarningIcon
+        size={24}
+        aria-hidden="true"
+        className={cn(
+          'shrink-0',
+          variant === 'danger'
+            ? 'text-red-600 dark:text-red-500'
+            : 'text-aurora-500',
+        )}
+      />
+    ) : (
+      icon
+    );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      theme={theme}
+      showCloseButton={false}
+      ariaLabelledBy={titleId}
+      containerClassName={containerClassName}
+      className={cn('max-w-125 min-h-0 min-w-0 gap-0 p-6', className)}
+      onClose={handleClose}
+    >
+      <form
+        id={formId}
+        noValidate
+        className="flex flex-col gap-6"
+        onSubmit={handleSubmit}
+      >
+        <Modal.Header className="flex items-start gap-4">
+          {resolvedIcon}
+
+          <div className="flex min-w-0 flex-1 flex-col gap-4">
+            <Typography
+              id={titleId}
+              variant="subtitle3"
+              component="h2"
+              className="text-slate-800 dark:text-slate-200"
+            >
+              {title}
+            </Typography>
+
+            {description ? (
+              <Typography
+                variant="body2"
+                className="text-slate-700 dark:text-slate-50"
+              >
+                {description}
+              </Typography>
+            ) : null}
+
+            {children}
+          </div>
+        </Modal.Header>
+
+        {requiresConfirmation ? (
+          <Modal.Body className="flex flex-col gap-2 pl-10">
+            <Typography
+              variant="body2"
+              component="p"
+              className="flex flex-wrap items-center gap-1 font-medium text-slate-800 dark:text-metal-50"
+            >
+              {confirmationPrompt ?? (
+                <>
+                  Type
+                  <CopyButton
+                    text={confirmationText}
+                    label={confirmationText}
+                    copyLabel={copyLabel}
+                    className="rounded-xs border border-gray-200 bg-gray-50 px-1 py-0.5 font-medium hover:bg-gray-100 dark:border-metal-700 dark:bg-metal-700 dark:hover:bg-metal-600"
+                  >
+                    {confirmationText}
+                  </CopyButton>
+                  to confirm
+                </>
+              )}
+            </Typography>
+
+            <Input
+              value={typedText}
+              autoComplete="off"
+              disabled={isPending}
+              className={confirmationInputClassName}
+              aria-label={
+                confirmationInputLabel ?? `Type ${confirmationText} to confirm`
+              }
+              onChange={(event) => {
+                setTypedText(event.target.value);
+              }}
+            />
+          </Modal.Body>
+        ) : null}
+
+        <Modal.Footer className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={isPending}
+            onClick={handleClose}
+          >
+            {cancelLabel}
+          </Button>
+
+          <Button
+            type="submit"
+            form={formId}
+            variant={variant}
+            disabled={isPending || !isConfirmationMet}
+          >
+            {isPending ? (pendingLabel ?? confirmLabel) : confirmLabel}
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+};
+
+ConfirmDialog.displayName = 'KonstructConfirmDialog';
+
+export { ConfirmDialog };

--- a/lib/components/ConfirmDialog/ConfirmDialog.types.ts
+++ b/lib/components/ConfirmDialog/ConfirmDialog.types.ts
@@ -1,0 +1,50 @@
+import { ReactNode } from 'react';
+
+import { Theme } from '@/domain/theme';
+
+import { Props as ButtonProps } from '../Button/Button.types';
+
+export type Props = {
+  /** Label of the cancel button */
+  cancelLabel?: ReactNode;
+  /** Extra content rendered below the description, e.g. an Alert */
+  children?: ReactNode;
+  /** Additional CSS classes for the dialog panel */
+  className?: string;
+  /** Additional CSS classes for the input the user types the confirmation into */
+  confirmationInputClassName?: string;
+  /** Accessible name of the confirmation input; defaults to "Type <text> to confirm" */
+  confirmationInputLabel?: string;
+  /** Custom prompt rendered above the input; defaults to "Type <text> to confirm" with a copyable chip */
+  confirmationPrompt?: ReactNode;
+  /** When set, the confirm button stays disabled until the user types this exact text */
+  confirmationText?: string;
+  /** Label of the confirm button */
+  confirmLabel?: ReactNode;
+  /** Additional CSS classes for the overlay container, e.g. to raise its z-index */
+  containerClassName?: string;
+  /** Accessible name of the copy button next to the confirmation text */
+  copyLabel?: string;
+  /** Secondary text below the title */
+  description?: ReactNode;
+  /** Icon rendered next to the title; defaults to a warning icon coloured by `variant` */
+  icon?: ReactNode;
+  /** Whether the dialog is open */
+  isOpen: boolean;
+  /** Disables both buttons and swaps the confirm label for `pendingLabel` */
+  isPending?: boolean;
+  /** Label of the confirm button while `isPending` */
+  pendingLabel?: ReactNode;
+  /** Theme override for this component */
+  theme?: Theme;
+  /** Title of the dialog */
+  title: ReactNode;
+  /** Variant of the confirm button; also colours the default icon */
+  variant?: Extract<ButtonProps['variant'], 'danger' | 'primary'>;
+  /** Called when the user cancels, presses Escape or clicks the overlay */
+  onClose: () => void;
+  /** Called when the user confirms */
+  onConfirm: () => void;
+};
+
+export type ConfirmDialogProps = Props;

--- a/lib/components/Modal/Modal.test.tsx
+++ b/lib/components/Modal/Modal.test.tsx
@@ -188,4 +188,31 @@ describe('Modal', () => {
       expect(trigger).toHaveFocus();
     });
   });
+  describe('accessible name', () => {
+    it('should name the dialog with ariaLabel', () => {
+      render(
+        <Modal isOpen ariaLabel="Cluster settings">
+          <Modal.Body>Content</Modal.Body>
+        </Modal>,
+      );
+
+      expect(
+        screen.getByRole('dialog', { name: 'Cluster settings' }),
+      ).toBeInTheDocument();
+    });
+
+    it('should name the dialog with ariaLabelledBy', () => {
+      render(
+        <Modal isOpen ariaLabelledBy="modal-title">
+          <Modal.Header>
+            <h2 id="modal-title">Delete cluster</h2>
+          </Modal.Header>
+        </Modal>,
+      );
+
+      expect(
+        screen.getByRole('dialog', { name: 'Delete cluster' }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/lib/components/Modal/Modal.types.ts
+++ b/lib/components/Modal/Modal.types.ts
@@ -23,6 +23,8 @@ import { modalVariants } from './components/Wrapper/Wrapper.variants';
 export type Props = PropsWithChildren &
   VariantProps<typeof modalVariants> & {
     /** CSS classes for the close button */
+    ariaLabel?: string;
+    ariaLabelledBy?: string;
     buttonCloseClassName?: string;
     /** Additional CSS classes for the modal */
     className?: string;

--- a/lib/components/Modal/components/Wrapper/Wrapper.tsx
+++ b/lib/components/Modal/components/Wrapper/Wrapper.tsx
@@ -13,6 +13,8 @@ import { Props } from './Wrapper.types';
 import { buttonCloseVariants, modalVariants } from './Wrapper.variants';
 
 export const Wrapper: FC<Props> = ({
+  ariaLabel,
+  ariaLabelledBy,
   buttonCloseClassName,
   children,
   className,
@@ -66,6 +68,8 @@ export const Wrapper: FC<Props> = ({
             )}
             role="dialog"
             aria-modal="true"
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledBy}
             layout="size"
             transition={transition ?? { duration: 0.25, ease: 'easeInOut' }}
           >

--- a/lib/components/Modal/components/Wrapper/Wrapper.types.ts
+++ b/lib/components/Modal/components/Wrapper/Wrapper.types.ts
@@ -8,6 +8,8 @@ import { modalVariants } from './Wrapper.variants';
 
 export type Props = PropsWithChildren &
   VariantProps<typeof modalVariants> & {
+    ariaLabel?: string;
+    ariaLabelledBy?: string;
     buttonCloseClassName?: string;
     className?: string;
     containerClassName?: string;

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -8,6 +8,7 @@ export * from './ButtonGroup/ButtonGroup';
 export * from './Card/Card';
 export * from './Checkbox/Checkbox';
 export * from './CopyButton/CopyButton';
+export * from './ConfirmDialog/ConfirmDialog';
 export type { Props as CopyButtonProps } from './CopyButton/CopyButton.types';
 export * from './Counter/Counter';
 export * from './Datepicker/DatePicker';


### PR DESCRIPTION
## Summary

Every microfrontend ships a "Delete <name>?" modal (warning icon, title, description, a "Type <name> to confirm" input gating the danger button, Cancel / "Yes, delete", `isPending` locking the dialog). vpc and objectstore carry byte-identical copies; compute, dns, volumes, kubernetes and databases have their own.

- **`ConfirmDialog`** (new, built on `Modal`): `title`, `description`, `children` (extra content such as an `Alert`), `confirmationText` gating the confirm button until the exact text is typed (Enter submits; the chip is a `CopyButton`), `isPending` + `pendingLabel`, `variant` (`danger` default or `primary`), `confirmLabel` / `cancelLabel`, `icon`, `containerClassName`. Typed text resets on reopen.
- **`Modal.ariaLabel` / `ariaLabelledBy`**: the `role="dialog"` element had no way to get an accessible name (axe `aria-dialog-name`). ConfirmDialog labels itself with its title.

## Test plan

- [x] New tests: dialog renders title/description, confirm/cancel, gate by exact text + Enter, copy chip, reset on reopen, pending locks buttons and Escape, axe; Modal accessible name via both props
- [x] `npx vitest run lib/components/ConfirmDialog lib/components/Modal`, lint, types, prettier
- [ ] Storybook: `ConfirmDialog` → `TypeToConfirm`, `Simple`