### PR TITLE
✨ feat: add Skeleton component

### DIFF
--- a/lib/components/Skeleton/Skeleton.stories.tsx
+++ b/lib/components/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Card } from '../Card/Card';
+
+import { Skeleton as SkeletonComponent } from './Skeleton';
+
+type Story = StoryObj<typeof SkeletonComponent>;
+
+const meta = {
+  title: 'In Review/Skeleton',
+  component: SkeletonComponent,
+} satisfies Meta<typeof SkeletonComponent>;
+
+export const Skeleton: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pulsing placeholders with a `role="status"` wrapper. `shape` picks a rectangle, a text line or a circle, `count` repeats it and `className` sizes each block. Settings, billing and dashboard-manager built these blocks by hand.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-6 max-w-100">
+      <Card className="flex flex-col gap-4">
+        <div className="flex items-center gap-3">
+          <SkeletonComponent shape="circle" wrapperClassName="w-auto" />
+          <SkeletonComponent shape="text" count={2} label="Loading member" />
+        </div>
+        <SkeletonComponent shape="text" count={3} label="Loading activity" />
+      </Card>
+
+      <SkeletonComponent className="h-8 w-40" label="Loading balance" />
+    </div>
+  ),
+};
+
+export default meta;

--- a/lib/components/Skeleton/Skeleton.test.tsx
+++ b/lib/components/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { Skeleton } from './Skeleton';
+
+describe('Skeleton', () => {
+  it('should announce the loading state with the default label', () => {
+    render(<Skeleton />);
+
+    const status = screen.getByRole('status', { name: 'Loading' });
+
+    expect(status).toHaveAttribute('aria-busy', 'true');
+    expect(status.childElementCount).toBe(1);
+  });
+
+  it('should render as many blocks as count with the requested shape', () => {
+    render(<Skeleton count={3} shape="text" label="Loading activity" />);
+
+    const status = screen.getByRole('status', { name: 'Loading activity' });
+
+    expect(status.childElementCount).toBe(3);
+    expect(status.firstElementChild).toHaveClass('h-3.5', 'animate-pulse');
+    expect(status.firstElementChild).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should apply the circle shape and custom classes', () => {
+    render(<Skeleton shape="circle" className="size-16" />);
+
+    const block = screen.getByRole('status').firstElementChild;
+
+    expect(block).toHaveClass('rounded-full', 'size-16');
+    expect(block).not.toHaveClass('size-10');
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = render(<Skeleton count={2} />);
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/Skeleton/Skeleton.tsx
+++ b/lib/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,45 @@
+import { FC } from 'react';
+
+import { cn } from '@/utils';
+
+import { Props } from './Skeleton.types';
+import { skeletonVariants } from './Skeleton.variants';
+
+/**
+ * Pulsing placeholder blocks shown while content loads.
+ *
+ * @example
+ * ```tsx
+ * <Skeleton shape="text" count={3} label="Loading activity" />
+ * <Skeleton shape="circle" />
+ * <Skeleton className="h-8 w-40" />
+ * ```
+ */
+const Skeleton: FC<Props> = ({
+  className,
+  count = 1,
+  label = 'Loading',
+  shape,
+  theme,
+  wrapperClassName,
+}) => (
+  <div
+    role="status"
+    aria-label={label}
+    aria-busy="true"
+    data-theme={theme}
+    className={cn('flex w-full flex-col gap-2', wrapperClassName)}
+  >
+    {Array.from({ length: count }, (_, index) => (
+      <span
+        key={index}
+        aria-hidden="true"
+        className={cn(skeletonVariants({ shape }), className)}
+      />
+    ))}
+  </div>
+);
+
+Skeleton.displayName = 'KonstructSkeleton';
+
+export { Skeleton };

--- a/lib/components/Skeleton/Skeleton.types.ts
+++ b/lib/components/Skeleton/Skeleton.types.ts
@@ -1,0 +1,20 @@
+import { VariantProps } from 'class-variance-authority';
+
+import { Theme } from '@/domain/theme';
+
+import { skeletonVariants } from './Skeleton.variants';
+
+export interface Props extends VariantProps<typeof skeletonVariants> {
+  /** Additional CSS classes for each placeholder block, e.g. a width or height */
+  className?: string;
+  /** Number of placeholder blocks to render */
+  count?: number;
+  /** Accessible name announced while the content loads */
+  label?: string;
+  /** Theme override for this component */
+  theme?: Theme;
+  /** Additional CSS classes for the wrapper */
+  wrapperClassName?: string;
+}
+
+export type SkeletonProps = Props;

--- a/lib/components/Skeleton/Skeleton.variants.ts
+++ b/lib/components/Skeleton/Skeleton.variants.ts
@@ -1,0 +1,17 @@
+import { cva } from 'class-variance-authority';
+
+export const skeletonVariants = cva(
+  ['block', 'animate-pulse', 'bg-gray-200', 'dark:bg-metal-700'],
+  {
+    variants: {
+      shape: {
+        rect: ['h-5', 'w-full', 'rounded'],
+        text: ['h-3.5', 'w-full', 'rounded'],
+        circle: ['size-10', 'rounded-full'],
+      },
+    },
+    defaultVariants: {
+      shape: 'rect',
+    },
+  },
+);

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -40,6 +40,7 @@ export * from './RadioGroup/RadioGroup';
 export * from './Range/Range';
 export * from './Select/Select';
 export * from './Sidebar/Sidebar';
+export * from './Skeleton/Skeleton';
 export * from './Slider/Slider';
 export * from './Spinner/Spinner';
 export * from './Stepper/Stepper';


### PR DESCRIPTION
## Summary

Settings (`ActivitySkeleton`), billing (`TransactionsSkeleton`) and dashboard-manager (`AccountSelector`, `RegionSelector`, `BillingStatCard`) each hand-build `animate-pulse` placeholder blocks because the only skeleton in the library is the table body one, which is internal.

- **`Skeleton`** (new): renders `count` blocks with `shape` `rect` (default), `text` or `circle`, sized further through `className`, inside a `role="status"` wrapper with `aria-busy` and an accessible `label` ("Loading" by default).
- Exported from the package root. The table skeleton is untouched.

## Test plan

- [x] New tests: status role and label, count and shape, circle + custom size, axe
- [x] `npx vitest run lib/components/Skeleton`, lint, types, prettier
- [ ] Storybook: `Skeleton`