### PR TITLE
✨ feat: add BadgeGroup component

### DIFF
--- a/lib/components/BadgeGroup/BadgeGroup.stories.tsx
+++ b/lib/components/BadgeGroup/BadgeGroup.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { BadgeGroup as BadgeGroupComponent } from './BadgeGroup';
+
+type Story = StoryObj<typeof BadgeGroupComponent>;
+
+const meta = {
+  title: 'In Review/BadgeGroup',
+  component: BadgeGroupComponent,
+} satisfies Meta<typeof BadgeGroupComponent>;
+
+const tags = [
+  { id: 1, label: 'web' },
+  { id: 2, label: 'database' },
+  { id: 3, label: 'staging' },
+  { id: 4, label: 'europe-west' },
+  { id: 5, label: 'critical' },
+  { id: 6, label: 'backup-daily' },
+];
+
+export const BadgeGroup: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A row of badges that collapses the ones that do not fit into a focusable "+N" badge whose tooltip lists the hidden labels; the full list is always available to screen readers. `maxVisible` limits by count (teams PermissionBadges) and `maxWidth` measures the labels to fit a column width (compute and vpc TagOverflowList).',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <BadgeGroupComponent items={tags} maxVisible={3} />
+      <BadgeGroupComponent items={tags} maxWidth={260} variant="info" />
+      <BadgeGroupComponent items={tags.slice(0, 2)} maxWidth={260} />
+    </div>
+  ),
+};
+
+export default meta;

--- a/lib/components/BadgeGroup/BadgeGroup.test.tsx
+++ b/lib/components/BadgeGroup/BadgeGroup.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { BadgeGroup } from './BadgeGroup';
+
+const items = [
+  { id: 1, label: 'web' },
+  { id: 2, label: 'database' },
+  { id: 3, label: 'staging' },
+  { id: 4, label: 'europe' },
+  { id: 5, label: 'critical' },
+];
+
+describe('BadgeGroup', () => {
+  it('should render every badge when nothing limits them', () => {
+    render(<BadgeGroup items={items} />);
+
+    items.forEach(({ label }) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should collapse the badges beyond maxVisible into an overflow badge with a tooltip', async () => {
+    const user = userEvent.setup();
+
+    render(<BadgeGroup items={items} maxVisible={2} />);
+
+    expect(screen.getByText('web')).toBeInTheDocument();
+    expect(screen.getByText('database')).toBeInTheDocument();
+    expect(screen.queryByText('staging')).not.toBeInTheDocument();
+
+    const overflow = screen.getByRole('button', { name: 'Show 3 more' });
+
+    expect(overflow).toHaveTextContent('+3');
+
+    await user.hover(overflow);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'staging, europe, critical',
+    );
+  });
+
+  it('should list every label for assistive technology when collapsed', () => {
+    render(<BadgeGroup items={items} maxVisible={1} />);
+
+    expect(
+      screen.getByText('web, database, staging, europe, critical'),
+    ).toHaveClass('sr-only');
+  });
+
+  it('should support a custom overflow label and tooltip content', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BadgeGroup
+        items={items}
+        maxVisible={4}
+        overflowLabel={(count) => `${count} etiqueta más`}
+        renderOverflow={(hidden) => (
+          <strong>{hidden[0].label.toUpperCase()}</strong>
+        )}
+      />,
+    );
+
+    const overflow = screen.getByRole('button', { name: '1 etiqueta más' });
+
+    await user.hover(overflow);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('CRITICAL');
+  });
+
+  it('should render nothing without items', () => {
+    const { container } = render(<BadgeGroup items={[]} maxVisible={2} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should show every badge when the width cannot be measured', () => {
+    render(<BadgeGroup items={items} maxWidth={120} />);
+
+    items.forEach(({ label }) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = render(<BadgeGroup items={items} maxVisible={2} />);
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/BadgeGroup/BadgeGroup.tsx
+++ b/lib/components/BadgeGroup/BadgeGroup.tsx
@@ -1,0 +1,133 @@
+import { FC, useRef } from 'react';
+
+import { cn } from '@/utils';
+
+import { Badge } from '../Badge/Badge';
+import { Tooltip } from '../Tooltip/Tooltip';
+
+import { Props } from './BadgeGroup.types';
+import { useVisibleBadgeCount } from './hooks';
+
+const GAP_PX = 8;
+const BADGE_HORIZONTAL_PADDING_PX = 16;
+const DEFAULT_ITEMS_PER_TOOLTIP_LINE = 4;
+
+const chunk = <T,>(items: T[], size: number) => {
+  const chunks: T[][] = [];
+
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+
+  return chunks;
+};
+
+/**
+ * Renders a row of badges and collapses the ones that do not fit into a
+ * "+N" badge whose tooltip lists the hidden labels. Limit by count with
+ * `maxVisible` or by available width with `maxWidth`.
+ *
+ * @example
+ * ```tsx
+ * <BadgeGroup items={tags} maxVisible={3} />
+ * <BadgeGroup items={regions} maxWidth={240} variant="info" />
+ * ```
+ */
+const BadgeGroup: FC<Props> = ({
+  badgeClassName,
+  className,
+  items,
+  itemsPerTooltipLine = DEFAULT_ITEMS_PER_TOOLTIP_LINE,
+  maxVisible,
+  maxWidth,
+  overflowLabel = (hiddenCount) => `Show ${hiddenCount} more`,
+  renderOverflow,
+  size,
+  variant,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const probeRef = useRef<HTMLSpanElement>(null);
+  const measuredCount = useVisibleBadgeCount({
+    containerRef,
+    gapPx: GAP_PX,
+    horizontalPaddingPx: BADGE_HORIZONTAL_PADDING_PX,
+    items,
+    maxWidth,
+    probeRef,
+  });
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  const visibleCount = Math.max(
+    1,
+    Math.min(measuredCount, maxVisible ?? items.length),
+  );
+  const visibleItems = items.slice(0, visibleCount);
+  const hiddenItems = items.slice(visibleCount);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn('relative min-w-0', className)}
+      style={maxWidth !== undefined ? { maxWidth } : undefined}
+    >
+      <span
+        ref={probeRef}
+        aria-hidden="true"
+        className="invisible absolute text-xs leading-4"
+      />
+
+      <div className="flex items-center gap-2 overflow-hidden">
+        {visibleItems.map((item) => (
+          <Badge
+            key={item.id}
+            label={item.label}
+            leftIcon={item.leftIcon}
+            size={size}
+            variant={item.variant ?? variant}
+            className={cn('shrink-0 whitespace-nowrap', badgeClassName)}
+          />
+        ))}
+
+        {hiddenItems.length > 0 ? (
+          <>
+            <span className="sr-only">
+              {items.map((item) => item.label).join(', ')}
+            </span>
+
+            <Tooltip
+              className="max-w-80 text-center"
+              content={
+                renderOverflow?.(hiddenItems) ??
+                chunk(hiddenItems, itemsPerTooltipLine).map((line) => (
+                  <div key={line[0].id}>
+                    {line.map((item) => item.label).join(', ')}
+                  </div>
+                ))
+              }
+            >
+              <button
+                type="button"
+                aria-label={overflowLabel(hiddenItems.length)}
+                className="shrink-0 cursor-pointer rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-aurora-500"
+              >
+                <Badge
+                  label={`+${hiddenItems.length}`}
+                  size={size}
+                  variant={variant}
+                  className={cn('shrink-0 whitespace-nowrap', badgeClassName)}
+                />
+              </button>
+            </Tooltip>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+BadgeGroup.displayName = 'KonstructBadgeGroup';
+
+export { BadgeGroup };

--- a/lib/components/BadgeGroup/BadgeGroup.types.ts
+++ b/lib/components/BadgeGroup/BadgeGroup.types.ts
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react';
+
+import { Props as BadgeProps } from '../Badge/Badge.types';
+
+export type BadgeGroupItem = Pick<BadgeProps, 'variant' | 'leftIcon'> & {
+  id: string | number;
+  label: string;
+};
+
+export type Props = Pick<BadgeProps, 'size' | 'variant'> & {
+  /** Additional CSS classes for each badge */
+  badgeClassName?: string;
+  /** Additional CSS classes for the wrapper */
+  className?: string;
+  /** Badges to display */
+  items: BadgeGroupItem[];
+  /** Hidden labels per line inside the overflow tooltip */
+  itemsPerTooltipLine?: number;
+  /** Show as many badges as fit in this width (px); the rest collapse into the overflow badge */
+  maxWidth?: number;
+  /** Show at most this many badges; the rest collapse into the overflow badge */
+  maxVisible?: number;
+  /** Accessible name of the overflow badge button */
+  overflowLabel?: (hiddenCount: number) => string;
+  /** Custom overflow tooltip content; defaults to the hidden labels */
+  renderOverflow?: (hidden: BadgeGroupItem[]) => ReactNode;
+};
+
+export type BadgeGroupProps = Props;

--- a/lib/components/BadgeGroup/hooks/index.ts
+++ b/lib/components/BadgeGroup/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-visible-badge-count/use-visible-badge-count';

--- a/lib/components/BadgeGroup/hooks/use-visible-badge-count/use-visible-badge-count.ts
+++ b/lib/components/BadgeGroup/hooks/use-visible-badge-count/use-visible-badge-count.ts
@@ -1,0 +1,114 @@
+import { useLayoutEffect, useState } from 'react';
+
+import { Params } from './use-visible-badge-count.types';
+
+let measureContext: CanvasRenderingContext2D | null = null;
+
+const getMeasureContext = () => {
+  if (!measureContext) {
+    measureContext = document.createElement('canvas')?.getContext('2d');
+  }
+
+  return measureContext;
+};
+
+const composeFont = (style: CSSStyleDeclaration) => {
+  if (!style.fontSize || !style.fontFamily) {
+    return '';
+  }
+
+  return `${style.fontStyle} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+};
+
+export const useVisibleBadgeCount = ({
+  containerRef,
+  gapPx,
+  horizontalPaddingPx,
+  items,
+  maxWidth,
+  probeRef,
+}: Params) => {
+  const [visibleCount, setVisibleCount] = useState(items.length);
+
+  useLayoutEffect(() => {
+    const probe = probeRef.current;
+    const container = containerRef.current;
+    const context = getMeasureContext();
+
+    if (
+      maxWidth === undefined ||
+      !probe ||
+      !container ||
+      !context ||
+      items.length === 0
+    ) {
+      setVisibleCount(items.length);
+
+      return;
+    }
+
+    const measure = () => {
+      const font = composeFont(getComputedStyle(probe));
+
+      if (!font) {
+        setVisibleCount(items.length);
+
+        return;
+      }
+
+      context.font = font;
+
+      const budgetWidth = Math.min(container.offsetWidth || maxWidth, maxWidth);
+      const widths = items.map((item) => {
+        return context.measureText(item.label).width + horizontalPaddingPx;
+      });
+      const overflowWidth =
+        context.measureText(`+${items.length}`).width + horizontalPaddingPx;
+      const totalWidth = widths.reduce((sum, width, index) => {
+        return sum + width + (index > 0 ? gapPx : 0);
+      }, 0);
+
+      if (totalWidth <= budgetWidth) {
+        setVisibleCount(items.length);
+
+        return;
+      }
+
+      const budget = budgetWidth - overflowWidth - gapPx;
+      let usedWidth = 0;
+      let count = 0;
+
+      for (const width of widths) {
+        const nextWidth = usedWidth + width + (count > 0 ? gapPx : 0);
+
+        if (nextWidth > budget) {
+          break;
+        }
+
+        usedWidth = nextWidth;
+        count += 1;
+      }
+
+      setVisibleCount(Math.max(1, count));
+    };
+
+    measure();
+
+    let isCancelled = false;
+    const observer = new ResizeObserver(measure);
+    observer.observe(container);
+
+    document.fonts?.ready.then(() => {
+      if (!isCancelled) {
+        measure();
+      }
+    });
+
+    return () => {
+      isCancelled = true;
+      observer.disconnect();
+    };
+  }, [containerRef, gapPx, horizontalPaddingPx, items, maxWidth, probeRef]);
+
+  return visibleCount;
+};

--- a/lib/components/BadgeGroup/hooks/use-visible-badge-count/use-visible-badge-count.types.ts
+++ b/lib/components/BadgeGroup/hooks/use-visible-badge-count/use-visible-badge-count.types.ts
@@ -1,0 +1,12 @@
+import { RefObject } from 'react';
+
+import { BadgeGroupItem } from '../../BadgeGroup.types';
+
+export type Params = {
+  containerRef: RefObject<HTMLElement | null>;
+  gapPx: number;
+  horizontalPaddingPx: number;
+  items: BadgeGroupItem[];
+  maxWidth?: number;
+  probeRef: RefObject<HTMLElement | null>;
+};

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -2,6 +2,7 @@ export * from './Alert/Alert';
 export * from './AlertDialog/AlertDialog';
 export * from './Autocomplete/Autocomplete';
 export * from './Badge/Badge';
+export * from './BadgeGroup/BadgeGroup';
 export * from './Breadcrumb/Breadcrumb';
 export * from './Button/Button';
 export * from './ButtonGroup/ButtonGroup';


### PR DESCRIPTION
## Summary

Compute and vpc (`TagOverflowList`) measure tag labels with a canvas to decide how many badges fit a table column and collapse the rest into a "+N" badge; teams (`PermissionBadges`) does the same by count.

- **`BadgeGroup`** (new): renders `items` as badges. `maxVisible` limits by count, `maxWidth` measures the labels (canvas + ResizeObserver, re-measured once fonts load) to fit the available width. Hidden items collapse into a focusable "+N" badge whose tooltip lists them (`itemsPerTooltipLine`, or `renderOverflow` for custom content); the full label list stays in an `sr-only` span. `overflowLabel(count)` localises the button name; `variant` / `size` / `leftIcon` pass through to `Badge`.
- Exported from the package root.

## Test plan

- [x] New tests: no limit renders all, `maxVisible` collapse + tooltip, sr-only full list, custom label and overflow content, empty items, unmeasurable width falls back to all, axe
- [x] `npx vitest run lib/components/BadgeGroup`, lint, types, prettier
- [ ] Storybook: `BadgeGroup` (count-limited and width-limited rows)