### PR TITLE
✨ feat: add TagsInput component

### DIFF
--- a/lib/components/TagsInput/TagsInput.stories.tsx
+++ b/lib/components/TagsInput/TagsInput.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { TagsInput as TagsInputComponent } from './TagsInput';
+
+type Story = StoryObj<typeof TagsInputComponent>;
+
+const meta = {
+  title: 'In Review/TagsInput',
+  component: TagsInputComponent,
+} satisfies Meta<typeof TagsInputComponent>;
+
+export const TagsInput: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Free-text tags with the `Input` API for label, error and helper text. Enter or comma adds a tag, Backspace on an empty field removes the last one, the pending text is committed on blur, and `suggestions` offers existing tags in a keyboard-navigable list. Compute (TagsInput) and vpc (ChipsInput) each built one.',
+      },
+    },
+  },
+  render: function TagsInputStory() {
+    const [tags, setTags] = useState<string[]>(['web']);
+    const [required, setRequired] = useState<string[]>([]);
+
+    return (
+      <div className="flex flex-col gap-6 max-w-100">
+        <TagsInputComponent
+          label="Tags"
+          placeholder="Add a tag…"
+          value={tags}
+          suggestions={['staging', 'production', 'database', 'critical']}
+          helperText="Press Enter or comma to add a tag"
+          onChange={setTags}
+        />
+
+        <TagsInputComponent
+          label="Firewall rules"
+          isRequired
+          value={required}
+          error={required.length === 0 ? 'Add at least one rule' : undefined}
+          onChange={setRequired}
+        />
+
+        <TagsInputComponent
+          label="Loading suggestions"
+          value={['web']}
+          isLoading
+          onChange={() => {}}
+        />
+      </div>
+    );
+  },
+};
+
+export default meta;

--- a/lib/components/TagsInput/TagsInput.test.tsx
+++ b/lib/components/TagsInput/TagsInput.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { useState } from 'react';
+
+import { TagsInput } from './TagsInput';
+import { Props } from './TagsInput.types';
+
+const Controlled = (props: Partial<Props>) => {
+  const [tags, setTags] = useState<string[]>(props.value ?? []);
+
+  return (
+    <TagsInput
+      label="Tags"
+      {...props}
+      value={tags}
+      onChange={(next) => {
+        setTags(next);
+        props.onChange?.(next);
+      }}
+    />
+  );
+};
+
+describe('TagsInput', () => {
+  const setup = (props: Partial<Props> = {}) => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    const utils = render(<Controlled {...props} onChange={onChange} />);
+
+    return {
+      ...utils,
+      user,
+      onChange,
+      getInput: () => screen.getByRole('combobox', { name: 'Tags' }),
+    };
+  };
+
+  it('should add tags with Enter and comma, trimming and ignoring duplicates', async () => {
+    const { user, onChange, getInput } = setup();
+
+    await user.type(getInput(), ' web {Enter}database,web{Enter}');
+
+    expect(onChange).toHaveBeenLastCalledWith(['web', 'database']);
+    expect(screen.getByText('web')).toBeInTheDocument();
+    expect(screen.getByText('database')).toBeInTheDocument();
+    expect(getInput()).toHaveValue('');
+  });
+
+  it('should remove the last tag with Backspace on an empty input and any tag from its badge', async () => {
+    const { user, onChange, getInput } = setup({ value: ['web', 'database'] });
+
+    await user.click(getInput());
+    await user.keyboard('{Backspace}');
+
+    expect(onChange).toHaveBeenLastCalledWith(['web']);
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('should offer suggestions filtered by the typed text and select them with the keyboard', async () => {
+    const { user, onChange, getInput } = setup({
+      suggestions: ['staging', 'production', 'web'],
+      value: ['web'],
+    });
+
+    await user.type(getInput(), 'p');
+
+    const listbox = screen.getByRole('listbox');
+
+    expect(
+      screen.getByRole('option', { name: 'production' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'web' }),
+    ).not.toBeInTheDocument();
+    expect(getInput()).toHaveAttribute('aria-controls', listbox.id);
+
+    await user.keyboard('{ArrowDown}{Enter}');
+
+    expect(onChange).toHaveBeenLastCalledWith(['web', 'production']);
+    expect(
+      screen.queryByRole('option', { name: 'production' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'staging' })).toBeInTheDocument();
+  });
+
+  it('should select a suggestion with the mouse', async () => {
+    const { user, onChange, getInput } = setup({
+      suggestions: ['staging', 'production'],
+    });
+
+    await user.click(getInput());
+    await user.click(screen.getByRole('option', { name: 'staging' }));
+
+    expect(onChange).toHaveBeenLastCalledWith(['staging']);
+  });
+
+  it('should commit the pending text when the input loses focus', async () => {
+    const { user, onChange, getInput } = setup();
+
+    await user.type(getInput(), 'critical');
+    await user.tab();
+
+    expect(onChange).toHaveBeenLastCalledWith(['critical']);
+  });
+
+  it('should keep the pending text on blur when commitOnBlur is false', async () => {
+    const { user, onChange, getInput } = setup({ commitOnBlur: false });
+
+    await user.type(getInput(), 'critical');
+    await user.tab();
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(getInput()).toHaveValue('critical');
+  });
+
+  it('should describe the field with the error and hide the helper text', () => {
+    const { getInput } = setup({
+      error: 'Add at least one tag',
+      helperText: 'Press Enter to add',
+    });
+
+    const error = screen.getByText('Add at least one tag');
+
+    expect(getInput()).toHaveAttribute('aria-invalid', 'true');
+    expect(getInput()).toHaveAttribute('aria-describedby', error.id);
+    expect(screen.queryByText('Press Enter to add')).not.toBeInTheDocument();
+  });
+
+  it('should announce loading and block edits while disabled', async () => {
+    const { user, onChange, getInput } = setup({
+      isLoading: true,
+      disabled: true,
+      value: ['web'],
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading suggestions');
+    expect(getInput()).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = setup({
+      value: ['web'],
+      helperText: 'Press Enter to add',
+      isRequired: true,
+    });
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/TagsInput/TagsInput.tsx
+++ b/lib/components/TagsInput/TagsInput.tsx
@@ -1,0 +1,348 @@
+import {
+  ChangeEvent,
+  FocusEvent,
+  forwardRef,
+  KeyboardEvent,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { LoaderIcon } from '@/assets/icons/components';
+import { cn, composeIds } from '@/utils';
+
+import { Badge } from '../Badge/Badge';
+import { Typography } from '../Typography/Typography';
+
+import { Props } from './TagsInput.types';
+
+const DEFAULT_DELIMITERS = ['Enter', ','];
+
+/**
+ * A free-text tags field. Typing a delimiter (Enter or comma) adds a tag,
+ * Backspace on an empty input removes the last one, and `suggestions` offers
+ * existing tags in a keyboard-navigable list. Mirrors the `Input` API for
+ * label, error and helper text.
+ *
+ * @example
+ * ```tsx
+ * <TagsInput
+ *   label="Tags"
+ *   value={tags}
+ *   suggestions={existingTags}
+ *   helperText="Press Enter or comma to add a tag"
+ *   onChange={setTags}
+ * />
+ * ```
+ */
+const TagsInput = forwardRef<HTMLInputElement, Props>(
+  (
+    {
+      className,
+      commitOnBlur = true,
+      delimiters = DEFAULT_DELIMITERS,
+      disabled = false,
+      error,
+      errorClassName,
+      helperText,
+      helperTextClassName,
+      id,
+      isLoading = false,
+      isRequired = false,
+      label,
+      labelAction,
+      loadingText = 'Loading suggestions',
+      placeholder,
+      suggestions = [],
+      theme,
+      value,
+      onBlur,
+      onChange,
+      onFocus,
+      ...delegated
+    },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
+    const listboxId = `${inputId}-suggestions`;
+    const errorId = `${inputId}-error`;
+    const helperTextId = `${inputId}-helper-text`;
+    const innerRef = useRef<HTMLInputElement | null>(null);
+    const [draft, setDraft] = useState('');
+    const [isOpen, setIsOpen] = useState(false);
+    const [activeIndex, setActiveIndex] = useState(-1);
+
+    const hasError = typeof error === 'string' && error.length > 0;
+    const hasHelperText = !hasError && !!helperText;
+    const describedBy = composeIds(
+      hasError && errorId,
+      hasHelperText && helperTextId,
+    );
+
+    const filteredSuggestions = useMemo(() => {
+      const query = draft.trim().toLowerCase();
+
+      return suggestions.filter((suggestion) => {
+        return (
+          !value.includes(suggestion) &&
+          suggestion.toLowerCase().includes(query)
+        );
+      });
+    }, [draft, suggestions, value]);
+
+    const isListVisible =
+      isOpen && !disabled && (isLoading || filteredSuggestions.length > 0);
+
+    const setRefs = (node: HTMLInputElement | null) => {
+      innerRef.current = node;
+
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    };
+
+    const addTag = (tag: string) => {
+      const trimmed = tag.trim();
+
+      if (trimmed && !value.includes(trimmed)) {
+        onChange([...value, trimmed]);
+      }
+
+      setDraft('');
+      setActiveIndex(-1);
+    };
+
+    const removeTag = (tag: string) => {
+      onChange(value.filter((current) => current !== tag));
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'ArrowDown' && filteredSuggestions.length > 0) {
+        event.preventDefault();
+        setIsOpen(true);
+        setActiveIndex((current) => (current + 1) % filteredSuggestions.length);
+
+        return;
+      }
+
+      if (event.key === 'ArrowUp' && filteredSuggestions.length > 0) {
+        event.preventDefault();
+        setActiveIndex((current) => {
+          return current <= 0 ? filteredSuggestions.length - 1 : current - 1;
+        });
+
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+        setActiveIndex(-1);
+
+        return;
+      }
+
+      if (delimiters.includes(event.key)) {
+        event.preventDefault();
+
+        if (isOpen && activeIndex >= 0 && filteredSuggestions[activeIndex]) {
+          addTag(filteredSuggestions[activeIndex]);
+
+          return;
+        }
+
+        addTag(draft);
+
+        return;
+      }
+
+      if (event.key === 'Backspace' && draft === '' && value.length > 0) {
+        event.preventDefault();
+        removeTag(value[value.length - 1]);
+      }
+    };
+
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      setDraft(event.target.value);
+      setIsOpen(true);
+      setActiveIndex(-1);
+    };
+
+    const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
+      setIsOpen(true);
+      onFocus?.(event);
+    };
+
+    const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+      if (commitOnBlur) {
+        addTag(draft);
+      }
+
+      setIsOpen(false);
+      setActiveIndex(-1);
+      onBlur?.(event);
+    };
+
+    return (
+      <div className="flex w-full flex-col gap-2" data-theme={theme}>
+        {label || labelAction ? (
+          <div className="flex items-center justify-between">
+            {label ? (
+              <Typography
+                component="label"
+                variant="labelLarge"
+                htmlFor={inputId}
+                className="cursor-pointer text-slate-800 dark:text-metal-50"
+              >
+                {label}
+                {isRequired ? (
+                  <span
+                    aria-hidden="true"
+                    className="ml-1 text-red-600 dark:text-red-500"
+                  >
+                    *
+                  </span>
+                ) : null}
+              </Typography>
+            ) : null}
+
+            {labelAction}
+          </div>
+        ) : null}
+
+        <div
+          role="presentation"
+          className={cn(
+            'relative flex min-h-10 w-full flex-wrap items-center gap-2 rounded border bg-white px-2.5 py-2 transition-all',
+            'focus-within:border-transparent focus-within:ring-1',
+            'dark:bg-metal-800',
+            hasError
+              ? 'border-red-600 focus-within:ring-red-600 dark:border-red-500 dark:focus-within:ring-red-500'
+              : 'border-gray-200 focus-within:ring-aurora-500 dark:border-metal-700',
+            disabled && 'cursor-not-allowed bg-gray-100 dark:bg-metal-900',
+            className,
+          )}
+          onClick={() => {
+            innerRef.current?.focus();
+          }}
+        >
+          {value.map((tag) => (
+            <Badge
+              key={tag}
+              label={tag}
+              dismissible
+              onDismiss={() => {
+                if (!disabled) {
+                  removeTag(tag);
+                }
+              }}
+            />
+          ))}
+
+          <input
+            {...delegated}
+            ref={setRefs}
+            id={inputId}
+            type="text"
+            role="combobox"
+            value={draft}
+            placeholder={value.length === 0 ? placeholder : undefined}
+            disabled={disabled}
+            autoComplete="off"
+            aria-expanded={isListVisible}
+            aria-controls={isListVisible ? listboxId : undefined}
+            aria-autocomplete="list"
+            aria-invalid={hasError || undefined}
+            aria-describedby={describedBy}
+            aria-required={isRequired || undefined}
+            className="min-w-24 flex-1 bg-transparent text-sm text-slate-800 outline-none placeholder:text-slate-400 disabled:cursor-not-allowed dark:text-metal-50 dark:placeholder:text-metal-400"
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+          />
+
+          {isLoading ? (
+            <span role="status" className="flex items-center">
+              <LoaderIcon
+                size={16}
+                aria-hidden="true"
+                className="animate-spin text-metal-400"
+              />
+              <span className="sr-only">{loadingText}</span>
+            </span>
+          ) : null}
+
+          {isListVisible ? (
+            <div
+              id={listboxId}
+              role="listbox"
+              className="absolute left-0 top-full z-10 mt-1 flex max-h-44 w-full flex-col overflow-y-auto rounded border border-gray-200 bg-white py-2 shadow-2xs animate-in fade-in-50 zoom-in-95 duration-200 dark:border-metal-700 dark:bg-metal-800"
+            >
+              {isLoading ? (
+                <span className="select-none px-6 py-1.5 text-sm text-slate-500 dark:text-metal-300">
+                  {loadingText}
+                </span>
+              ) : (
+                filteredSuggestions.map((suggestion, index) => (
+                  <button
+                    key={suggestion}
+                    type="button"
+                    role="option"
+                    tabIndex={-1}
+                    aria-selected={index === activeIndex}
+                    className={cn(
+                      'flex min-h-10 w-full cursor-pointer items-center px-6 py-1.5 text-left text-sm text-slate-800 transition-colors hover:bg-gray-50 dark:text-metal-50 dark:hover:bg-metal-700',
+                      index === activeIndex && 'bg-gray-50 dark:bg-metal-700',
+                    )}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                    }}
+                    onClick={() => {
+                      addTag(suggestion);
+                    }}
+                  >
+                    {suggestion}
+                  </button>
+                ))
+              )}
+            </div>
+          ) : null}
+        </div>
+
+        {hasError ? (
+          <Typography
+            component="span"
+            id={errorId}
+            className={cn(
+              'text-xs tracking-normal text-red-700 dark:text-red-400',
+              errorClassName,
+            )}
+          >
+            {error}
+          </Typography>
+        ) : null}
+
+        {hasHelperText ? (
+          <Typography
+            component="span"
+            id={helperTextId}
+            className={cn(
+              'text-xs text-slate-600 dark:text-slate-200',
+              helperTextClassName,
+            )}
+          >
+            {helperText}
+          </Typography>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+TagsInput.displayName = 'KonstructTagsInput';
+
+export { TagsInput };

--- a/lib/components/TagsInput/TagsInput.types.ts
+++ b/lib/components/TagsInput/TagsInput.types.ts
@@ -1,0 +1,43 @@
+import { InputHTMLAttributes, ReactNode } from 'react';
+
+import { Theme } from '@/domain/theme';
+
+export interface Props extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'value' | 'onChange'
+> {
+  /** Additional CSS classes for the field container */
+  className?: string;
+  /** Commit the typed text as a tag when the input loses focus. Defaults to true */
+  commitOnBlur?: boolean;
+  /** Keys that commit the typed text as a tag. Defaults to Enter and comma */
+  delimiters?: string[];
+  /** Error message displayed below the field */
+  error?: string;
+  /** Additional CSS classes for the error message */
+  errorClassName?: string;
+  /** Helper text displayed below the field when there is no error */
+  helperText?: string;
+  /** Additional CSS classes for the helper text */
+  helperTextClassName?: string;
+  /** Show a spinner in the field and a loading row in the suggestions */
+  isLoading?: boolean;
+  /** Show required indicator */
+  isRequired?: boolean;
+  /** Label displayed above the field */
+  label?: ReactNode;
+  /** Content displayed at the right end of the label row */
+  labelAction?: ReactNode;
+  /** Accessible name of the spinner and the loading row */
+  loadingText?: string;
+  /** Existing tags offered while typing; already selected ones are hidden */
+  suggestions?: string[];
+  /** Theme override for this component */
+  theme?: Theme;
+  /** Current tags */
+  value: string[];
+  /** Called with the new tags when one is added or removed */
+  onChange: (tags: string[]) => void;
+}
+
+export type TagsInputProps = Props;

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -48,6 +48,7 @@ export * from './Table/Table';
 export * from './Tabs/Tabs';
 export * from './Tag/Tag';
 export * from './TagSelect/TagSelect';
+export * from './TagsInput/TagsInput';
 export * from './TextArea/TextArea';
 export * from './TimePicker/TimePicker';
 export * from './Toast/Toast';


### PR DESCRIPTION
## Summary

Compute (`TagsInput`) and vpc (`ChipsInput`) each built a free-text tags field because `TagSelect` only selects from a fixed list and exposes no label, error or helper text.

- **`TagsInput`** (new): controlled `value: string[]` / `onChange`. Enter or comma (`delimiters`) adds the trimmed, de-duplicated tag; Backspace on an empty field removes the last one; each tag is a dismissible `Badge`. The pending text is committed on blur (`commitOnBlur`). `suggestions` shows the unselected matches in a listbox with ArrowUp/ArrowDown/Enter/Escape and mouse selection; `isLoading` shows a spinner and a loading row. Mirrors the `Input` API: `label`, `isRequired`, `labelAction`, `error`, `helperText`, `aria-invalid` / `aria-describedby`, `disabled`.
- Exported from the package root.

## Test plan

- [x] New tests: add with Enter/comma (trim + dedupe), remove with Backspace and badge, filtered suggestions + keyboard select, mouse select, commit on blur, `commitOnBlur=false`, error/helper description, loading + disabled, axe
- [x] `npx vitest run lib/components/TagsInput`, lint, types, prettier
- [ ] Storybook: `TagsInput`