### PR TITLE
✨ feat: add OtpInput and PasswordRules components

### DIFF
--- a/lib/components/OtpInput/OtpInput.stories.tsx
+++ b/lib/components/OtpInput/OtpInput.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { OtpInput as OtpInputComponent } from './OtpInput';
+
+type Story = StoryObj<typeof OtpInputComponent>;
+
+const meta = {
+  title: 'In Review/OtpInput',
+  component: OtpInputComponent,
+} satisfies Meta<typeof OtpInputComponent>;
+
+export const OtpInput: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One box per digit. The first box accepts SMS autofill and spreads a pasted or autofilled code across the others; Backspace and the arrow keys move between boxes. Dashboard-manager (signup) and settings (phone verification) carried the same implementation.',
+      },
+    },
+  },
+  render: function OtpInputStory() {
+    const [code, setCode] = useState('');
+    const isWrong = code.length === 6 && code !== '123456';
+
+    return (
+      <div className="flex flex-col gap-6">
+        <OtpInputComponent
+          label="Verification code"
+          autoFocus
+          onChange={setCode}
+          error={isWrong ? 'The code is not valid. Try 123456.' : undefined}
+        />
+
+        <OtpInputComponent
+          label="Disabled code"
+          length={4}
+          value="12"
+          disabled
+        />
+      </div>
+    );
+  },
+};
+
+export default meta;

--- a/lib/components/OtpInput/OtpInput.test.tsx
+++ b/lib/components/OtpInput/OtpInput.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { OtpInput } from './OtpInput';
+import { Props } from './OtpInput.types';
+
+describe('OtpInput', () => {
+  const setup = (props: Partial<Props> = {}) => {
+    const onChange = vi.fn();
+    const onComplete = vi.fn();
+    const user = userEvent.setup();
+    const utils = render(
+      <OtpInput
+        label="Verification code"
+        onChange={onChange}
+        onComplete={onComplete}
+        {...props}
+      />,
+    );
+
+    return {
+      ...utils,
+      user,
+      onChange,
+      onComplete,
+      getDigit: (position: number) => {
+        return screen.getByRole('textbox', { name: `Digit ${position}` });
+      },
+    };
+  };
+
+  it('should render one labelled input per digit inside a named group', () => {
+    setup({ length: 4 });
+
+    expect(
+      screen.getByRole('group', { name: 'Verification code' }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('textbox')).toHaveLength(4);
+    expect(screen.getByRole('textbox', { name: 'Digit 1' })).toHaveAttribute(
+      'autocomplete',
+      'one-time-code',
+    );
+  });
+
+  it('should move focus forward while typing and report the code when complete', async () => {
+    const { user, onChange, onComplete, getDigit } = setup({ length: 4 });
+
+    await user.click(getDigit(1));
+    await user.keyboard('1234');
+
+    expect(onChange).toHaveBeenLastCalledWith('1234');
+    expect(onComplete).toHaveBeenCalledWith('1234');
+    expect(getDigit(4)).toHaveFocus();
+  });
+
+  it('should ignore non-digit characters', async () => {
+    const { user, onChange, getDigit } = setup({ length: 4 });
+
+    await user.click(getDigit(1));
+    await user.keyboard('a7');
+
+    expect(getDigit(1)).toHaveValue('7');
+    expect(onChange).toHaveBeenLastCalledWith('7');
+  });
+
+  it('should spread a pasted or autofilled code across the digits', async () => {
+    const { user, onComplete, getDigit } = setup({ length: 6 });
+
+    await user.click(getDigit(1));
+    await user.paste('482913');
+
+    expect(onComplete).toHaveBeenCalledWith('482913');
+    expect(getDigit(6)).toHaveValue('3');
+    expect(getDigit(6)).toHaveFocus();
+  });
+
+  it('should clear the previous digit with Backspace on an empty box and move with the arrows', async () => {
+    const { user, onChange, getDigit } = setup({
+      length: 4,
+      defaultValue: '12',
+    });
+
+    await user.click(getDigit(3));
+    await user.keyboard('{Backspace}');
+
+    expect(getDigit(2)).toHaveValue('');
+    expect(getDigit(2)).toHaveFocus();
+    expect(onChange).toHaveBeenLastCalledWith('1');
+
+    await user.keyboard('{ArrowLeft}');
+    expect(getDigit(1)).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}{ArrowRight}');
+    expect(getDigit(3)).toHaveFocus();
+  });
+
+  it('should follow a controlled value and expose it through the hidden input', () => {
+    const { getDigit } = setup({ length: 4, value: '90', name: 'code' });
+
+    expect(getDigit(1)).toHaveValue('9');
+    expect(getDigit(2)).toHaveValue('0');
+    expect(getDigit(3)).toHaveValue('');
+  });
+
+  it('should announce the error and mark the inputs invalid', () => {
+    const { getDigit } = setup({ length: 4, error: 'The code is not valid' });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The code is not valid',
+    );
+    expect(getDigit(1)).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = setup({ length: 6, error: 'The code is not valid' });
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/OtpInput/OtpInput.tsx
+++ b/lib/components/OtpInput/OtpInput.tsx
@@ -1,0 +1,235 @@
+import {
+  ChangeEvent,
+  ClipboardEvent,
+  FC,
+  KeyboardEvent,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+
+import { cn } from '@/utils';
+
+import { Typography } from '../Typography/Typography';
+
+import { Props } from './OtpInput.types';
+
+const toDigits = (code: string | undefined, length: number) => {
+  return Array.from({ length }, (_, index) => code?.[index] ?? '');
+};
+
+/**
+ * One-time code input split into one box per digit. The first box opts into
+ * SMS autofill (`autocomplete="one-time-code"`) and spreads a pasted or
+ * autofilled code across the boxes; Backspace, ArrowLeft and ArrowRight move
+ * between them.
+ *
+ * @example
+ * ```tsx
+ * <OtpInput
+ *   label="Verification code"
+ *   error={verifyError}
+ *   onComplete={(code) => verify(code)}
+ * />
+ * ```
+ */
+const OtpInput: FC<Props> = ({
+  autoFocus = false,
+  className,
+  defaultValue,
+  digitLabel = (position) => `Digit ${position}`,
+  disabled = false,
+  error,
+  inputClassName,
+  label,
+  length = 6,
+  name,
+  theme,
+  value,
+  onChange,
+  onComplete,
+}) => {
+  const id = useId();
+  const errorId = `${id}-error`;
+  const inputsRef = useRef<Array<HTMLInputElement | null>>([]);
+  const [internalDigits, setInternalDigits] = useState(() => {
+    return toDigits(defaultValue, length);
+  });
+  const digits = value !== undefined ? toDigits(value, length) : internalDigits;
+  const hasError = typeof error === 'string' && error.length > 0;
+
+  useEffect(() => {
+    if (autoFocus) {
+      const firstEmpty = digits.findIndex((digit) => digit === '');
+      inputsRef.current[firstEmpty === -1 ? length - 1 : firstEmpty]?.focus();
+    }
+  }, [autoFocus]);
+
+  const focusInput = (index: number) => {
+    const input = inputsRef.current[Math.min(Math.max(index, 0), length - 1)];
+
+    input?.focus();
+    input?.select();
+  };
+
+  const commit = (nextDigits: string[]) => {
+    setInternalDigits(nextDigits);
+
+    const code = nextDigits.join('');
+
+    onChange?.(code);
+
+    if (nextDigits.every((digit) => digit !== '')) {
+      onComplete?.(code);
+    }
+  };
+
+  const distribute = (raw: string, startIndex: number) => {
+    const cleaned = raw.replace(/\D/g, '');
+
+    if (!cleaned) {
+      return;
+    }
+
+    const nextDigits = [...digits];
+    let writeIndex = startIndex;
+
+    for (const char of cleaned) {
+      if (writeIndex >= length) {
+        break;
+      }
+
+      nextDigits[writeIndex] = char;
+      writeIndex += 1;
+    }
+
+    commit(nextDigits);
+    focusInput(writeIndex);
+  };
+
+  const handleChange = (
+    index: number,
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const cleaned = event.target.value.replace(/\D/g, '');
+
+    if (cleaned.length > 1) {
+      distribute(cleaned, index);
+
+      return;
+    }
+
+    const nextDigits = [...digits];
+    nextDigits[index] = cleaned;
+    commit(nextDigits);
+
+    if (cleaned && index < length - 1) {
+      focusInput(index + 1);
+    }
+  };
+
+  const handleKeyDown = (
+    index: number,
+    event: KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (event.key === 'Backspace' && !digits[index] && index > 0) {
+      event.preventDefault();
+      const nextDigits = [...digits];
+      nextDigits[index - 1] = '';
+      commit(nextDigits);
+      focusInput(index - 1);
+
+      return;
+    }
+
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      focusInput(index - 1);
+
+      return;
+    }
+
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      focusInput(index + 1);
+    }
+  };
+
+  const handlePaste = (
+    index: number,
+    event: ClipboardEvent<HTMLInputElement>,
+  ) => {
+    const pasted = event.clipboardData.getData('text');
+
+    if (!pasted) {
+      return;
+    }
+
+    event.preventDefault();
+    distribute(pasted, index);
+  };
+
+  return (
+    <div className="flex flex-col gap-2" data-theme={theme}>
+      <fieldset
+        className={cn('flex gap-3 border-0 p-0', className)}
+        aria-describedby={hasError ? errorId : undefined}
+        aria-invalid={hasError || undefined}
+        disabled={disabled}
+      >
+        <legend className="sr-only">{label}</legend>
+
+        {digits.map((digit, index) => (
+          <input
+            key={index}
+            ref={(element) => {
+              inputsRef.current[index] = element;
+            }}
+            type="text"
+            inputMode="numeric"
+            autoComplete={index === 0 ? 'one-time-code' : 'off'}
+            maxLength={index === 0 ? length : 1}
+            value={digit}
+            disabled={disabled}
+            aria-label={digitLabel(index + 1)}
+            aria-invalid={hasError || undefined}
+            className={cn(
+              'size-10 rounded border bg-white text-center text-base text-slate-800 transition-all',
+              'focus-visible:border-transparent focus-visible:outline-none focus-visible:ring-1',
+              'disabled:cursor-not-allowed disabled:bg-gray-100',
+              'dark:bg-metal-800 dark:text-metal-50 dark:disabled:bg-metal-900',
+              hasError
+                ? 'border-red-600 focus-visible:ring-red-600 dark:border-red-500'
+                : 'border-gray-200 focus-visible:ring-aurora-500 dark:border-metal-700',
+              inputClassName,
+            )}
+            onChange={(event) => handleChange(index, event)}
+            onKeyDown={(event) => handleKeyDown(index, event)}
+            onPaste={(event) => handlePaste(index, event)}
+            onFocus={(event) => event.target.select()}
+          />
+        ))}
+
+        {name ? (
+          <input type="hidden" name={name} value={digits.join('')} />
+        ) : null}
+      </fieldset>
+
+      {hasError ? (
+        <Typography
+          component="span"
+          id={errorId}
+          role="alert"
+          className="text-xs tracking-normal text-red-700 dark:text-red-400"
+        >
+          {error}
+        </Typography>
+      ) : null}
+    </div>
+  );
+};
+
+OtpInput.displayName = 'KonstructOtpInput';
+
+export { OtpInput };

--- a/lib/components/OtpInput/OtpInput.types.ts
+++ b/lib/components/OtpInput/OtpInput.types.ts
@@ -1,0 +1,34 @@
+import { Theme } from '@/domain/theme';
+
+export type Props = {
+  /** Focus the first empty digit on mount */
+  autoFocus?: boolean;
+  /** Additional CSS classes for the fieldset */
+  className?: string;
+  /** Initial code for uncontrolled usage */
+  defaultValue?: string;
+  /** Accessible name of each digit input; receives the 1-based position */
+  digitLabel?: (position: number) => string;
+  /** Disable every digit input */
+  disabled?: boolean;
+  /** Error message announced below the inputs */
+  error?: string;
+  /** Additional CSS classes for each digit input */
+  inputClassName?: string;
+  /** Accessible name of the whole code field */
+  label: string;
+  /** Number of digits */
+  length?: number;
+  /** Form field name for the hidden input that carries the full code */
+  name?: string;
+  /** Theme override for this component */
+  theme?: Theme;
+  /** Controlled code */
+  value?: string;
+  /** Fired with the current code on every change */
+  onChange?: (code: string) => void;
+  /** Fired once every digit is filled */
+  onComplete?: (code: string) => void;
+};
+
+export type OtpInputProps = Props;

--- a/lib/components/PasswordRules/PasswordRules.stories.tsx
+++ b/lib/components/PasswordRules/PasswordRules.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Input } from '../Input/Input';
+
+import { PasswordRules as PasswordRulesComponent } from './PasswordRules';
+
+type Story = StoryObj<typeof PasswordRulesComponent>;
+
+const meta = {
+  title: 'In Review/PasswordRules',
+  component: PasswordRulesComponent,
+} satisfies Meta<typeof PasswordRulesComponent>;
+
+export const PasswordRules: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Live list of password requirements: each rule flips from a bullet to a check as the value satisfies it and carries a screen-reader status. Dashboard-manager (signup) and settings (security tab) each had a copy; the settings one had lost the live region.',
+      },
+    },
+  },
+  render: function PasswordRulesStory() {
+    const [password, setPassword] = useState('');
+
+    return (
+      <div className="flex flex-col gap-4 max-w-80">
+        <Input
+          label="Password"
+          type="password"
+          value={password}
+          onChange={(event) => {
+            setPassword(event.target.value);
+          }}
+        />
+
+        <PasswordRulesComponent
+          value={password}
+          title="Your password must contain at least:"
+          rules={[
+            {
+              id: 'length',
+              label: '8 characters',
+              test: (value) => value.length >= 8,
+            },
+            {
+              id: 'upper',
+              label: 'one uppercase letter',
+              test: (value) => /[A-Z]/.test(value),
+            },
+            {
+              id: 'number',
+              label: 'one number',
+              test: (value) => /\d/.test(value),
+            },
+            {
+              id: 'symbol',
+              label: 'one symbol',
+              test: (value) => /[^A-Za-z0-9]/.test(value),
+            },
+          ]}
+        />
+      </div>
+    );
+  },
+};
+
+export default meta;

--- a/lib/components/PasswordRules/PasswordRules.test.tsx
+++ b/lib/components/PasswordRules/PasswordRules.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, within } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { PasswordRules } from './PasswordRules';
+import { PasswordRule } from './PasswordRules.types';
+
+const rules: PasswordRule[] = [
+  { id: 'length', label: '8 characters', test: (value) => value.length >= 8 },
+  { id: 'number', label: 'one number', test: (value) => /\d/.test(value) },
+];
+
+describe('PasswordRules', () => {
+  it('should list every rule with its status', () => {
+    render(<PasswordRules value="abc" rules={rules} title="Must contain:" />);
+
+    expect(screen.getByText('Must contain:')).toBeInTheDocument();
+
+    const items = screen.getAllByRole('listitem');
+
+    expect(items).toHaveLength(2);
+    expect(within(items[0]).getByText('8 characters')).toBeInTheDocument();
+    expect(within(items[0]).getByText('pending')).toHaveClass('sr-only');
+    expect(items[0]).toHaveAttribute('data-met', 'false');
+  });
+
+  it('should mark rules as met while the value changes', () => {
+    const { rerender } = render(<PasswordRules value="abc" rules={rules} />);
+
+    rerender(<PasswordRules value="abcdefg1" rules={rules} />);
+
+    const items = screen.getAllByRole('listitem');
+
+    expect(within(items[0]).getByText('met')).toBeInTheDocument();
+    expect(within(items[1]).getByText('met')).toBeInTheDocument();
+    expect(items[1]).toHaveAttribute('data-met', 'true');
+  });
+
+  it('should use custom status labels', () => {
+    render(
+      <PasswordRules
+        value="1"
+        rules={rules}
+        metLabel="cumplido"
+        pendingLabel="pendiente"
+      />,
+    );
+
+    expect(screen.getByText('pendiente')).toBeInTheDocument();
+    expect(screen.getByText('cumplido')).toBeInTheDocument();
+  });
+
+  it("shouldn't have accessibility violations", async () => {
+    const { container } = render(
+      <PasswordRules value="abc" rules={rules} title="Must contain:" />,
+    );
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/lib/components/PasswordRules/PasswordRules.tsx
+++ b/lib/components/PasswordRules/PasswordRules.tsx
@@ -1,0 +1,96 @@
+import { FC } from 'react';
+
+import { CheckAltIcon } from '@/assets/icons/components';
+import { cn } from '@/utils';
+
+import { Typography } from '../Typography/Typography';
+
+import { Props } from './PasswordRules.types';
+
+/**
+ * Lists password requirements and marks each one as met while the user types.
+ * The list is a live region and every rule carries a screen-reader status.
+ *
+ * @example
+ * ```tsx
+ * <PasswordRules
+ *   value={password}
+ *   title="Your password must contain at least:"
+ *   rules={[
+ *     { id: 'length', label: '8 characters', test: (value) => value.length >= 8 },
+ *     { id: 'number', label: 'one number', test: (value) => /\d/.test(value) },
+ *   ]}
+ * />
+ * ```
+ */
+const PasswordRules: FC<Props> = ({
+  className,
+  metLabel = 'met',
+  pendingLabel = 'pending',
+  rules,
+  theme,
+  title,
+  value,
+}) => (
+  <div
+    aria-live="polite"
+    data-theme={theme}
+    className={cn('flex flex-col gap-1', className)}
+  >
+    {title ? (
+      <Typography
+        variant="body3"
+        component="p"
+        className="text-slate-700 dark:text-metal-200"
+      >
+        {title}
+      </Typography>
+    ) : null}
+
+    <ul className="m-0 flex list-none flex-col gap-1 p-0">
+      {rules.map((rule) => {
+        const isMet = rule.test(value);
+
+        return (
+          <li
+            key={rule.id}
+            data-met={isMet}
+            className="flex items-center gap-3"
+          >
+            <span className="relative inline-flex size-4 items-center justify-center">
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'absolute inset-0 inline-flex items-center justify-center leading-none text-slate-500 transition-all duration-200 ease-out dark:text-metal-400',
+                  isMet ? 'scale-75 opacity-0' : 'scale-100 opacity-100',
+                )}
+              >
+                •
+              </span>
+              <CheckAltIcon
+                aria-hidden="true"
+                className={cn(
+                  'absolute inset-0 size-4 text-green-600 transition-all duration-200 ease-out dark:text-green-400',
+                  isMet ? 'scale-100 opacity-100' : 'scale-75 opacity-0',
+                )}
+              />
+            </span>
+
+            <Typography
+              variant="body3"
+              component="span"
+              className="text-slate-700 dark:text-metal-200"
+            >
+              {rule.label}
+            </Typography>
+            <span className="sr-only">{isMet ? metLabel : pendingLabel}</span>
+          </li>
+        );
+      })}
+    </ul>
+  </div>
+);
+
+PasswordRules.displayName = 'KonstructPasswordRules';
+
+export { PasswordRules };

--- a/lib/components/PasswordRules/PasswordRules.types.ts
+++ b/lib/components/PasswordRules/PasswordRules.types.ts
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+
+import { Theme } from '@/domain/theme';
+
+export type PasswordRule = {
+  id: string;
+  label: ReactNode;
+  test: (value: string) => boolean;
+};
+
+export type Props = {
+  /** Additional CSS classes for the list wrapper */
+  className?: string;
+  /** Screen-reader status appended to a satisfied rule */
+  metLabel?: string;
+  /** Screen-reader status appended to an unsatisfied rule */
+  pendingLabel?: string;
+  /** Rules to evaluate against `value` */
+  rules: PasswordRule[];
+  /** Theme override for this component */
+  theme?: Theme;
+  /** Heading rendered above the rules */
+  title?: ReactNode;
+  /** Current password */
+  value: string;
+};
+
+export type PasswordRulesProps = Props;

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -29,6 +29,8 @@ export * from './Input/Input';
 export * from './LineChart/LineChart';
 export * from './Loading/Loading';
 export * from './Modal/Modal';
+export * from './OtpInput/OtpInput';
+export * from './PasswordRules/PasswordRules';
 export * from './MultiSelectDropdown/MultiSelectDropdown';
 export * from './PhoneNumberInput/PhoneNumberInput';
 export * from './PieChart/PieChart';


### PR DESCRIPTION
## Summary

Dashboard-manager (signup `VerifyCodeStep`, `PasswordRules`) and settings (`VerifyPhoneModal`, `PasswordRequirements`) carry near-verbatim copies of a one-time-code input and a live password requirements list. The settings copy of the rules had lost its `aria-live` region.

- **`OtpInput`** (new): one box per digit inside a fieldset named by `label`. The first box opts into SMS autofill (`autocomplete="one-time-code"`, uncapped `maxLength`) and a pasted or autofilled code is spread across the boxes. Backspace on an empty box clears and focuses the previous one; ArrowLeft/ArrowRight move; non-digits are dropped. `onChange` on every change, `onComplete` when full; controlled (`value`) or uncontrolled (`defaultValue`); `name` renders a hidden input with the full code; `error` is announced with `role="alert"`; `digitLabel` localises each box.
- **`PasswordRules`** (new): `rules` (`id`, `label`, `test`) evaluated against `value` in an `aria-live` region; each rule swaps a bullet for a check and appends a screen-reader status (`metLabel` / `pendingLabel`).
- Both exported from the package root.

## Test plan

- [x] OtpInput: group + autocomplete, typing advances and completes, non-digits ignored, paste spreads, Backspace/arrows, controlled value + hidden input, error announcement, axe
- [x] PasswordRules: statuses, updates on value change, custom labels, axe
- [x] `npx vitest run lib/components/OtpInput lib/components/PasswordRules`, lint, types, prettier
- [ ] Storybook: `OtpInput`, `PasswordRules`