### PR TITLE
🐛 fix: date inputs autofill off by default and a whole-pixel actions menu

### DIFF
--- a/lib/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/lib/components/DateRangePicker/DateRangePicker.test.tsx
@@ -326,11 +326,20 @@ describe('DateRangePicker', () => {
       expect(await getEndDateInput()).toBeInTheDocument();
     });
 
-    it('should keep the browser autofill off the date inputs', async () => {
+    it('should keep the browser autofill off the date inputs by default', async () => {
       const { getStartDateInput, getEndDateInput } = setup();
 
       expect(await getStartDateInput()).toHaveAttribute('autocomplete', 'off');
       expect(await getEndDateInput()).toHaveAttribute('autocomplete', 'off');
+    });
+
+    it('should let the consumer opt back into autofill', async () => {
+      const { getStartDateInput, getEndDateInput } = setup({
+        autoComplete: 'on',
+      });
+
+      expect(await getStartDateInput()).toHaveAttribute('autocomplete', 'on');
+      expect(await getEndDateInput()).toHaveAttribute('autocomplete', 'on');
     });
 
     it('should render time inputs by default', async () => {

--- a/lib/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/lib/components/DateRangePicker/DateRangePicker.test.tsx
@@ -326,6 +326,13 @@ describe('DateRangePicker', () => {
       expect(await getEndDateInput()).toBeInTheDocument();
     });
 
+    it('should keep the browser autofill off the date inputs', async () => {
+      const { getStartDateInput, getEndDateInput } = setup();
+
+      expect(await getStartDateInput()).toHaveAttribute('autocomplete', 'off');
+      expect(await getEndDateInput()).toHaveAttribute('autocomplete', 'off');
+    });
+
     it('should render time inputs by default', async () => {
       const { getStartTimeInput, getEndTimeInput } = setup();
 

--- a/lib/components/DateRangePicker/DateRangePicker.tsx
+++ b/lib/components/DateRangePicker/DateRangePicker.tsx
@@ -75,6 +75,7 @@ const DateRangePicker: FC<Props> = ({
   ariaLabelPrevMonthEnd,
   ariaLabelNextMonthEnd,
   // DateTimeInputs props
+  autoComplete,
   labelStartDate,
   labelEndDate,
   labelTime,
@@ -175,6 +176,7 @@ const DateRangePicker: FC<Props> = ({
           className={cn(rightPanelVariants(), classNames?.rightPanel)}
         >
           <DateTimeInputs
+            autoComplete={autoComplete}
             labelStartDate={labelStartDate}
             labelEndDate={labelEndDate}
             labelTime={labelTime}

--- a/lib/components/DateRangePicker/DateRangePicker.types.ts
+++ b/lib/components/DateRangePicker/DateRangePicker.types.ts
@@ -1,5 +1,5 @@
 import { VariantProps } from 'class-variance-authority';
-import { ReactNode } from 'react';
+import { InputHTMLAttributes, ReactNode } from 'react';
 
 import { Theme } from '@/domain/theme';
 
@@ -50,6 +50,12 @@ export type {
  * ```
  */
 export type Props = VariantProps<typeof dateRangePickerVariants> & {
+  /**
+   * Browser autofill for the From/To date fields (default: 'off'). The default
+   * keeps the browser's saved-value dropdown from covering the calendar; set it
+   * when the picker sits in a form where autofill is wanted.
+   */
+  autoComplete?: InputHTMLAttributes<HTMLInputElement>['autoComplete'];
   /** Initial date range */
   defaultRange?: DateRange;
   /** Initial time range */

--- a/lib/components/DateRangePicker/components/DateTimeInputs/DateTimeInputs.tsx
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/DateTimeInputs.tsx
@@ -10,6 +10,7 @@ import { dateTimeInputsVariants } from './DateTimeInputs.variants';
 import { useDateTimeInputs } from './hooks';
 
 export const DateTimeInputs: FC<DateTimeInputsProps> = ({
+  autoComplete,
   className,
   labelStartDate = 'Start date',
   labelEndDate = 'End date',
@@ -63,6 +64,7 @@ export const DateTimeInputs: FC<DateTimeInputsProps> = ({
       )}
     >
       <StartInputFields
+        autoComplete={autoComplete}
         dateValue={startDateValue}
         timeValue={time.startTime}
         error={startDateError}
@@ -81,6 +83,7 @@ export const DateTimeInputs: FC<DateTimeInputsProps> = ({
       />
 
       <EndInputFields
+        autoComplete={autoComplete}
         dateValue={endDateValue}
         timeValue={time.endTime}
         error={endDateError}

--- a/lib/components/DateRangePicker/components/DateTimeInputs/DateTimeInputs.types.ts
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/DateTimeInputs.types.ts
@@ -1,3 +1,5 @@
+import { InputHTMLAttributes } from 'react';
+
 export type DateTimeInputsClassNames = {
   /** Root container */
   root?: string;
@@ -14,6 +16,8 @@ export type DateTimeInputsClassNames = {
 };
 
 export type DateTimeInputsProps = {
+  /** Browser autofill for both date fields (default: 'off') */
+  autoComplete?: InputHTMLAttributes<HTMLInputElement>['autoComplete'];
   className?: string;
   /** Label for start date input (default: 'Start date') */
   labelStartDate?: string;

--- a/lib/components/DateRangePicker/components/DateTimeInputs/components/EndInputFields/EndInputFields.tsx
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/components/EndInputFields/EndInputFields.tsx
@@ -16,6 +16,7 @@ import {
 import { Props } from './EndInputFields.types';
 
 export const EndInputFields: FC<Props> = ({
+  autoComplete = 'off',
   dateValue,
   timeValue,
   error,
@@ -72,7 +73,7 @@ export const EndInputFields: FC<Props> = ({
           disabled={disabled}
           className={cn(classNames?.input)}
           aria-label={ariaLabelDate}
-          autoComplete="off"
+          autoComplete={autoComplete}
         />
       </div>
 

--- a/lib/components/DateRangePicker/components/DateTimeInputs/components/EndInputFields/EndInputFields.tsx
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/components/EndInputFields/EndInputFields.tsx
@@ -72,6 +72,7 @@ export const EndInputFields: FC<Props> = ({
           disabled={disabled}
           className={cn(classNames?.input)}
           aria-label={ariaLabelDate}
+          autoComplete="off"
         />
       </div>
 

--- a/lib/components/DateRangePicker/components/DateTimeInputs/components/EndInputFields/EndInputFields.types.ts
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/components/EndInputFields/EndInputFields.types.ts
@@ -1,6 +1,8 @@
-import { ChangeEvent, FocusEvent } from 'react';
+import { ChangeEvent, FocusEvent, InputHTMLAttributes } from 'react';
 
 export type Props = {
+  /** Browser autofill for the end date field (default: 'off') */
+  autoComplete?: InputHTMLAttributes<HTMLInputElement>['autoComplete'];
   dateValue: string;
   timeValue?: Date;
   error?: string;

--- a/lib/components/DateRangePicker/components/DateTimeInputs/components/StartInputFields/StartInputFields.tsx
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/components/StartInputFields/StartInputFields.tsx
@@ -72,6 +72,7 @@ export const StartInputFields: FC<Props> = ({
           disabled={disabled}
           className={cn(classNames?.input)}
           aria-label={ariaLabelDate}
+          autoComplete="off"
         />
       </div>
 

--- a/lib/components/DateRangePicker/components/DateTimeInputs/components/StartInputFields/StartInputFields.tsx
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/components/StartInputFields/StartInputFields.tsx
@@ -16,6 +16,7 @@ import {
 import { Props } from './StartInputFields.types';
 
 export const StartInputFields: FC<Props> = ({
+  autoComplete = 'off',
   dateValue,
   timeValue,
   error,
@@ -72,7 +73,7 @@ export const StartInputFields: FC<Props> = ({
           disabled={disabled}
           className={cn(classNames?.input)}
           aria-label={ariaLabelDate}
-          autoComplete="off"
+          autoComplete={autoComplete}
         />
       </div>
 

--- a/lib/components/DateRangePicker/components/DateTimeInputs/components/StartInputFields/StartInputFields.types.ts
+++ b/lib/components/DateRangePicker/components/DateTimeInputs/components/StartInputFields/StartInputFields.types.ts
@@ -1,6 +1,8 @@
-import { ChangeEvent, FocusEvent } from 'react';
+import { ChangeEvent, FocusEvent, InputHTMLAttributes } from 'react';
 
 export type Props = {
+  /** Browser autofill for the start date field (default: 'off') */
+  autoComplete?: InputHTMLAttributes<HTMLInputElement>['autoComplete'];
   dateValue: string;
   timeValue?: Date;
   error?: string;

--- a/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
+++ b/lib/components/VirtualizedTable/components/Actions/Actions.test.tsx
@@ -363,6 +363,22 @@ describe('Actions', () => {
       expect(menu).toHaveStyle({ top: '234px', left: '585px' });
     });
 
+    it('should snap the menu to whole pixels for a fractional trigger rect', async () => {
+      mockLayout({
+        innerHeight: 1000,
+        menuHeight: 100,
+        menuWidth: 215,
+        triggerRect: { top: 200.5, bottom: 230.5, right: 800.5 },
+      });
+
+      const { user, trigger, getMenu } = setup();
+
+      await user.click(trigger);
+      const menu = await getMenu();
+
+      expect(menu).toHaveStyle({ top: '235px', left: '586px' });
+    });
+
     it('should flip the menu above the trigger when it does not fit below', async () => {
       mockLayout({
         innerHeight: 300,

--- a/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-interactions/use-menu-interactions.ts
+++ b/lib/components/VirtualizedTable/components/Actions/components/PortalActions/hooks/use-menu-interactions/use-menu-interactions.ts
@@ -100,8 +100,13 @@ export const useMenuInteractions = ({
       ? rect.bottom + MENU_GAP_PX
       : rect.top - MENU_GAP_PX - menu.offsetHeight;
 
-    menu.style.top = `${Math.max(top, MENU_GAP_PX)}px`;
-    menu.style.left = `${Math.max(rect.right - menu.offsetWidth, MENU_GAP_PX)}px`;
+    // Rounded to whole pixels. A trigger sitting on a half pixel (table layouts
+    // routinely do) would otherwise place the menu at x.5, and the text inside it
+    // is rasterized on the compositing layer the enter animation's transform
+    // creates, then again against the page grid once that transform is gone —
+    // two different roundings of the same glyphs, read as a 1px jump on open.
+    menu.style.top = `${Math.round(Math.max(top, MENU_GAP_PX))}px`;
+    menu.style.left = `${Math.round(Math.max(rect.right - menu.offsetWidth, MENU_GAP_PX))}px`;
   }, [menuRef, triggerRef]);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
Three small rendering fixes found while wiring the `Created` range filter and the portalled row actions menu into compute.

## 1. The browser's autofill covered the calendar

The `From` / `To` fields of `DateRangePicker` are plain text inputs, so the browser offered its own saved-value list on focus. In the filter dropdown that list renders on top of the calendar panel, over the days the user is about to click.

`autoComplete` now defaults to `'off'`.

## 2. …but that is not every consumer's call

Off is right for a picker in a dropdown, not for one sitting in a form. The `autoComplete` prop rides from `DateRangePicker` down to both date fields, so the dropdown case stays fixed with nothing to pass and a form can opt back in:

```tsx
<DateRangePicker autoComplete="on" />
```

## 3. The actions menu labels jumped a pixel on open

A trigger whose right edge sits on a half pixel — table layouts routinely produce one — placed the portalled menu at `x.5`. The text inside it is then rasterized twice: once on the compositing layer the enter animation's `transform` creates, and once against the page grid after that transform is gone. The two roundings disagree, so the labels appear to slide sideways as the menu settles.

Measured in the app before the fix, with the trigger's right edge at `1399.5`:

| | Before | After |
|---|---|---|
| Menu `left` | 1259.5px | 1260px |
| First item's left | 1260.5px | 1261px |

Rounding `top` and `left` keeps the panel on the pixel grid, so both paints land on the same glyph positions. Layout was never moving, which is why no positional assertion caught it.

## Tests

- The autofill default and the opt-in are asserted on both inputs.
- A positioning test feeds a fractional trigger rect and expects whole-pixel offsets.
- Full suite green: 56 files, 849 tests.

Validated end to end by building this branch into `compute-micro-frontend`: the menu lands on `1260px`, both date fields render `autocomplete="off"`, and compute's 121 e2e tests pass against it.